### PR TITLE
Respect popwin-mode in flycheck-list-errors function.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2934,7 +2934,8 @@ list."
   ;; Show the error list in a window, and re-select the old window
   (let ((old-window (selected-window)))
     (pop-to-buffer (flycheck-error-list-buffer))
-    (select-window old-window))
+    (or (and (boundp 'popwin-mode) popwin-mode) ;Respect popwin window manager
+        (select-window old-window)))
   ;; Finally, refresh the error list to show the most recent errors
   (flycheck-error-list-refresh))
 


### PR DESCRIPTION
Some people use popwin-mode together with flycheck. When hardcoded `select-window' function switch window focus popwin close flycheck window due to its behaviour rules. So just don't select-window in this case.

See more on https://github.com/m2ym/popwin-el
