### PR TITLE
Remove -property option from D checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3530,7 +3530,7 @@ declaration in the current buffer."
   "A D syntax checker using the DMD compiler.
 
 See URL `http://dlang.org/'."
-  :command ("dmd" "-debug" "-o-" "-property"
+  :command ("dmd" "-debug" "-o-"
                   "-wi" ; Compilation will continue even if there are warnings
                   (eval (s-concat "-I" (flycheck-d-base-directory)))
                   source)


### PR DESCRIPTION
In DMD v2.064 (next release), new property syntax will be the default setting and `-property` option will be deprecated.
Unfortunately, `-property` is too strict compared with the new property syntax.

For example:

``` d
int foo() { return 0; }

void main()
{
  auto a = foo; // ok in the next release
                // but -property rejects it
}
```

It will confuse the users. I think it is better to remove `-property` option from the command for `d-dmd`.
