### PR TITLE
change rustc invocation to --no-trans

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4655,10 +4655,13 @@ See URL `http://jruby.org/'."
   "A Rust syntax checker using Rust compiler.
 
 See URL `http://rust-lang.org'."
-  :command ("rustc" "--parse-only" source)
+  :command ("rustc" "--no-trans" source-inplace)
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": "
           (one-or-more digit) ":" (one-or-more digit) " error: "
+          (message) line-end)
+   (warning line-start (file-name) ":" line ":" column ": "
+          (one-or-more digit) ":" (one-or-more digit) " warning: "
           (message) line-end))
   :modes rust-mode)
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4151,12 +4151,19 @@ Why not:
      '(16 nil warning "Useless use of == in void context."
           :checker ruby-jruby))))
 
-(ert-deftest flycheck-define-checker/rust ()
+(ert-deftest flycheck-define-checker/rust-syntax-error ()
   :tags '(builtin-checker external-tool language-rust)
   (skip-unless (flycheck-check-executable 'rust))
   (flycheck-test-should-syntax-check
    "checkers/rust-syntax-error.rs" 'rust-mode
-   '(3 10 error "expected `{` but found `bla`" :checker rust)))
+   '(4 5 error "unresolved name `bla`." :checker rust)))
+
+(ert-deftest flycheck-define-checker/rust-warning ()
+  :tags '(builtin-checker external-tool language-rust)
+  (skip-unless (flycheck-check-executable 'rust))
+  (flycheck-test-should-syntax-check
+   "checkers/rust-warning.rs" 'rust-mode
+   '(4 9 warning "unused variable: `x`, #[warn(unused_variable)] on by default" :checker rust)))
 
 (ert-deftest flycheck-define-checker/sass ()
   :tags '(builtin-checker external-tool language-sass)

--- a/test/resources/checkers/rust-syntax-error.rs
+++ b/test/resources/checkers/rust-syntax-error.rs
@@ -1,3 +1,5 @@
 // A simple syntax error
 
-fn main() bla
+fn main() {
+    bla;
+}

--- a/test/resources/checkers/rust-warning.rs
+++ b/test/resources/checkers/rust-warning.rs
@@ -1,0 +1,5 @@
+// a warning for an unused variable
+
+fn main() {
+    let x = 5;
+}


### PR DESCRIPTION
per mozilla/rust#3808

Currently `rustc --parse-only` only catches syntax errors. `--no-trans` ensures the code will compile. Unfortunately, this is slow. But, at the moment parse-only doesn't do much. Syntastic for vim is using `--no-trans` as of a39b397e6ae3b32d2a0497d0f4ddfec0479ad2bb, for example.
