### PR TITLE
Replace flymake-mode

### DIFF
--- a/flymake-checkers.el
+++ b/flymake-checkers.el
@@ -332,6 +332,12 @@ INCOMPATIBLE with this mode."
 Use either flymake-mode or flymake-checkers-mode"))
   (cond
    (flymake-checkers-mode
+    ;; Enable flymake-cursor if available
+    (when (fboundp 'flyc/show-fly-error-at-point-pretty-soon)
+      (add-hook 'post-command-hook
+                'flyc/show-fly-error-at-point-pretty-soon
+                nil t))
+
     (add-hook 'after-change-functions 'flymake-after-change-function nil t)
     (add-hook 'after-save-hook 'flymake-after-save-hook nil t)
     (add-hook 'kill-buffer-hook 'flymake-kill-buffer-hook nil t)


### PR DESCRIPTION
Remove the dependency against `flymake-mode`, and only leverage the internal flymake API.

Implementation:
- Advice `flymake-mode` to prevent it from being enabled if `flymake-checkers-mode` is active.
- In `flymake-checkers-mode` check for `flymake-mode` to prevent the former from being enabled if the latter is active.
- Advice `flymake-report-status` to update the modeline with flymake-checkers hinter.
- Advice `flymake-report-fatal-status` to suppress GUI messages in `flymake-checkers-mode` and prevent calls to `flymake-mode`.
- Copy the definition from `flymake-mode` to `flymake-checkers-mode`, probably with some modifications.

The current state is only a sketch of this and far from complete.
