### PR TITLE
Haskell ghc checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1669,7 +1669,7 @@ back to `xml-parse-region'.")
   (let ((next (flycheck-haskell-parse-until-next lines (list))))
     (if (null (cadr next))
         '()
-      (gather-errors (cadr next)))))
+      (flycheck-haskell-gather-errors (cadr next)))))
 
 (defun flycheck-haskell-gather-errors (lines)
   (if (null lines) (list)


### PR DESCRIPTION
Fixes #32 and implements flycheckers for haskell using ghc -Wall and hlint.

This is not ready to be merged yet, creating the CR to have some discussion and hopefully learn something.

Problems:
- I did not create any tests. I'll look into doing that over the weekend but as the code probably shows I don't normally program emacs-lisp, so I reserve the right to be confused and possibly take longer.
- It should probably be written using loops for clarity, but I don't know elisp loop constructs.
- The contributed functions should probably be renamed, since they're not really specific to anything haskell, just the output format that both hlint and ghc use for warnings and errors.
- Should probably set up a way to pass some parameters to ghc to enable turning off some of the warnings that are really annoying to get while coding.

I kind of hacked this together in an hour because I wanted to have something like it for a haskell workshop the day after, but it works.
