### PR TITLE
Add Go syntax checker that uses gofmt tool and the go compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ The following people contributed to flycheck:
 - [Marian Schubert][maio] added the Perl syntax checker.
 - [Martin Grenfell][scrooloose] created the awesome Vim library [syntastic][]
   which inspired this project and many of its checkers.
-- [Peter Vasil][ptrv] created the XML and Lua syntax checkers, added unit tests
-  and did valuable testing.
-- [Robert Zaremba][robert-zaremba] added the Go syntax checker.
+- [Peter Vasil][ptrv] created the XML, Lua and go-build/test Go syntax
+  checkers, added unit tests and did valuable testing.
+- [Robert Zaremba][robert-zaremba] added the gofmt Go syntax checker.
 - [steckerhalter][] provided the PHP CodeSniffer checker.
 - [Steve Purcell][purcell] implemented many checkers, contributed important
   ideas to the design of the checker API and engaged in worthwhile discussion to

--- a/doc/checkers.texi
+++ b/doc/checkers.texi
@@ -9,6 +9,8 @@ order of their appearance in the default value of
 @iflyc emacs-lisp
 @iflyc emacs-lisp-checkdoc
 @iflyc go-gofmt
+@iflyc go-build
+@iflyc go-test
 @iflyc haml
 @iflyc html-tidy
 @iflyc javascript-jshint

--- a/doc/credits.texi
+++ b/doc/credits.texi
@@ -31,7 +31,7 @@ awesome Vim library @uref{https://github.com/scrooloose/syntastic,
 syntastic} which inspired this project and many of its checkers.
 
 @item
-@uref{https://github.com/ptrv, Peter Vasil} created the XML and Lua
+@uref{https://github.com/ptrv, Peter Vasil} created the XML, Lua and Go
 syntax checkers, added unit tests and did valuable testing.
 
 @item

--- a/doc/introduction.texi
+++ b/doc/introduction.texi
@@ -46,7 +46,7 @@ CSS (using @command{csslint}))
 @item
 Emacs Lisp (using the byte compiler and CheckDoc)
 @item
-Go (using @command{gofmt})
+Go (using @command{gofmt}, @command{go build} and @command{go test})
 @item
 Haml
 @item

--- a/tests/resources/checkers/go-testpackage/go-import-error.go
+++ b/tests/resources/checkers/go-testpackage/go-import-error.go
@@ -1,0 +1,7 @@
+// A simple import error in Go
+
+package testpackage
+
+func Foo() {
+	fmt.Println("foo")
+}

--- a/tests/resources/checkers/go-testpackage/go-import-error_test.go
+++ b/tests/resources/checkers/go-testpackage/go-import-error_test.go
@@ -1,0 +1,9 @@
+// A simple import error in Go test file
+
+package testpackage
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+	fmt.Println("foo")
+}

--- a/tests/test-checkers/test-go-build.el
+++ b/tests/test-checkers/test-go-build.el
@@ -1,0 +1,43 @@
+;;; test-go-build.el --- Test the go-build checker -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2013 Sebastian Wiesner <lunaryorn@gmail.com>,
+;;                    Peter Vasil <mail@petervasil.net>,
+;;
+;; Author: Sebastian Wiesner <lunaryorn@gmail.com>,
+;;         Peter Vasil <mail@petervasil.net>,
+;; URL: https://github.com/lunaryorn/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'flycheck)
+
+(require 'go-mode nil :no-error)
+
+(ert-deftest checker-go-build-import-error ()
+  "Test an import error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'go-build)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/go-testpackage/go-import-error.go" 'go-mode nil
+   '(6 nil "undefined: fmt" error)))
+
+;; Local Variables:
+;; coding: utf-8
+;; End:
+
+;;; test-go-build.el ends here

--- a/tests/test-checkers/test-go-test.el
+++ b/tests/test-checkers/test-go-test.el
@@ -1,0 +1,43 @@
+;;; test-go-test.el --- Test the go-test checker -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2013 Sebastian Wiesner <lunaryorn@gmail.com>,
+;;                    Peter Vasil <mail@petervasil.net>,
+;;
+;; Author: Sebastian Wiesner <lunaryorn@gmail.com>,
+;;         Peter Vasil <mail@petervasil.net>,
+;; URL: https://github.com/lunaryorn/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'flycheck)
+
+(require 'go-mode nil :no-error)
+
+(ert-deftest checker-go-test-import-error ()
+  "Test an import error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'go-test)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/go-testpackage/go-import-error_test.go" 'go-mode nil
+   '(8 nil "undefined: fmt" error)))
+
+;; Local Variables:
+;; coding: utf-8
+;; End:
+
+;;; test-go-test.el ends here


### PR DESCRIPTION
Two issues with these checkers:

The first problem is that the Go compiler returns the following when running `go build -o /dev/null` in a package foo:

```
go install foo: build output "/dev/null" already exists and is not an object file
```

This issue has been already reported in the Go project:
https://code.google.com/p/go/issues/detail?id=4851

The consequence is that flycheck reports: `Checker definition probably flawed` and `FlyC?`. In small packages with one file flycheck reports errors correct, because its the only file, but when the package has multiple files and some can be compiled and some not, then flycheck does not work because of that nonzero output

Another issue is that this way the second part of the checker (go-build and go-test) does not work on unsaved files only after saving it (like with source-original)

My other go checker https://gist.github.com/ptrv/5373321
does not have these issues
