### PR TITLE
Move the Flycheck menu under Tools.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -210,14 +210,17 @@ overlay setup)."
     map)
   "Keymap of `flycheck-mode'.")
 
-(easy-menu-define nil flycheck-mode-map "Flycheck Menu"
-  '("Flycheck"
+(easy-menu-add-item nil '("Tools")
+  '("Syntax Checking"
     ["Check current buffer" flycheck-buffer t]
     ["Clear errors in buffer" flycheck-clear t]
     "---"
     ["Select checker" flycheck-select-checker t]
     "---"
-    ["Describe checker" flycheck-describe-checker t]))
+    ["Describe checker" flycheck-describe-checker t])
+  "Spell Checking")
+
+(easy-menu-add-item nil '("Tools") '("--") "Spell Checking")
 
 (defun flycheck-teardown ()
   "Teardown flyheck.


### PR DESCRIPTION
Minor modes are not supposed to define top-level
menus in Emacs. The proper thing for them is generally to
add a menu item under Tools. This particular commit
positions the Flycheck menu item just above "Spell Checking".
