### PR TITLE
Configurable display function

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -369,6 +369,17 @@ when Flycheck failed.
 
 This variable is a normal hook.")
 
+(defcustom flycheck-display-error-messages-function 'flycheck-display-message-or-buffer
+  "Function to display error messages.
+
+This function takes a single argument: A string with all error messages.
+
+The default function uses `display-message-or-buffer'.
+
+A value of nil will disable the display of error messages."
+  :group 'flycheck
+  :type 'function)
+
 ;; TODO: Remove the obsolete faces in 0.14
 (defface flycheck-error
   '((((supports :underline (:style wave)))
@@ -2430,9 +2441,15 @@ or nil if the buffer does not exist."
 
 (defun flycheck-display-error-messages (error-messages)
   "Display Flycheck ERROR-MESSAGES."
-  (when error-messages
-    (display-message-or-buffer error-messages
-                               flycheck-error-message-buffer)))
+  (when (and error-messages flycheck-display-error-messages-function)
+    (funcall flycheck-display-error-messages-function error-messages)))
+
+(defun flycheck-display-message-or-buffer (error-messages)
+  "Display ERROR-MESSAGES in the echo area or a pop-up buffer.
+
+Uses `display-message-or-buffer'."
+  (display-message-or-buffer error-messages
+                             flycheck-error-message-buffer))
 
 (defvar-local flycheck-error-show-error-timer nil
   "Timer to automatically show the error at point in minibuffer.")

--- a/tests/test-configurable-display-function.el
+++ b/tests/test-configurable-display-function.el
@@ -1,0 +1,43 @@
+;;; test-configurable-display-function.el --- Test custom display functions -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
+;;
+;; Author: Sebastian Wiesner <lunaryorn@gmail.com>
+;; URL: https://github.com/lunaryorn/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'flycheck)
+
+(ert-deftest flycheck-uses-custom-display-function ()
+  (mocker-let ((display-function (messages)
+                                 ((:input '("test") :min-occur 1))))
+    (let ((flycheck-display-error-messages-function 'display-function))
+      (flycheck-display-error-messages "test"))))
+
+(ert-deftest flycheck-uses-default-display-function ()
+  (mocker-let ((flycheck-display-message-or-buffer (messages)
+                                 ((:input '("test") :min-occur 1))))
+    (flycheck-display-error-messages "test")))
+
+;; Local Variables:
+;; coding: utf-8
+;; End:
+
+;;; test-configurable-display-function.el ends here


### PR DESCRIPTION
Allows the user to determine via a custom setting how Flycheck will display error messages, defaulting to the original behaviour of `display-message-or-buffer`.
