### PR TITLE
Make error level extensible

### DIFF
--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -1006,13 +1006,14 @@ Flycheck to make it available to other users, too.  @xref{Contributing
 syntax checkers}, for more information.
 
 @menu
-* Definition::          How to define syntax checkers
-* Error parsers::       Built-in error parsers
-* Option filters::      Built-in option filters
-* Examples::            Examples on how to define syntax checkers
+* Definition::                  How to define syntax checkers
+* Error levels::                Built-in error levels and how to define new
+* Error parsers::               Built-in error parsers
+* Option filters::              Built-in option filters
+* Examples::                    Examples on how to define syntax checkers
 @end menu
 
-@node Definition, Error parsers, Extending, Extending
+@node Definition, Error levels, Extending, Extending
 @comment  node-name,  next,  previous,  up
 @section Definition of syntax checkers
 
@@ -1175,8 +1176,13 @@ This property is @b{mandatory}.
 An unquoted list of one or more error patterns to parse the output of
 the syntax checker @code{:command}.
 
-@var{level} is either @code{warning} or @code{error} and denotes the
-severity of errors matched by the pattern.
+@var{level} is a Flycheck error level, and denotes the severity of
+errors matched by the pattern.  This mainly affects the visual
+representation of matched errors in buffers.
+
+Flycheck provides the built-in error levels @code{error} and
+@code{warning}.  You can define your own error levels with
+@code{flycheck-define-error-level}.
 
 The @var{level} is followed by one or more @code{rx} @var{sexp}
 elements.  See the docstring of the function @code{rx} for more
@@ -1323,7 +1329,52 @@ Use this macro together with the @code{option} cell in the command of a
 syntax checker.
 @end defmac
 
-@node Error parsers, Option filters, Definition, Extending
+@node Error levels, Error parsers, Definition, Extending
+@comment  node-name,  next,  previous,  up
+@section Error levels
+
+Flycheck provides two built-in error levels:
+
+@table @code
+@item error
+Severe errors which cannot be ignored
+@item warning
+Potential errors which can be ignored
+@end table
+
+You can define your own error levels with
+@code{flycheck-define-error-level}:
+
+@deffn flycheck-define-error-level @var{level} &rest @var{properties}
+Define a new error @var{level} with @var{properties}.
+
+The following @var{properties} constitute an error level:
+
+@table @code
+@item :overlay-category @var{category}
+The overlay @var{category} for @var{level}, as symbol.
+
+An overlay category is a symbol whose properties provide the default
+values for overlays of this category.  @xref{Overlay properties, ,
+,elisp}, for more information about overlay properties and categories.
+
+A category for an error level overlay should at least define the
+@code{face} property, for error highlighting.  Other useful properties
+for error level categories are @code{priority} to influence the stacking
+of multiple error level overlays, and @code{help-echo} to define a
+default error messages for errors without messages.
+@item :fringe-face @var{face}
+A face to use for fringe indicators for @var{level}, as symbol.
+@item :fringe-bitmap @var{bitmap}
+A fringe bitmap to use for fringe indicators for @var{level}, as symbol.
+
+@xref{Fringe Bitmaps, , ,elisp}, for a list of built-in fringe bitmaps,
+and instructions on how to define new bitmaps.
+@end table
+
+@end deffn
+
+@node Error parsers, Option filters, Error levels, Extending
 @comment  node-name,  next,  previous,  up
 @section Error parsers
 
@@ -1458,7 +1509,7 @@ Next we give the list of @code{:error-patterns} to parse errors.  These
 patterns extract the error location and the error message from the
 output of @command{epylint}.  An error pattern is a list containing a
 regular expression with match groups to extract the error information,
-and an error level (either @code{warning} or @code{error}).
+and an error level.
 
 Eventually we enable the syntax checker in @code{python-mode}.
 
@@ -1546,7 +1597,7 @@ the @option{--config} option.
 
 To use a configuration file with jshint, we first declare the variable
 @code{flycheck-jshintrc} that provides the name of the file, as
-explained in @ref{Configuration}.
+oexplained in @ref{Configuration}.
 
 In the @code{:command} we use a @code{config-file} element to pass the
 configuration file to the syntax checker.  If the configuration file is
