### PR TITLE
Fix error navigation

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -706,8 +706,10 @@ non-whitespace character on the ERR line and END its end."
     (forward-line (- (flycheck-error-line-no err) 1))
     (let ((col (if ignore-column nil (flycheck-error-col-no err))))
       (if col
-          ;; If the error has a column, return that column only
-          (let ((pos (+ (line-beginning-position) col)))
+          ;; If the error has a column, return that column only.
+          ;; Checkers report column numbers that are off by one compared
+          ;; to the corresponding ones in Emacs
+          (let ((pos (+ (line-beginning-position) col -1)))
             `(,pos . ,pos))
         ;; Otherwise the region extends from the first non-whitespace character
         ;; on the line to its end.
@@ -923,9 +925,9 @@ flycheck exclamation mark otherwise.")
       (forward-line (- (flycheck-error-line-no err) 1))
       (let* ((level (flycheck-error-level err))
              (region (flycheck-error-region err flycheck-ignore-columns))
-             (end (cdr region))
+             (beg (car region))
              ;; Highlight the column appropriately
-             (beg (if (= (car region) end) (- end 1) (car region)))
+             (end (if (= (cdr region) beg) (+ beg 1) (cdr region)))
              (category (cdr (assq level flycheck-overlay-categories-alist)))
              (text (flycheck-error-text err))
              (overlay (make-overlay beg end (flycheck-error-buffer err)))


### PR DESCRIPTION
I've seen when `flycheck-ignore-column` is `nil`, error navigation with `next-error` causes moving point one character too far and no message in the minibuffer.

An example:

``` python
def a(): pass
def b(): pass
```

Try to navigate errors with `C-x `` (with flake8 checker). No messages are displayed in the minibuffer.

This commit _should_ fix it but I'm not sure if it is the desired behaviour.
