### PR TITLE
Support using html-tidy check for web-mode

### DIFF
--- a/Carton
+++ b/Carton
@@ -14,6 +14,7 @@
  ;; Various modes for use in the unit tests
  (depends-on "coffee-mode")
  (depends-on "haml-mode")
+ (depends-on "web-mode")
  (depends-on "js2-mode")
  (depends-on "js3-mode")
  (depends-on "lua-mode")

--- a/doc/changes.texi
+++ b/doc/changes.texi
@@ -712,6 +712,18 @@ Fix version information on Emacs trunk builds
 @comment  node-name,  next,  previous,  up
 @unnumberedsec master (unreleased)
 
+@itemize @bullet
+@item
+Improvements:
+
+@itemize @bullet
+@item
+@ghissue{157, Support} @uref{http://web-mode.org/, Web Mode} in
+@code{html-tidy} syntax checker
+@end itemize
+
+@end itemize
+
 @c Local Variables:
 @c mode: texinfo
 @c TeX-master: "flycheck"

--- a/flycheck.el
+++ b/flycheck.el
@@ -2892,7 +2892,7 @@ See URL `https://github.com/w3c/tidy-html5'."
   '(("^line \\(?2:[0-9]+\\) column \\(?3:[0-9]+\\) - Error: \\(?4:.*\\)$" error)
     ("^line \\(?2:[0-9]+\\) column \\(?3:[0-9]+\\) - Warning: \\(?4:.*\\)$"
      warning))
-  :modes '(html-mode nxhtml-mode))
+  :modes '(html-mode nxhtml-mode web-mode))
 
 (flycheck-def-config-file-var flycheck-jshintrc javascript-jshint ".jshintrc")
 

--- a/tests/flycheck-testsuite.el
+++ b/tests/flycheck-testsuite.el
@@ -121,6 +121,7 @@
           elixir-mode
           go-mode
           haml-mode
+          web-mode
           js2-mode
           js3-mode
           lua-mode
@@ -2147,7 +2148,7 @@ See URL `https://github.com/lunaryorn/flycheck/issues/45' and URL
   "Test an error caused by an unknown tag."
   :expected-result (flycheck-testsuite-fail-unless-checker 'html-tidy)
   (flycheck-testsuite-should-syntax-check
-   "checkers/html-tidy-warning-and-error.html" 'html-mode nil
+   "checkers/html-tidy-warning-and-error.html" '(html-mode web-mode) nil
    '(3 1 "missing <!DOCTYPE> declaration" warning :filename nil)
    '(8 5 "<spam> is not recognized!" error :filename nil)
    '(8 5 "discarding unexpected <spam>" warning :filename nil)))


### PR DESCRIPTION
I've been using web-mode for my development. (http://web-mode.org/) However, flycheck won't work because it's not one of the supported modes. In the current version it's 

```
:modes '(html-mode nxhtml-mode))
```

Is it as simple as adding web-mode to that list? Or is there something else?
