### PR TITLE
Add a checker based on RuboCop

### DIFF
--- a/doc/changes.texi
+++ b/doc/changes.texi
@@ -446,6 +446,14 @@ compatibility library will be installed from GNU ELPA.
 
 @itemize @bullet
 @item
+New syntax checkers:
+
+@itemize @bullet
+@item
+Ruby using RuboCop
+
+@itemize @bullet
+@item
 Improvements:
 
 @itemize @bullet

--- a/doc/checkers.texi
+++ b/doc/checkers.texi
@@ -23,6 +23,7 @@ order of their appearance in the default value of
 @iflyc python-pylint
 @iflyc python-pyflakes
 @iflyc rst
+@iflyc ruby-rubocop
 @iflyc ruby
 @iflyc rust-rustc
 @iflyc sass

--- a/doc/introduction.texi
+++ b/doc/introduction.texi
@@ -69,7 +69,7 @@ PHP (using the PHP Command Line and PHP CodeSniffer)
 @item
 Python (using @command{flake8}, @command{pylint}, or @command{pyflakes})
 @item
-Ruby
+Ruby (using @command{ruby} or @command{rubocop})
 @item
 Rust (using @command{rustc})
 @item

--- a/flycheck.el
+++ b/flycheck.el
@@ -103,6 +103,7 @@ buffer-local wherever it is set."
     python-pylint
     python-pyflakes
     rst
+    ruby-rubocop
     ruby
     rust-rustc
     sass
@@ -2502,6 +2503,17 @@ See URL `http://docutils.sourceforge.net/'."
   "A Ruby syntax checker using the Ruby interpreter."
   :command '("ruby" "-w" "-c" source)
   :error-patterns '(("^\\(?1:.*\\):\\(?2:[0-9]+\\): \\(?4:.*\\)$" error))
+  :modes 'ruby-mode)
+
+(flycheck-declare-checker ruby-rubocop
+  "A Ruby syntax checker using the RuboCop tool.
+
+See URL `https://github.com/bbatsov/rubocop'."
+  :command '("rubocop" "-e" "-s" source)
+  :error-patterns
+  '(("^\\(?1:.*\\):\\(?2:[0-9]+\\): C: \\(?4:.*\\)$" warning)
+    ("^\\(?1:.*\\):\\(?2:[0-9]+\\): W: \\(?4:.*\\)$" warning)
+    ("^\\(?1:.*\\):\\(?2:[0-9]+\\): E: \\(?4:.*\\)$" error))
   :modes 'ruby-mode)
 
 (flycheck-declare-checker rust-rustc

--- a/tests/test-checkers/test-ruby-rubocop.el
+++ b/tests/test-checkers/test-ruby-rubocop.el
@@ -1,0 +1,39 @@
+;;; test-ruby-rubocop.el --- Test the RuboCop checker -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
+;;
+;; Author: Sebastian Wiesner <lunaryorn@gmail.com>
+;; URL: https://github.com/lunaryorn/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as publirubyed by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You rubyould have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'flycheck)
+
+(ert-deftest checker-ruby-rubocop-syntax-error ()
+  "Test a Ruby syntax error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'ruby-rubocop)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/ruby-syntax-error.rb" 'ruby-mode nil
+   '(5 nil "Syntax error, unexpected tCONSTANT, expecting $end" error)))
+
+;; Local Variables:
+;; coding: utf-8
+;; End:
+
+;;; test-ruby-rubocop.el ends here

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -99,7 +99,8 @@ npm coffee-script coffeelint \
     jsonlint
 
 gem haml \
-    sass
+    sass \
+    rubocop
 
 # Install carton for Emacs dependency management
 CARTON_VERSION=0.2.0


### PR DESCRIPTION
RuboCop is an advanced code analysis tool, based on the community Ruby
Style Guide. RuboCop runs internally `ruby -wc`(just one of its many
"cops"), so it could be considered a superset of it.

@lunaryorn, I guess that I probably missed something, so any feedback is welcome.
