### PR TITLE
Correct section order in flycheck.texi

### DIFF
--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -1664,7 +1664,7 @@ for more information about Flycheck errors.
 Flycheck provides some utility functions to implement error parsers.
 @xref{Error parser API}.
 
-@node Option filters, Examples, Error parsers, Extending
+@node Option filters, Extending checkers, Error parsers, Extending
 @comment  node-name,  next,  previous,  up
 @section Option filters
 
@@ -1697,7 +1697,7 @@ to the @code{:next-checkers} property.
 @var{checker}, unless @var{append} is non-nil.
 @end defun
 
-@node Examples,  , Option filters, Extending
+@node Examples,  , Extending checkers, Extending
 @comment  node-name,  next,  previous,  up
 @section Examples of syntax checkers
 


### PR DESCRIPTION
To avoid these verbose warning messages.

$ makeinfo flycheck.texi
/home/hyungchan/EmacsDot2/el-get/flycheck/doc//flycheck.texi:1683: Next field of node `Extending checkers' not pointed to (perhaps incorrect sectioning?).
/home/hyungchan/EmacsDot2/el-get/flycheck/doc//flycheck.texi:1700: This node (Examples) has the bad Prev.
/home/hyungchan/EmacsDot2/el-get/flycheck/doc//flycheck.texi:1683: Prev field of node`Extending checkers' not pointed to.
/home/hyungchan/EmacsDot2/el-get/flycheck/doc//flycheck.texi:1667: This node (Option filters) has the bad Next.
makeinfo: Removing output file `/home/hyungchan/EmacsDot2/el-get/flycheck/doc/flycheck.info' due to errors; use --force to preserve.
