### PR TITLE
Add a custom variable to perform a syntax check only when a file is saved

### DIFF
--- a/doc/usage.texi
+++ b/doc/usage.texi
@@ -25,6 +25,10 @@ or if new lines are inserted.
 @end itemize
 
 @noindent
+It is possible to check the buffer only upon saving if the custom variable
+@code{flycheck-check-on-save-only} it set to non-nil.
+
+@noindent
 You can also check the buffer manually:
 
 @table @kbd

--- a/flycheck.el
+++ b/flycheck.el
@@ -180,6 +180,11 @@ jumps to the error column regardless of the highlighting mode."
                  (const :tag "Highlight whole lines" lines)
                  (const :tag "Do not highlight errors" nil))
   :package-version '(flycheck . "0.6"))
+  
+(defcustom flycheck-check-on-save-only nil
+  "If non-nil, flycheck will perform a syntax check only when the file is saved."
+  :group 'flycheck
+  :type 'boolean)
 
 (defcustom flycheck-mode-hook nil
   "Hooks to run after `flycheck-mode'."
@@ -254,6 +259,10 @@ running checks, and empty all variables used by flycheck."
 (defvar-local flycheck-previous-next-error-function nil
   "Remember the previous `next-error-function'.")
 
+(defun flycheck-check-on-save-only-p ()
+  "Determine if flycheck performs a syntax check on file save only ."
+  flycheck-check-on-save-only)
+
 ;;;###autoload
 (define-minor-mode flycheck-mode
   "Minor mode for on-the-fly syntax checking.
@@ -284,7 +293,8 @@ buffer manually.
     (flycheck-clear)
 
     (add-hook 'after-save-hook 'flycheck-buffer-safe nil t)
-    (add-hook 'after-change-functions 'flycheck-handle-change nil t)
+    (if (not (flycheck-check-on-save-only-p))
+         (add-hook 'after-change-functions 'flycheck-handle-change nil t))
     (add-hook 'kill-buffer-hook 'flycheck-teardown nil t)
     ;; Execute deferred checks if the buffer visibility changes
     (add-hook 'window-configuration-change-hook
@@ -301,7 +311,8 @@ buffer manually.
     (flycheck-buffer-safe))
    (t
     (remove-hook 'after-save-hook 'flycheck-buffer-safe t)
-    (remove-hook 'after-change-functions 'flycheck-handle-change t)
+    (if (not (flycheck-check-on-save-only-p))
+         (remove-hook 'after-change-functions 'flycheck-handle-change t))
     (remove-hook 'kill-buffer-hook 'flycheck-teardown t)
     (remove-hook 'window-configuration-change-hook
                  'flycheck-perform-deferred-syntax-check t)


### PR DESCRIPTION
Hi Sebastian,

This PR adds a custom variable to perform a syntax check only when a file is saved.
This is an attempt to fix the [issue #126](https://github.com/lunaryorn/flycheck/issues/126).

Cheers,
syl20bnr
