### PR TITLE
Add D programming language support

### DIFF
--- a/Carton
+++ b/Carton
@@ -29,4 +29,5 @@
  (depends-on "go-mode")
  (depends-on "rust-mode")
  (depends-on "elixir-mode")
- (depends-on "erlang"))
+ (depends-on "erlang")
+ (depends-on "d-mode"))

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Features
 - Built-in syntax checkers for:
   - CoffeeScript
   - CSS
+  - D
   - Elixir
   - Emacs Lisp
   - Erlang

--- a/flycheck.el
+++ b/flycheck.el
@@ -114,6 +114,7 @@ buffer-local wherever it is set."
   '(bash
     coffee-coffeelint
     css-csslint
+    d
     elixir
     emacs-lisp
     emacs-lisp-checkdoc
@@ -2928,6 +2929,28 @@ See URL `https://github.com/stubbornella/csslint'."
             line ", col "
             column ", Warning - " (message) line-end))
   :modes css-mode)
+
+(defun flycheck-d-base-dir ()
+  (let ((nest (save-excursion
+                (goto-char (point-min))
+                (if (re-search-forward "module\s+\\([^\s]+\\);" nil t)
+                    (->> (match-string-no-properties 1)
+                      string-to-vector
+                      (cl-count ?.))
+                    0))))
+    (when (equal (file-name-nondirectory (buffer-file-name)) "package.d")
+      (cl-incf nest))
+    (concat "-I./" (s-repeat nest "../"))))
+
+(flycheck-define-checker d
+  "A D syntax checker using D compiler."
+  :command ("dmd" "-debug" "-o-" "-property"
+                  "-wi" ; Compilation will continue even if there are warnings
+                  (eval (flycheck-d-base-dir)) source)
+  :error-patterns
+  ((error line-start (file-name) "(" line "): Error: " (message) line-end)
+   (warning line-start (file-name) "(" line "): " (or "Warning" "Deprecation") ": " (message) line-end))
+  :modes d-mode)
 
 (flycheck-define-checker elixir
   "An Elixir syntax checker using the Elixir interpreter.

--- a/tests/flycheck-testsuite.el
+++ b/tests/flycheck-testsuite.el
@@ -133,6 +133,7 @@
 (--each '(sh-script
           coffee-mode
           css-mode
+          d-mode
           elixir-mode
           erlang
           elixir-mode
@@ -1997,6 +1998,30 @@ many-errors-for-error-list.el:14:1:warning: the function
    '(4 16 "Unexpected token '100%' at line 4, col 16." error)
    '(4 20 "Unexpected token ';' at line 4, col 20." error)
    '(5 1 "Unexpected token '}' at line 5, col 1." error)))
+
+(ert-deftest checker-d-syntax-error ()
+  :expected-result (flycheck-testsuite-fail-unless-checker 'd)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/d-syntax-error.d" 'd-mode nil
+   '(2 nil "module studio is in file 'std/studio.d' which cannot be read" error)))
+
+(ert-deftest checker-d-syntax-warning ()
+  :expected-result (flycheck-testsuite-fail-unless-checker 'd)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/d-syntax-warning.d" 'd-mode nil
+   '(6 nil "statement is not reachable" warning)))
+
+(ert-deftest checker-d-syntax-deprecated ()
+  :expected-result (flycheck-testsuite-fail-unless-checker 'd)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/d-syntax-deprecated.d" 'd-mode nil
+   '(11 nil "function d_syntax_deprecated.foo is deprecated" warning)))
+
+(ert-deftest checker-d-syntax-error-without-module ()
+  :expected-result (flycheck-testsuite-fail-unless-checker 'd)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/d_syntax_error_without_module.d" 'd-mode nil
+   '(5 nil "undefined identifier writel, did you mean template write(T...)(T args) if (!is(T[0] : File))?" error)))
 
 (ert-deftest checker-elixir-error ()
   :expected-result (flycheck-testsuite-fail-unless-checker 'elixir)

--- a/tests/resources/checkers/d-syntax-deprecated.d
+++ b/tests/resources/checkers/d-syntax-deprecated.d
@@ -1,0 +1,12 @@
+module d_syntax_deprecated;
+
+deprecated
+auto foo(int a)
+{
+    return a;
+}
+
+void main()
+{
+    auto bar = foo(1);
+}

--- a/tests/resources/checkers/d-syntax-error.d
+++ b/tests/resources/checkers/d-syntax-error.d
@@ -1,0 +1,7 @@
+module d_syntax_error;
+import std.studio;
+
+void main()
+{
+    writeln("Hello, world!");
+}

--- a/tests/resources/checkers/d-syntax-warning.d
+++ b/tests/resources/checkers/d-syntax-warning.d
@@ -1,0 +1,7 @@
+module d_syntax_warning;
+
+auto foo(int a)
+{
+    return a;
+    return a;
+}

--- a/tests/resources/checkers/d_syntax_error_without_module.d
+++ b/tests/resources/checkers/d_syntax_error_without_module.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+    writel("Hello");
+}

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -169,6 +169,15 @@ if ! [ -d "$ELIXIR_DIR" -a -x "$ELIXIR_DIR/elixirc" ]; then
     sudo ln -fs "$ELIXIR_DIR/bin/elixirc" "$ELIXIR_SYMDIR"
 fi
 
+# Install D compiler.
+DMD_VERSION=2.063.2
+DMD_DEB="dmd_${DMD_VERSION}-0_amd64.deb"
+command wget -q "http://downloads.dlang.org/releases/2013/${DMD_DEB}"
+# DMD depends on these packages but dpkg doesn't care about them.
+apt gcc-multilib xdg-utils
+sudo dpkg --install "$DMD_DEB"
+rm "$DMD_DEB"
+
 # Install carton for Emacs dependency management
 CARTON_VERSION=0.3.0
 CARTON_DIR="/opt/carton-${CARTON_VERSION}"


### PR DESCRIPTION
This pull request adds support for D programming language (http://dlang.org/).

It adds a syntax checker for D using `dmd` which is a reference compiler for D (http://dlang.org/download.html).

It also adds a unittesting checker for D using `rdmd` which is bundled with `dmd`.
D has a unit test feature as a language specification and we can easily run the unit tests by using `rdmd` without explicit compilation step.
So I think it is worth adding unit testing checker to flycheck.
