### PR TITLE
Add Verilog checker using Verilator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,7 @@ Features
   - Slim
   - TeX/LaTeX
   - Texinfo
+  - Verilog
   - XML
   - YAML
 

--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -248,6 +248,8 @@ TeX/LaTeX (using @command{chktex} or @command{lacheck})
 @item
 Texinfo (using @command{makeinfo})
 @item
+Verilog (using @command{verilator})
+@item
 XML (using @command{xmlstarlet} or @command{xmllint})
 @item
 YAML (using @command{js-yaml} or @command{ruby})
@@ -3271,7 +3273,8 @@ checker.
 
 @item
 @gh{dholm, David Holm} added C/C++ syntax and style checkers using
-@command{clang} and @command{cppcheck} respectively.
+@command{clang} and @command{cppcheck} respectively.  He also added Verilog
+syntax checking using @command{verilator}.
 
 @item
 @gh{gfrey, Gereon Frey} fixed the @command{go-build} syntax checker and
@@ -3432,6 +3435,7 @@ order of their appearance in the default value of
 @iflyc tex-chktex
 @iflyc tex-lacheck
 @iflyc texinfo
+@iflyc verilog-verilator
 @iflyc xml-xmlstarlet
 @iflyc xml-xmllint
 @iflyc yaml-jsyaml

--- a/flycheck.el
+++ b/flycheck.el
@@ -182,6 +182,7 @@ buffer-local wherever it is set."
     tex-chktex
     tex-lacheck
     texinfo
+    verilog-verilator
     xml-xmlstarlet
     xml-xmllint
     yaml-jsyaml
@@ -4601,6 +4602,18 @@ See URL `http://www.gnu.org/software/texinfo/'."
           line (optional ":" column) ": "
           (message) line-end))
   :modes texinfo-mode)
+
+(flycheck-define-checker verilog-verilator
+  "A Verilog syntax checker using the Verilator Verilog HDL simulator.
+
+See URL `http://www.veripool.org/wiki/verilator'."
+  :command ("verilator" "--lint-only" "-Wall" source)
+  :error-patterns
+  ((warning line-start "%Warning-" (zero-or-more not-newline) ": "
+            (file-name) ":" line ": " (message) line-end)
+   (error line-start "%Error: " (file-name) ":"
+          line ": " (message) line-end))
+  :modes (verilog-mode))
 
 (flycheck-define-checker xml-xmlstarlet
   "A XML syntax checker and validator using the xmlstarlet utility.

--- a/puppet/modules/flycheck/manifests/checkers.pp
+++ b/puppet/modules/flycheck/manifests/checkers.pp
@@ -112,6 +112,7 @@ class flycheck::checkers {
                 'puppet',          # puppet-parser
                 'scala',           # scala
                 'dash',            # sh-dash
+                'verilator',       # verilog-verilator
                 'chktex',          # tex-chktex
                 'lacheck',         # tex-lacheck
                 'xmlstarlet',      # xml-xmlstarlet

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4108,6 +4108,22 @@ Why not:
    '(9 nil warning "printindex before document beginning: @printindex cp"
        :checker texinfo)))
 
+(ert-deftest flycheck-define-checker/verilog-verilator-error ()
+  :tags '(builtin-checker external-tool language-verilog)
+  (skip-unless (flycheck-check-executable 'verilog-verilator))
+  (flycheck-test-should-syntax-check
+   "checkers/verilog_verilator_error.v" 'verilog-mode
+   '(4 nil error "syntax error, unexpected ')'"
+       :checker verilog-verilator)))
+
+(ert-deftest flycheck-define-checker/verilog-verilator-warning ()
+  :tags '(builtin-checker external-tool language-verilog)
+  (skip-unless (flycheck-check-executable 'verilog-verilator))
+  (flycheck-test-should-syntax-check
+   "checkers/verilog_verilator_warning.v" 'verilog-mode
+   '(2 nil warning "Signal is not driven, nor used: val"
+       :checker verilog-verilator)))
+
 (ert-deftest flycheck-define-checker/xml-xmlstarlet ()
   :tags '(builtin-checker external-tool language-xml)
   (skip-unless (flycheck-check-executable 'xml-xmlstarlet))

--- a/test/resources/checkers/verilog_verilator_error.v
+++ b/test/resources/checkers/verilog_verilator_error.v
@@ -1,0 +1,7 @@
+module verilog_verilator_error;
+   initial begin
+      forever begin
+         i = $fopen("test.log");
+      end
+   end
+endmodule

--- a/test/resources/checkers/verilog_verilator_warning.v
+++ b/test/resources/checkers/verilog_verilator_warning.v
@@ -1,0 +1,3 @@
+module verilog_verilator_warning;
+   reg val;
+endmodule


### PR DESCRIPTION
Support for syntax checking of Verilog code using Verilator, a free Verilog HDL
simulator.  Two test cases are included, one for error messages and another for
warnings.
