### PR TITLE
Fix typos in conversion of haskell regexps to rx

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3128,7 +3128,7 @@ See URL `https://github.com/bitc/hdevtools'."
   :command ("hdevtools" "check" "-g" "-Wall" source-inplace)
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ":"
-            (or " " "\n    ") "Warning:" (optional "/n")
+            (or " " "\n    ") "Warning:" (optional "\n")
             (one-or-more " ")
             (message (one-or-more not-newline)
                      (zero-or-more "\n"
@@ -3153,7 +3153,7 @@ See URL `http://www.haskell.org/ghc/'."
   :command ("ghc" "-Wall" "-fno-code" source-inplace)
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ":"
-            (or " " "\n    ") "Warning:" (optional "/n")
+            (or " " "\n    ") "Warning:" (optional "\n")
             (one-or-more " ")
             (message (one-or-more not-newline)
                      (zero-or-more "\n"


### PR DESCRIPTION
See #32.

(Sorry, haven't taken the time to add further failing tests.)
