### PR TITLE
Add support to search for include files.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3278,7 +3278,9 @@ The checker runs `checkdoc-current-buffer'."
 
 (flycheck-define-checker erlang
   "An Erlang syntax checker using the Erlang interpreter."
-  :command ("erlc" "-o" temporary-directory "-Wall" source)
+  :command ("erlc" "-o" temporary-directory "-Wall"
+            "-I" "../include" "-I" "../../include"
+            "-I" "../../../include" source)
   :error-patterns
   ((warning line-start (file-name) ":" line ": Warning:" (message) line-end)
    (error line-start (file-name) ":" line ": " (message) line-end))


### PR DESCRIPTION
Search the `include` directory for Erlang. As the `hrl` files may be placed there.

According to common situations, it will search the `include` directory in at most 3 levels above the current directory.
