### PR TITLE
Fix a typo in the manual

### DIFF
--- a/doc/flycheck.info
+++ b/doc/flycheck.info
@@ -319,7 +319,7 @@ files are provided by Flycheck:
      The configuration file for the 'javascript-jshint' syntax checker.
 
  -- User Option: flycheck-rubocoprc
-     The configuration file for the 'ruby-rubocup' syntax checker.
+     The configuration file for the 'ruby-rubocop' syntax checker.
 
  -- User Option: flycheck-tidyrc
      The configuration file for the 'html-tidy' syntax checker.

--- a/doc/usage.texi
+++ b/doc/usage.texi
@@ -194,7 +194,7 @@ The configuration file for the @code{javascript-jshint} syntax checker.
 @end defopt
 
 @defopt flycheck-rubocoprc
-The configuration file for the @code{ruby-rubocup} syntax checker.
+The configuration file for the @code{ruby-rubocop} syntax checker.
 @end defopt
 
 @defopt flycheck-tidyrc


### PR DESCRIPTION
It's RuboCop, not RuboCup ;-)
