### PR TITLE
Remove use of deprecated RuboCop flag --silent

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3450,7 +3450,7 @@ See URL `http://docutils.sourceforge.net/'."
   "A Ruby syntax and style checker using the RuboCop tool.
 
 See URL `http://batsov.com/rubocop/'."
-  :command ("rubocop" "--format" "emacs" "--silent"
+  :command ("rubocop" "--format" "emacs"
             (config-file "--config" flycheck-rubocoprc)
             source)
   :error-patterns


### PR DESCRIPTION
`--silent` has been out of commission since RuboCop 0.12.
