### PR TITLE
fixed readme.md reference to global-flycheck-modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To enable Flycheck mode in all buffers, in which it can be used, add the
 following to your `init.el` file:
 
 ```scheme
-(add-hook 'after-init-hook #'global-flycheck-modes)
+(add-hook 'after-init-hook #'global-flycheck-mode)
 ```
 
 In Flycheck mode the buffer will automatically be checked on the fly, if a


### PR DESCRIPTION
global-flycheck-modes doesn't seem to exist in the source, and the info file mentions global-flycheck-mode instead.
