### PR TITLE
Highlight lines from first non-whitespace char

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -600,15 +600,20 @@ region.  Hence the region will always extend over the whole line.
 Return a cons cell (BEG . END).  BEG is the beginning of the
 error region and END its end.  If ERR has a column number and
 IGNORE-COLUMN is omitted or nil BEG and END are equal and refer
-to the error column.  Otherwise BEG is the beginning of the ERR
-line and END its end."
+to the error column.  Otherwise BEG is the position of the first
+non-whitespace character on the ERR line and END its end."
   (save-excursion
     (goto-char (point-min))
     (forward-line (- (flycheck-error-line-no err) 1))
-    (let* ((col (if ignore-column nil (flycheck-error-col-no err)))
-           (beg (+ (line-beginning-position) (or col 0)))
-           (end (if col beg (line-end-position))))
-      `(,beg . ,end))))
+    (let ((col (if ignore-column nil (flycheck-error-col-no err))))
+      (if col
+          ;; If the error has a column, return that column only
+          (let ((pos (+ (line-beginning-position) col)))
+            `(,pos . ,pos))
+        ;; Otherwise the region extends from the first non-whitespace character
+        ;; on the line to its end.
+        (back-to-indentation)
+        `(,(point) . ,(line-end-position))))))
 
 (defun flycheck-error-pos (err)
   "Get the buffer position of ERR.


### PR DESCRIPTION
Only highlight from the beginning of the line.
# Current state

![Highlighting the complete line](https://f.cloud.github.com/assets/224922/37393/e87e740a-5441-11e2-86b2-56357c4de223.png)
# With this branch

![Highlighting from beginning of indentation](https://f.cloud.github.com/assets/224922/37401/a624b434-5446-11e2-8927-35b02c43ca52.png)

Inviting @ptrv and @wyuenho to discuss this change.
