### PR TITLE
update documentation to look better with `package-list-packages'

### DIFF
--- a/flycheck-pkg.el
+++ b/flycheck-pkg.el
@@ -1,12 +1,3 @@
 (define-package "flycheck" "0.8"
-  "Flymake done right
-
-Flycheck provides on-the-fly syntax checker with
-
-- major-mode based checkers,
-- simple declarative checker definitions,
-- built-in checkers for many languages,
-- standard error navigation,
-- easy customization,
-- and a clean, concise and understandable implementation."
+  "Flymake done right."
   '((s "1.3.1") (dash "1.0.3")))

--- a/flycheck.el
+++ b/flycheck.el
@@ -24,7 +24,18 @@
 ;;; Commentary:
 
 ;; On-the-fly syntax checking for GNU Emacs (aka "flymake done right")
-
+;;
+;;
+;; Flycheck provides on-the-fly syntax checker with
+;;
+;; - major-mode based checkers,
+;; - simple declarative checker definitions,
+;; - built-in checkers for many languages,
+;; - standard error navigation,
+;; - easy customization,
+;; - and a clean, concise and understandable implementation.
+;;
+;;
 ;; Provide `flycheck-mode' which enables on-the-fly syntax checking for a large
 ;; number of different modes and languages (see `flycheck-checkers' for a
 ;; complete list).


### PR DESCRIPTION
Right now I see something like this:

![image](https://f.cloud.github.com/assets/38066/357038/4c3fcc7c-a11e-11e2-9d26-da49c1676658.png)

By incorporating these changes, the same information will be displayed when someone actually clicks on the package name.
