### PR TITLE
Add syntax checker for YAML using the psych YAML parer

### DIFF
--- a/Cask
+++ b/Cask
@@ -32,4 +32,5 @@
  (depends-on "rust-mode")
  (depends-on "elixir-mode")
  (depends-on "erlang")
- (depends-on "d-mode"))
+ (depends-on "d-mode")
+ (depends-on "yaml-mode"))

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Features
   - Shell scripts (POSIX Shell, Bash and Zsh)
   - TeX/LaTeX
   - XML
+  - YAML
 - Nice error indication and highlighting
 - Easy customization
 - Syntax checker configuration with project-specific configuration files and

--- a/flycheck.el
+++ b/flycheck.el
@@ -161,6 +161,7 @@ buffer-local wherever it is set."
     tex-lacheck
     xml-xmlstarlet
     xml-xmllint
+    yaml
     zsh)
   "Syntax checkers available for automatic selection.
 
@@ -4266,6 +4267,22 @@ The xmllint is part of libxml2, see URL
   :error-patterns
   ((error line-start (file-name) ":" line ": " (message) line-end))
   :modes (xml-mode nxml-mode))
+
+(flycheck-define-checker yaml
+  "A YAML syntax checker using the psych YAML parer available in Ruby 1.9.2.
+
+See URL `http://www.ruby-lang.org/'."
+  :command ("ruby" "-ryaml" "-e"
+"begin;
+   file_name = ARGV[0]; \
+   YAML.load(ARGF); \
+ rescue Exception => e; \
+   STDERR.puts \"#{file_name}:#{e}\"; \
+ end" source)
+  :error-patterns
+  ((error line-start (file-name) ":" (zero-or-more not-newline) ":" (message)
+          "at line " line " column " column  (zero-or-more not-newline) line-end))
+  :modes yaml-mode)
 
 (flycheck-define-checker zsh
   "A Zsh syntax checker using the Zsh shell.

--- a/test/builtin-checkers-test.el
+++ b/test/builtin-checkers-test.el
@@ -51,7 +51,8 @@
           rust-mode
           sass-mode
           scala-mode2
-          scss-mode)
+          scss-mode
+          yaml-mode)
   (require it))
 
 (eval-when-compile
@@ -860,6 +861,12 @@ See URL `https://github.com/flycheck/flycheck/issues/45' and URL
    "checkers/xml-syntax-error.xml" 'nxml-mode 'xml-xmlstarlet
    '(4 nil "parser error : Opening and ending tag mismatch: spam line 3 and with" error)
    '(5 nil "parser error : Extra content at the end of the document" error)))
+
+(ert-deftest checker-yaml-syntax-error ()
+  :expected-result (flycheck-testsuite-fail-unless-checker 'yaml)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/yaml-syntax-error.yaml" 'yaml-mode nil
+   '(4 5 "mapping values are not allowed in this context" error)))
 
 (ert-deftest checker-zsh-syntax-error ()
   "Test a syntax error from a missing semicolon."

--- a/test/resources/checkers/yaml-syntax-error.yaml
+++ b/test/resources/checkers/yaml-syntax-error.yaml
@@ -1,0 +1,5 @@
+# A simple syntax error in YAML
+
+A: foo
+  a1: bar
+  a2: baz


### PR DESCRIPTION
This pull request add a syntax checker for YAML (http://yaml.org/).

The YAML syntax checker use the psych library available in Ruby 1.9.2 (http://www.ruby-lang.org/).
