### PR TITLE
Fill list of available PHPCS standards dynamically.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3861,6 +3861,15 @@ See URL `http://php.net/manual/en/features.commandline.php'."
   :modes (php-mode php+-mode)
   :next-checkers ((warnings-only . php-phpcs)))
 
+(defvar flycheck-phpcs-standards-list
+      (s-split ", "
+	       (s-chop-prefix
+		"The installed coding standards are "
+		(s-replace-all '((" and " . ", ")(" PEAR," . ""))
+			   (substring
+			    (shell-command-to-string "phpcs -i")  0 -1))))
+      "List of currently installed coding standards for PHP CodeSniffer.")
+
 (flycheck-def-option-var flycheck-phpcs-standard nil php-phpcs
   "The coding standard for PHP CodeSniffer.
 
@@ -3868,8 +3877,11 @@ When nil, use the default standard from the global PHP
 CodeSniffer configuration.  When set to a string, pass the string
 to PHP CodeSniffer which will interpret it as name as a standard,
 or as path to a standard specification."
-  :type '(choice (const :tag "Default standard" nil)
-                 (string :tag "Standard name or file"))
+  :type `(choice (const :tag "Default standard (PEAR)" nil)
+		 ,@(mapcar (lambda (c)
+                           (list 'const :tag c c))
+		    flycheck-phpcs-standards-list)
+		 (string :tag "Custom standard name or config file"))
   :safe #'stringp)
 
 (flycheck-define-checker php-phpcs


### PR DESCRIPTION
List of available PHPCS standards generated dynamically.
It's still available to set string as custom coding standard.
As mentioned in PHPCS documentation, default coding standard is PEAR.
So, PEAR is removed from list and is used if flycheck-phpcs-standard is nil.
