### PR TITLE
Checker for Rust programming language.

### DIFF
--- a/Carton
+++ b/Carton
@@ -25,4 +25,5 @@ Flycheck provides on-the-fly syntax checker with
  (depends-on "php-mode")
  (depends-on "php+-mode")
  (depends-on "sass-mode")
- (depends-on "go-mode"))
+ (depends-on "go-mode")
+ (depends-on "rust-mode"))

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Features
   - PHP
   - Python
   - Ruby
+  - Rust
   - Sass
   - Shell scripts (Bash, Dash and Zsh)
   - TeX/LaTeX
@@ -130,6 +131,7 @@ The following people contributed to flycheck:
   shape this project.
 - [Yannick Roehlly][yannick1974] added support for PEP8 naming errors to the
   Flake8 syntax checker.
+- [Victor Deryagin][vderyagin] added the Rust syntax checker.
 
 
 License
@@ -173,3 +175,4 @@ See [COPYING][] for details.
 [steckerhalter]: https://github.com/steckerhalter
 [yannick1974]: https://github.com/yannick1974
 [copying]: https://github.com/lunaryorn/flycheck/blob/master/COPYING
+[vderyagin]: https://github.com/vderyagin

--- a/doc/checkers.texi
+++ b/doc/checkers.texi
@@ -21,6 +21,7 @@ order of their appearance in the default value of
 @iflyc python-pylint
 @iflyc python-pyflakes
 @iflyc ruby
+@iflyc rust-rustc
 @iflyc sass
 @iflyc sh
 @iflyc tex-chktex

