### PR TITLE
Add syntax checker for Handlebars using Handlebars compiler

### DIFF
--- a/Cask
+++ b/Cask
@@ -16,6 +16,7 @@
  ;; Various modes for use in the unit tests
  (depends-on "coffee-mode")
  (depends-on "haml-mode")
+ (depends-on "handlebars-mode")
  (depends-on "haskell-mode")
  (depends-on "web-mode")
  (depends-on "js2-mode")

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Features
   - Erlang
   - Go
   - Haml
+  - Handlebars
   - Haskell
   - HTML
   - Javascript

--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -192,6 +192,8 @@ Go (using @command{gofmt}, @command{go build} and @command{go test})
 @item
 Haml
 @item
+Handlebars
+@item
 Haskell (using @command{ghc}, @command{hdevtools} and @command{hlint})
 @item
 HTML (using @command{tidy})
@@ -3241,6 +3243,7 @@ order of their appearance in the default value of
 @iflyc go-build
 @iflyc go-test
 @iflyc haml
+@iflyc handlebars
 @iflyc haskell-hdevtools
 @iflyc haskell-ghc
 @iflyc haskell-hlint

--- a/flycheck.el
+++ b/flycheck.el
@@ -127,6 +127,7 @@ buffer-local wherever it is set."
     go-build
     go-test
     haml
+    handlebars
     haskell-hdevtools
     haskell-ghc
     haskell-hlint
@@ -3701,6 +3702,18 @@ See URL `http://haml.info'."
   :error-patterns
   ((error line-start "Syntax error on line " line ": " (message) line-end))
   :modes haml-mode)
+
+(flycheck-define-checker handlebars
+  "A Handlebars syntax checker using the Handlebars compiler.
+
+See URL `https://github.com/wycats/handlebars.js'."
+  :command ("handlebars" source)
+  :error-patterns
+  ((error line-start
+          "Error: Parse error on line " line ":" (optional "\r") "\n"
+          (zero-or-more not-newline) "\n" (zero-or-more not-newline) "\n"
+          (message) line-end))
+  :modes (handlebars-mode handlebars-sgml-mode))
 
 (flycheck-define-checker haskell-hdevtools
   "A Haskell syntax and type checker using hdevtools.

--- a/puppet/modules/flycheck/manifests/checkers.pp
+++ b/puppet/modules/flycheck/manifests/checkers.pp
@@ -47,6 +47,7 @@ class flycheck::checkers {
   $node_packages = ['coffee-script', # coffee
                     'coffeelint',    # coffee-coffeelint
                     'csslint',       # css-csslint
+                    'handlebars',    # handlebars
                     'jshint',        # javascript-jshint
                     'jsonlint',      # json-jsonlint
                     'less',          # less

--- a/test/builtin-checkers-test.el
+++ b/test/builtin-checkers-test.el
@@ -39,6 +39,7 @@
           elixir-mode
           go-mode
           haml-mode
+          handlebars-mode
           haskell-mode
           web-mode
           js2-mode
@@ -468,6 +469,13 @@ found)."
    "checkers/haml-error.haml" 'haml-mode
    '(5 nil error "Inconsistent indentation: 3 spaces used for indentation, but the rest of the document was indented using 2 spaces."
        :checker haml :filename nil)))
+
+(ert-deftest builtin-checker/handlebars-error ()
+  :expected-result (flycheck-testsuite-fail-unless-checker 'handlebars)
+  (flycheck-testsuite-should-syntax-check
+   "checkers/handlebars-error.hbs" 'handlebars-mode
+   '(2 nil error "Expecting 'ID', 'DATA', got 'INVALID'"
+       :checker handlebars :filename nil)))
 
 ;; HDevtools tests fail on Vagrant, because hdevtools can't create unix sockets
 ;; on shared folders, and on Travis CI, because hdevtools doesn't install with

--- a/test/resources/checkers/handlebars-error.hbs
+++ b/test/resources/checkers/handlebars-error.hbs
@@ -1,0 +1,3 @@
+<div class="entry">
+  {{! This comment will not be in the output }
+</div>


### PR DESCRIPTION
For information about `Handlebars`, See URL: https://github.com/wycats/handlebars.js.
