### PR TITLE
Add support for auctex's LaTeX-mode

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1344,13 +1344,13 @@ output: %s\nChecker definition probably flawed."
   :error-patterns
   '(("^\\(?1:.*\\):\\(?2:[0-9]+\\):\\(?3:[0-9]+\\):\\(?4:[0-9]+:.*\\)$"
      warning))
-  :modes '(latex-mode plain-tex-mode))
+  :modes '(latex-mode plain-tex-mode LaTeX-mode))
 
 (flycheck-declare-checker flycheck-checker-tex-lacheck
   :command '("lacheck" source-inplace)
   :error-patterns
   '(("^\"\\(?1:.*\\)\", line \\(?2:[0-9]+\\): \\(?4:.*\\)$" warning))
-  :modes 'latex-mode)
+  :modes '(latex-mode LaTeX-mode))
 
 (flycheck-declare-checker flycheck-checker-xml-xmlstarlet
   :command '("xmlstarlet" "val" "-e" "-q" source)


### PR DESCRIPTION
auctex's `LaTeX-mode` is not triggered anymore with `latex-mode`. Add support for `LaTeX-mode`.