--- a/doc/credits.texi
+++ b/doc/credits.texi
@@ -50,6 +50,10 @@ and engaged in worthwhile discussion to shape this project.
 @item
 @uref{https://github.com/yannick1974, Yannick Roehlly} added support for
 PEP8 naming errors to the Flake8 syntax checker.
+
+@item
+@uref{https://github.com/vderyagin, Victor Deryagin} added the Rust
+syntax checker.
 @end itemize
 
 @c Local Variables:

--- a/doc/flycheck.info
+++ b/doc/flycheck.info
@@ -92,6 +92,7 @@ File: flycheck.info,  Node: Features,  Next: Installation,  Prev: Introduction, 
         * PHP (using the PHP Command Line and PHP CodeSniffer)
         * Python (using 'flake8', 'pylint', or 'pyflakes')
         * Ruby
+        * Rust (using 'rustc')
         * Sass
         * Shell scripts (using Bash, Dash, or Zsh depending on the type
           of shell script)
@@ -1588,6 +1589,9 @@ their support and patches are greatly appreciated.
    * Yannick Roehlly (https://github.com/yannick1974) added support for
      PEP8 naming errors to the Flake8 syntax checker.
 
+   * Victor Deryagin (https://github.com/vderyagin) added the Rust
+     syntax checker.
+
 
 File: flycheck.info,  Node: GNU Free Documentation License,  Next: Syntax checkers,  Prev: Credits,  Up: Top
 
@@ -2097,6 +2101,7 @@ order of their appearance in the default value of 'flycheck-checkers':
    * 'python-pylint'
    * 'python-pyflakes'
    * 'ruby'
+   * 'rust-rustc'
    * 'sass'
    * 'sh'
    * 'tex-chktex'
@@ -2154,46 +2159,46 @@ Tag Table:
 Node: Top689
 Node: Introduction1993
 Node: Features2784
-Node: Installation3695
-Node: Activation4869
-Node: Usage5220
-Node: Syntax checking5843
-Node: Selection7105
-Node: Configuration9686
-Node: Reporting12354
-Node: Navigation14709
-Node: Mode line16505
-Node: Extending17406
-Node: Declaration18005
-Node: Error parsers29059
-Node: Option filters30043
-Node: Examples30382
-Node: Simple example30814
-Node: Predicate example33878
-Node: Configuration example35859
-Node: Chaining example38518
-Node: API39904
-Node: Error API40692
-Node: Error parser API43293
-Node: Contribution43519
-Node: Reporting issues44195
-Node: Contributing syntax checkers44931
-Node: Contributing code45726
-Node: Unit tests47066
-Node: Changes48353
-Node: 0.148873
-Node: 0.249157
-Node: 0.349435
-Node: 0.449671
-Node: 0.550446
-Node: 0.651666
-Node: 0.6.154516
-Node: 0.754665
-Node: 0.7.155679
-Node: master56397
-Node: Credits57694
-Node: GNU Free Documentation License59518
-Node: Syntax checkers84670
-Node: Function and Variable Index85535
+Node: Installation3726
+Node: Activation4900
+Node: Usage5251
+Node: Syntax checking5874
+Node: Selection7136
+Node: Configuration9717
+Node: Reporting12385
+Node: Navigation14740
+Node: Mode line16536
+Node: Extending17437
+Node: Declaration18036
+Node: Error parsers29090
+Node: Option filters30074
+Node: Examples30413
+Node: Simple example30845
+Node: Predicate example33909
+Node: Configuration example35890
+Node: Chaining example38549
+Node: API39935
+Node: Error API40723
+Node: Error parser API43324
+Node: Contribution43550
+Node: Reporting issues44226
+Node: Contributing syntax checkers44962
+Node: Contributing code45757
+Node: Unit tests47097
+Node: Changes48384
+Node: 0.148904
+Node: 0.249188
+Node: 0.349466
+Node: 0.449702
+Node: 0.550477
+Node: 0.651697
+Node: 0.6.154547
+Node: 0.754696
+Node: 0.7.155710
+Node: master56428
+Node: Credits57725
+Node: GNU Free Documentation License59638
+Node: Syntax checkers84790
+Node: Function and Variable Index85673
 
 End Tag Table

--- a/doc/introduction.texi
+++ b/doc/introduction.texi
@@ -63,6 +63,8 @@ Python (using @command{flake8}, @command{pylint}, or @command{pyflakes})
 @item
 Ruby
 @item
+Rust (using @command{rustc})
+@item
 Sass
 @item
 Shell scripts (using Bash, Dash, or Zsh depending on the type of shell

--- a/flycheck.el
+++ b/flycheck.el
@@ -99,6 +99,7 @@ buffer-local wherever it is set."
     python-pylint
     python-pyflakes
     ruby
+    rust-rustc
     sass
     sh
     tex-chktex
@@ -2456,6 +2457,14 @@ See URL `http://www.zsh.org/'."
   :error-patterns '(("^\\(?1:.*\\):\\(?2:[0-9]+\\): \\(?4:.*\\)$" error))
   :modes 'sh-mode
   :predicate '(eq sh-shell 'zsh))
+
+(flycheck-declare-checker rust-rustc
+  "A Rust syntax checker using rustc parsing option.
+
+See URL `http://rust-lang.org'."
+  :command '("rustc" "--parse-only" source)
+  :error-patterns '(("^\\(?1:.+\\.r[cs]\\):\\(?2:[[:digit:]]+\\):\\(?3:[[:digit:]]+\\): [[:digit:]]+:[[:digit:]]+ error: \\(?4:.+\\)$" error))
+  :modes 'rust-mode)
 
 (provide 'flycheck)
 

--- a/tests/resources/missing-semicolon.rs
+++ b/tests/resources/missing-semicolon.rs
@@ -1,0 +1,3 @@
+// A syntax error resulting from a missing semicolon
+
+use core::io::println

--- a/tests/resources/syntax-error.rs
+++ b/tests/resources/syntax-error.rs
@@ -1,0 +1,3 @@
+// A simple syntax error
+
+fn main() bla

--- a/tests/test-checkers/test-rust.el
+++ b/tests/test-checkers/test-rust.el
@@ -1,0 +1,48 @@
+;;; test-rust.el --- Test the rust checker -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2013 Victor Deryagin <vderyagin@gmail.com>
+;;
+;; Author: Victor Deryagin <vderyagin@gmail.com>
+;; URL: https://github.com/lunaryorn/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'flycheck)
+
+(require 'rust-mode nil :no-error)
+
+(ert-deftest checker-rust-syntax-error ()
+  "Test a syntax error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'rust-rustc)
+  (flycheck-testsuite-should-syntax-check
+   "missing-semicolon.rs" 'rust-mode nil
+   '(3 14 "expected `;` but found `<eof>`" error)))
+
+(ert-deftest checker-rust-missing-semicolon ()
+  "Test missing semicolon detection."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'rust-rustc)
+  (flycheck-testsuite-should-syntax-check
+   "missing-semicolon.rs" 'rust-mode nil
+   '(3 14 "expected `;` but found `<eof>`" error)))
+
+;; Local Variables:
+;; coding: utf-8
+;; End:
+
+;;; test-rust.el ends here

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -59,7 +59,7 @@ apt_update
 apt make python-software-properties
 
 # Bring in the necessary PPAs
-ppa ppa:cassou/emacs ppa:ondrej/php5 ppa:richarvey/nodejs ppa:gophers/go
+ppa ppa:cassou/emacs ppa:ondrej/php5 ppa:richarvey/nodejs ppa:gophers/go ppa:kevincantu/rust
 apt_update
 
 # Install texinfo to build documentation
@@ -86,7 +86,8 @@ apt bash \
     chktex lacheck \
     xmlstarlet \
     zsh \
-    golang-stable
+    golang-stable \
+    rust
 
 pip flake8 pep8-naming pylint pyflakes
 


### PR DESCRIPTION
This adds  checker  for Rust (http://www.rust-lang.org/) using compiler parse option `rustc --parse-only`.
