### PR TITLE
Teach the ruby checker about warnings

### DIFF
--- a/doc/changes.texi
+++ b/doc/changes.texi
@@ -519,6 +519,12 @@ CodeSniffer}
 @comment  node-name,  next,  previous,  up
 @unnumberedsec master (unreleased)
 
+@item
+Improvements:
+
+@itemize @bullet
+@item
+The @code{ruby} checker now differentiates warnings from errors
 
 @c Local Variables:
 @c mode: texinfo

--- a/flycheck.el
+++ b/flycheck.el
@@ -2636,7 +2636,9 @@ See URL `https://github.com/bbatsov/rubocop'."
 (flycheck-declare-checker ruby
   "A Ruby syntax checker using the Ruby interpreter."
   :command '("ruby" "-w" "-c" source)
-  :error-patterns '(("^\\(?1:.*\\):\\(?2:[0-9]+\\): \\(?4:.*\\)$" error))
+  :error-patterns
+  '(("^\\(?1:.*\\):\\(?2:[0-9]+\\): warning: \\(?4:.*\\)$" warning)
+    ("^\\(?1:.*\\):\\(?2:[0-9]+\\): \\(?4:.*\\)$" error))
   :modes 'ruby-mode)
 
 (flycheck-declare-checker rust

--- a/tests/resources/checkers/ruby-warning.rb
+++ b/tests/resources/checkers/ruby-warning.rb
@@ -1,0 +1,3 @@
+# generates warning 'possibly useless use of == in void context'
+
+test == 20

--- a/tests/test-checkers/test-ruby.el
+++ b/tests/test-checkers/test-ruby.el
@@ -32,6 +32,13 @@
    "checkers/ruby-syntax-error.rb" 'ruby-mode '(ruby-rubocop)
    '(5 nil "syntax error, unexpected tCONSTANT, expecting $end" error)))
 
+(ert-deftest checker-ruby-warning ()
+  "Test a Ruby syntax error."
+  :expected-result (flycheck-testsuite-fail-unless-checker 'ruby)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/ruby-warning.rb" 'ruby-mode '(ruby-rubocop)
+   '(3 nil "possibly useless use of == in void context" warning)))
+
 ;; Local Variables:
 ;; coding: utf-8
 ;; End:


### PR DESCRIPTION
The warnings generated by the interpreter always start with `warning:`
(unlike errors that have no prefix). While I'd love everyone to use
RuboCop, I'd like us to have a smarter basic Ruby checker until the moment of
RuboCop world hegemony :-)