@@ -1675,8 +1726,8 @@ whole line.
 The human-readable error message as string.
 
 @item level
-The severity of the error message, as either @code{error} or
-@code{warning}.
+The error level of the message, as symbol denoting an error level
+defined with @code{flycheck-define-error-level}.
 @end table
 
 There are two constructors you may use to create errors:
@@ -2843,6 +2894,9 @@ checker commands
 files for C/C++ syntax checking}
 @item
 Add configuration file variable @code{flycheck-pylintrc} for Pylint
+@item
+@ghissue{212, Define new error levels with
+@code{flycheck-define-error-level}}
 @end itemize
 
 @item

--- a/flycheck.el
+++ b/flycheck.el
@@ -1404,8 +1404,6 @@ value."
       (error "Missing :error-pattern or :error-parser"))
     (unless (or (null parser) (functionp parser))
       (error "%S is not a function" parser))
-    (unless (--all? (memq (car it) '(warning error)) patterns)
-      (error "Patterns %S have invalid levels" patterns))
     (unless (or modes predicate)
       (error "Missing :modes or :predicate"))
     (unless (or (symbolp modes) (-all? #'symbolp modes))
@@ -2280,6 +2278,109 @@ _not_ include the file name."
       (s-lex-format "${line}:${level}: ${message} (${checker})"))))
 
 
+;;;; Error levels
+
+;;;###autoload
+(defun flycheck-define-error-level (level &rest properties)
+  "Define a new error LEVEL with PROPERTIES.
+
+The following PROPERTIES constitute an error level:
+
+`:overlay-category CATEGORY'
+     A symbol denoting the overlay category to use for error
+     highlight overlays for this level.  See Info
+     node `(elisp)Overlay properties' for more information about
+     overlay categories.
+
+`:fringe-bitmap BITMAP'
+     A fringe bitmap symbol denoting the bitmap to use for fringe
+     indicators for this level.  See Info node `(elisp)Fringe
+     Bitmaps' for more information about fringe bitmaps.
+
+`:fringe-face FACE'
+     A face symbol denoting the face to use for fringe indicators
+     for this level."
+  (declare (indent 1))
+  (put level :flycheck-error-level t)
+  (put level :flycheck-overlay-category
+       (plist-get properties :overlay-category))
+  (put level :flycheck-fringe-bitmap
+       (plist-get properties :fringe-bitmap))
+  (put level :flycheck-fringe-face
+       (plist-get properties :fringe-face)))
+
+(defun flycheck-error-level-p (level)
+  "Determine whether LEVEL is a Flycheck error level."
+  (get level :flycheck-error-level))
+
+(defun flycheck-error-level-overlay-category (level)
+  "Get the overlay category for LEVEL."
+  (get level :flycheck-overlay-category))
+
+(defun flycheck-error-level-fringe-bitmap (level)
+  "Get the fringe bitmap for LEVEL."
+  (get level :flycheck-fringe-bitmap))
+
+(defun flycheck-error-level-fringe-face (level)
+  "Get the fringe face for LEVEL."
+  (get level :flycheck-fringe-face))
+
+(defun flycheck-error-level-make-fringe-icon (level side)
+  "Create the fringe icon for LEVEL at SIDE.
+
+Return a propertized string that shows a fringe bitmap according
+to LEVEL and the given fringe SIDE.
+
+LEVEL is a Flycheck error level defined with
+`flycheck-define-error-level', and SIDE is either `left-fringe'
+or `right-fringe'.
+
+Return a propertized string representing the fringe icon,
+intended for use as `before-string' of an overlay to actually
+show the icon."
+  (unless (memq side '(left-fringe right-fringe))
+    (error "Invalid fringe side: %S" side))
+  (propertize "!" 'display
+              (list side
+                    (flycheck-error-level-fringe-bitmap level)
+                    (flycheck-error-level-fringe-face level))))
+
+
+;;;; Built-in error levels
+(when (fboundp 'define-fringe-bitmap)
+  ;; define-fringe-bitmap is not available if Emacs is built without GUI
+  ;; support, see https://github.com/flycheck/flycheck/issues/57
+  (define-fringe-bitmap 'flycheck-fringe-exclamation-mark
+    [24 60 60 24 24 0 0 24 24] nil nil 'center))
+
+(defconst flycheck-fringe-exclamation-mark
+  (if (get 'exclamation-mark 'fringe)
+      'exclamation-mark
+    'flycheck-fringe-exclamation-mark)
+  "The symbol to use as exclamation mark bitmap.
+
+Defaults to the built-in exclamation mark if available or to the
+flycheck exclamation mark otherwise.")
+
+(put 'flycheck-error-overlay 'face 'flycheck-error)
+(put 'flycheck-error-overlay 'priority 110)
+(put 'flycheck-error-overlay 'help-echo "Unknown error.")
+
+(flycheck-define-error-level 'error
+  :overlay-category 'flycheck-error-overlay
+  :fringe-bitmap flycheck-fringe-exclamation-mark
+  :fringe-face 'flycheck-fringe-error)
+
+(put 'flycheck-warning-overlay 'face 'flycheck-warning)
+(put 'flycheck-warning-overlay 'priority 100)
+(put 'flycheck-warning-overlay 'help-echo "Unknown warning.")
+
+(flycheck-define-error-level 'warning
+  :overlay-category 'flycheck-warning-overlay
+  :fringe-bitmap 'question-mark
+  :fringe-face 'flycheck-fringe-warning)
+
+
 ;;;; General error parsing
 (defun flycheck-parse-output (output checker buffer)
   "Parse OUTPUT from CHECKER in BUFFER.
@@ -2608,76 +2709,32 @@ If LEVEL is omitted if the current buffer has any errors at all."
 
 
 ;;;; Error overlay management
-(when (fboundp 'define-fringe-bitmap)
-  ;; define-fringe-bitmap is not available if Emacs is built without GUI
-  ;; support, see https://github.com/flycheck/flycheck/issues/57
-  (define-fringe-bitmap 'flycheck-fringe-exclamation-mark
-    [24 60 60 24 24 0 0 24 24] nil nil 'center))
-
-(defconst flycheck-fringe-exclamation-mark
-  (if (get 'exclamation-mark 'fringe)
-      'exclamation-mark
-    'flycheck-fringe-exclamation-mark)
-  "The symbol to use as exclamation mark bitmap.
-
-Defaults to the built-in exclamation mark if available or to the
-flycheck exclamation mark otherwise.")
-
-(put 'flycheck-error-overlay 'flycheck-overlay t)
-(put 'flycheck-error-overlay 'face 'flycheck-error)
-(put 'flycheck-error-overlay 'priority 110)
-(put 'flycheck-error-overlay 'help-echo "Unknown error.")
-(put 'flycheck-error-overlay 'flycheck-fringe-face 'flycheck-fringe-error)
-(put 'flycheck-error-overlay 'flycheck-fringe-bitmap
-     flycheck-fringe-exclamation-mark)
-
-(put 'flycheck-warning-overlay 'flycheck-overlay t)
-(put 'flycheck-warning-overlay 'face 'flycheck-warning)
-(put 'flycheck-warning-overlay 'priority 100)
-(put 'flycheck-warning-overlay 'help-echo "Unknown warning.")
-(put 'flycheck-warning-overlay 'flycheck-fringe-face 'flycheck-fringe-warning)
-(put 'flycheck-warning-overlay 'flycheck-fringe-bitmap 'question-mark)
-
-(defun flycheck-make-fringe-icon (category)
-  "Create the fringe icon for CATEGORY.
-
-Return a propertized string that shows a fringe bitmap according
-to CATEGORY and the side specified `flycheck-indication-mode'.
-Use this string as `before-string' of an overlay to actually show
-the icon.
-
-If `flycheck-indication-mode' is neither `left-fringe' nor
-`right-fringe', returned nil."
-  (when (memq flycheck-indication-mode '(left-fringe right-fringe))
-    (let ((bitmap (get category 'flycheck-fringe-bitmap))
-          (face (get category 'flycheck-fringe-face)))
-      (propertize "!" 'display (list flycheck-indication-mode bitmap face)))))
-
 (defun flycheck-add-overlay (err)
   "Add overlay for ERR.
 
 Return the created overlay."
   (flycheck-error-with-buffer err
-    (pcase-let* ((mode flycheck-highlighting-mode)
-                 ;; Default to lines highlighting.  If MODE is nil, we want the
-                 ;; line for the sake of indication and error messages.  We erase
-                 ;; the highlighting later on
-                 (`(,beg . ,end) (flycheck-error-region-for-mode
-                                  err (or mode 'lines)))
+    ;; We must have a proper error region for the sake of fringe indication,
+    ;; error display and error navigation, even if the highlighting is disabled.
+    ;; We erase the highlighting later on in this case
+    (pcase-let* ((`(,beg . ,end) (flycheck-error-region-for-mode
+                                  err (or flycheck-highlighting-mode'lines)))
                  (overlay (make-overlay beg end))
                  (level (flycheck-error-level err))
-                 (category (pcase level
-                             (`warning 'flycheck-warning-overlay)
-                             (`error 'flycheck-error-overlay)
-                             (_ (error "Invalid error level %S" level)))))
+                 (category (flycheck-error-level-overlay-category level)))
+      (unless (flycheck-error-level-p level)
+        (error "Undefined error level: %S" level))
+      (overlay-put overlay 'flycheck-overlay t)
       (overlay-put overlay 'flycheck-error err)
       ;; TODO: Consider hooks to re-check if overlay contents change
       (overlay-put overlay 'category category)
-      (unless mode
+      (unless flycheck-highlighting-mode
         ;; Erase the highlighting from the overlay if requested by the user
         (overlay-put overlay 'face nil))
-      (-when-let (icon (flycheck-make-fringe-icon category))
-        (overlay-put overlay 'before-string icon))
+      (when flycheck-indication-mode
+        (overlay-put overlay 'before-string
+                     (flycheck-error-level-make-fringe-icon
+                      level flycheck-indication-mode)))
       (overlay-put overlay 'help-echo (flycheck-error-message err))
       overlay)))
 

--- a/test/error-level-test.el
+++ b/test/error-level-test.el
@@ -1,0 +1,52 @@
+;;; error-level-test.el --- Test for error levels -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2013  Sebastian Wiesner
+
+;; Author: Sebastian Wiesner <lunaryorn@gmail.com>
+;; URL: https://github.com/flycheck/flycheck
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for error levels
+
+;;; Code:
+
+(require 'flycheck)
+(require 'test-helper)
+
+;; A level for the following unit tests
+(flycheck-define-error-level 'test-level
+    :overlay-category 'category
+    :fringe-bitmap 'left-triangle
+    :fringe-face 'highlight)
+
+(ert-deftest flycheck-define-error-level ()
+  (should (flycheck-error-level-p 'test-level))
+  (should (eq (flycheck-error-level-fringe-bitmap 'test-level) 'bitmap))
+  (should (eq (flycheck-error-level-fringe-face 'test-level) 'face))
+  (should (eq (flycheck-error-level-overlay-category 'test-level) 'category)))
+
+(ert-deftest flycheck-error-level-make-fringe-icon ()
+  (--each '(left-fringe right-fringe)
+    (pcase-let* ((icon (flycheck-error-level-make-fringe-icon 'test-level it))
+                 (`(,side ,bitmap ,face) (get-text-property 0 'display icon)))
+      (should (eq side it))
+      (should (eq bitmap 'left-triangle))
+      (should (eq face 'highlight)))))
+
+;;; error-level-test.el ends here


### PR DESCRIPTION
Provide an API to add new error levels to Flycheck.
# Rationale

Users may wish to create their own syntax checkers with more subtle highlighting, see #211.
# Interface

``` lisp
(flycheck-define-error-level 'warning
  :overlay-category 'flycheck-warning-overlay 
  :fringe-bitmap flycheck-fringe-exclamation-mark
  :fringe-face 'flycheck-fringe-warning)
```
# Implementation
- Store error level properties in symbol properties of the error level symbol
- When creating overlays, retrieve the categories and fringe settings from the error level again
# Status
- [x] Add `flycheck-define-error-level`
- [x] Define built-in error levels
- [x] Use error level properties when creating overlays and fringe icons
- [x] Document error levels
- [ ] Add unit tests
# Potential pitfalls
- ~~Do not set the essential `flycheck-overlay` overlay property via overlay categories, as we cannot rely on custom categories to set this symbol as well.  Instead, set it directly in `flycheck-add-overlay`~~
- ~~Do not check error pattern  levels in `flycheck-define-checker`~~
