### PR TITLE
Restore compatibility with ESLint 0.3.0

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4205,6 +4205,7 @@ for more information about the custom directory."
 
 See URL `https://github.com/nzakas/eslint'."
   :command ("eslint"
+            "--format=compact"    
             (config-file "--config" flycheck-eslintrc)
             (option "--rulesdir" flycheck-eslint-rulesdir)
             source)


### PR DESCRIPTION
Since 0.3.0 the "stylish" formatter is the default. "compact" is still easier parseable, so force it.
