### PR TITLE
Enable debug in flycheck-error-with-buffer macro

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1426,7 +1426,7 @@ Pop up a help buffer with the documentation of CHECKER."
   "Switch to the buffer of ERR and evaluate FORMS.
 
 If the buffer of ERR is not live, FORMS are not evaluated."
-  (declare (indent 1))
+  (declare (indent 1) (debug t))
   `(when (buffer-live-p (flycheck-error-buffer ,err))
      (with-current-buffer (flycheck-error-buffer ,err)
        ,@forms)))


### PR DESCRIPTION
When I investigated flycheck behavior with edebug, especially for `flycheck-create-overlay`. I was confused about  edebug finished at the `flycheck-error-with-buffer` macro entry.
How about declare debug spec?
http://www.gnu.org/software/emacs/manual/html_node/elisp/Declare-Form.html#Declare-Form
