### PR TITLE
Add test for lua

### DIFF
--- a/tests/test-lua/missing-quote.lua
+++ b/tests/test-lua/missing-quote.lua
@@ -1,0 +1,7 @@
+-- A syntax error caused by a missing quote
+--
+-- Checkers: lua
+
+print "oh no
+
+print "hello world"

--- a/tests/test-lua/test-lua.el
+++ b/tests/test-lua/test-lua.el
@@ -1,0 +1,42 @@
+;;; test-lua.el --- Test the lua checker
+
+;; Copyright (c) 2013 Sebastian Wiesner <lunaryorn@gmail.com>,
+;;                    Peter Vasil <mail@petervasil.net>
+;;
+;; Author: Sebastian Wiesner <lunaryorn@gmail.com>,
+;;         Peter Vasil <mail@petervasil.net>
+;; URL: https://github.com/lunaryorn/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'flycheck)
+
+(package-need 'lua-mode)
+(require 'lua-mode)
+
+(testsuite-module "lua")
+
+(ert-deftest lua-missing-quote ()
+  "Test a syntax error with lua."
+  (should-flycheck-checker
+   (testsuite-lua-resource "missing-quote.lua")
+   'lua-mode 'lua
+   '(5 nil "unfinished string near '\"oh no'" error)))
+
+;;; test-lua.el ends here


### PR DESCRIPTION
I added a test for the lua chcker. It needs lua-mode package from melpa. However I dont use the  melpa package by myself, because it doesn't work. It crashes my emacs on opening a lua file and there is an output from lua-mode in the minibuffer `prefix key set to "C-c"`. I use the lua-mode package from my debian/ubuntu package manager.
The test however works with the melpa version of lua-mode, but there is this output "prefix key set to C-c".
I could have added `sudo apt-get install -yy lua-mode` to the vagrant script but I dont't know how you want to handle the install of lua-mode generally for the tests.
