### PR TITLE
Customizable idle displaying error message delay

### DIFF
--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -888,6 +888,10 @@ With prefix arg, list only errors at point.
 If you hover a highlighted error with the mouse, a tooltip with the
 top-most error message will be shown.
 
+@defopt flycheck-idle-display-delay
+Delay in seconds before displaying errors at point.
+@end defopt
+
 Flycheck also displays errors under point, via
 @code{flycheck-display-errors-function}:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -360,6 +360,13 @@ This variable has no effect, if `idle-change' is not contained in
   :package-version '(flycheck . "0.13")
   :safe #'numberp)
 
+(defcustom flycheck-idle-display-delay 0.9
+  "Delay in seconds before displaying errors at point."
+  :group 'flycheck
+  :type 'number
+  :package-version '(flycheck . "0.15")
+  :safe #'numberp)
+
 (defcustom flycheck-google-max-messages 5
   "How many messages to google at once.
 
@@ -3065,7 +3072,7 @@ Show the error message at point in minibuffer after a short delay."
   (flycheck-cancel-error-show-error-timer)
   (when (flycheck-overlays-at (point))
     (setq flycheck-error-show-error-timer
-          (run-at-time 0.9 nil 'flycheck-show-error-at-point))))
+          (run-at-time flycheck-idle-display-delay nil 'flycheck-show-error-at-point))))
 
 
 ;;;; Error display functions

--- a/test/customization-test.el
+++ b/test/customization-test.el
@@ -86,6 +86,9 @@ All declared checkers should be registered."
 (ert-deftest flycheck-idle-change-delay ()
   (should (equal flycheck-idle-change-delay 0.5)))
 
+(ert-deftest flycheck-idle-display-delay ()
+  (should (equal flycheck-idle-display-delay 0.9)))
+
 (ert-deftest flycheck-google-max-messages ()
   (should (equal flycheck-google-max-messages 5)))
 


### PR DESCRIPTION
`0.9` second is hard-coded in original code. I sometimes feel long till error message is displayed.
I introduced custom variable `flycheck-idle-display-delay` and make its delay configurable.

Please see this patch.
