### PR TITLE
Add Go checker that uses go compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ flycheck-*.tar
 
 # HTML documentation
 doc/html/
+
+# Go compiler noise
+command-line-arguments.test

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ The following people contributed to flycheck:
 - [Marian Schubert][maio] added the Perl syntax checker.
 - [Martin Grenfell][scrooloose] created the awesome Vim library [syntastic][]
   which inspired this project and many of its checkers.
-- [Peter Vasil][ptrv] created the XML and Lua syntax checkers, added unit tests
-  and did valuable testing.
-- [Robert Zaremba][robert-zaremba] added the Go syntax checker.
+- [Peter Vasil][ptrv] created the Go, XML and Lua syntax checkers, added
+  unit tests and did valuable testing.
+- [Robert Zaremba][robert-zaremba] added the Go-Gofmt syntax checker.
 - [steckerhalter][] provided the PHP CodeSniffer checker.
 - [Steve Purcell][purcell] implemented many checkers, contributed important
   ideas to the design of the checker API and engaged in worthwhile discussion to

--- a/doc/checkers.texi
+++ b/doc/checkers.texi
@@ -8,6 +8,7 @@ order of their appearance in the default value of
 @iflyc css-csslint
 @iflyc emacs-lisp
 @iflyc emacs-lisp-checkdoc
+@iflyc go
 @iflyc go-gofmt
 @iflyc haml
 @iflyc html-tidy

--- a/doc/credits.texi
+++ b/doc/credits.texi
@@ -31,12 +31,12 @@ awesome Vim library @uref{https://github.com/scrooloose/syntastic,
 syntastic} which inspired this project and many of its checkers.
 
 @item
-@uref{https://github.com/ptrv, Peter Vasil} created the XML and Lua
+@uref{https://github.com/ptrv, Peter Vasil} created the Go, XML and Lua
 syntax checkers, added unit tests and did valuable testing.
 
 @item
-@uref{https://github.com/robert-zaremba, Robert Zaremba} added the Go
-syntax checker.
+@uref{https://github.com/robert-zaremba, Robert Zaremba} added the
+Go-Gofmt syntax checker.
 
 @item
 @uref{https://github.com/steckerhalter, steckerhalter} provided the PHP

--- a/doc/flycheck.info
+++ b/doc/flycheck.info
@@ -82,7 +82,7 @@ File: flycheck.info,  Node: Features,  Next: Installation,  Prev: Introduction, 
         * CoffeeScript
         * CSS
         * Emacs Lisp (using the byte compiler and CheckDoc)
-        * Go (using 'gofmt')
+        * Go (using go compiler and 'gofmt')
         * Haml
         * HTML
         * Javascript
@@ -2104,6 +2104,7 @@ order of their appearance in the default value of 'flycheck-checkers':
    * 'css-csslint'
    * 'emacs-lisp'
    * 'emacs-lisp-checkdoc'
+   * 'go'
    * 'go-gofmt'
    * 'haml'
    * 'html-tidy'

--- a/tests/resources/go-test-files/missing-import/missing-import.go
+++ b/tests/resources/go-test-files/missing-import/missing-import.go
@@ -1,0 +1,7 @@
+// A missing import error in Go
+
+package main
+
+func main() {
+	fmt.Printf("Hello\n")
+}

--- a/tests/resources/go-test-files/syntax-error-in-test-file/syntax-error_test.go
+++ b/tests/resources/go-test-files/syntax-error-in-test-file/syntax-error_test.go
@@ -1,0 +1,7 @@
+// A syntax error in a test file
+
+package syntax_error_in_test_file
+
+func TestFunc() {
+	x = 1
+}

--- a/tests/resources/go-test-files/undefined-variable/undefined-variable.go
+++ b/tests/resources/go-test-files/undefined-variable/undefined-variable.go
@@ -1,0 +1,7 @@
+// An undefined variable error in Go
+
+package main
+
+func main() {
+	x = 1
+}

--- a/tests/resources/go-test-files/unused-variable/unused-variable.go
+++ b/tests/resources/go-test-files/unused-variable/unused-variable.go
@@ -1,0 +1,7 @@
+// A unused variable error in Go
+
+package main
+
+func main() {
+	x := 1
+}

--- a/tests/test-checkers/test-go.el
+++ b/tests/test-checkers/test-go.el
@@ -1,0 +1,78 @@
+;;; test-go.el --- Test the go checker -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2013 Sebastian Wiesner <lunaryorn@gmail.com>,
+;;                    Peter Vasil <mail@petervasil.net>,
+;;
+;; Author: Sebastian Wiesner <lunaryorn@gmail.com>,
+;;         Peter Vasil <mail@petervasil.net>,
+;; URL: https://github.com/lunaryorn/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'flycheck)
+
+(require 'go-mode nil :no-error)
+
+(ert-deftest checker-go-syntax-error ()
+  "Test a syntax error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'go)
+  (flycheck-testsuite-should-syntax-check
+   "syntax-error.go" 'go-mode nil
+   '(5 nil "syntax error: unexpected name, expecting (" error)
+   ))
+
+(ert-deftest checker-go-missing-import ()
+  "Test a a missing import error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'go)
+  (flycheck-testsuite-should-syntax-check
+   "go-test-files/missing-import/missing-import.go" 'go-mode nil
+   '(6 nil "undefined: fmt" error)
+   ))
+
+(ert-deftest checker-go-unused-variable ()
+  "Test an unused variable error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'go)
+  (flycheck-testsuite-should-syntax-check
+   "go-test-files/unused-variable/unused-variable.go" 'go-mode nil
+   '(6 nil "x declared and not used" error)
+   ))
+
+(ert-deftest checker-go-undefined-variable ()
+  "Test an undefined variable error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'go)
+  (flycheck-testsuite-should-syntax-check
+   "go-test-files/undefined-variable/undefined-variable.go" 'go-mode nil
+   '(6 nil "undefined: x" error)
+   '(6 nil "cannot assign to x" error)
+   ))
+
+(ert-deftest checker-go-syntax-error-in-test-file ()
+  "Test a syntax error in a test file."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'go)
+  (flycheck-testsuite-should-syntax-check
+   "go-test-files/syntax-error-in-test-file/syntax-error_test.go" 'go-mode nil
+   '(6 nil "undefined: x" error)
+   '(6 nil "cannot assign to x" error)
+   ))
+
+;; Local Variables:
+;; coding: utf-8
+;; End:
+
+;;; test-go.el ends here


### PR DESCRIPTION
First version of go checker that uses the go compiler command. The checker command depends on the source file to check. It also adds the files that are part of the source package to the checker command via the `go list` command, to get also dependency errors within a source package. Executing `go list -f '{{.GoFiles}} {{.CgoFiles}}'` would output something like

```
[main.go file1.go file2.go][]
```

and if the current file is a test file then

```
[main.go file1.go file2.go][][file_test.go]
```

For a regular go file and using with flycheck the command would look like (main.go is the current file)

```
go build -o /dev/null flycheck-main.go file1.go file2.go
```

I basically copied the 'go-flymake' functionality to elisp.

My code is probably not the best regarding style, so feel free to change anything.

For the tests I had to create subdirectories to extract the errors because the checker command takes all go file within a directory into account and the test output would not have been clear when multiple files have errors.

I am looking forward to your comments.
