### PR TITLE
Add Flycheck checker for Objective Caml (OCaml).

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -165,6 +165,7 @@ buffer-local wherever it is set."
     less
     lua
     make
+    ocaml-ocamlc
     perl
     perl-perlcritic
     php
@@ -4457,6 +4458,43 @@ See URL `http://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html'."
    ;; http://www.openbsd.org/cgi-bin/man.cgi?query=make
    (error line-start (message) " (" (file-name) ":" line ")" line-end))
   :modes (makefile-mode makefile-gmake-mode makefile-bsdmake-mode))
+
+(eval-and-compile
+  (defun flycheck-parse-ocamlc (output _checker _buffer)
+    "Parse OCaml compiler errors errors from OUTPUT.
+
+Parse error and warning output from the ocamlc compiler.
+
+_CHECKER and _BUFFER are ignored."
+    (let* ((lines (s-split "File " output t))
+           (file-message-pairs
+            (mapcar #'(lambda (line) (s-split "\"" line t)) lines)))
+      (mapcar
+       #'(lambda (message)
+         (let* ((message-no-line (s-chop-prefix ", line " (car (cdr message))))
+                  (line (car (s-match "^[0-9]+" message-no-line)))
+                  (message-char (s-chop-prefix line message-no-line))
+                  (message-no-char (s-chop-prefix ", characters " message-char))
+                  (column (car (s-match "^[0-9]+" message-no-char)))
+                  (begin (car (s-match "^[0-9]+-[0-9]+:\n" message-no-char)))
+                  (message-warning (s-chop-prefix begin message-no-char)))
+             (flycheck-error-new
+              :filename (car message)
+              :line (string-to-number line)
+              :column (string-to-number column)
+              :message message-warning
+              :level (if (s-match "^Error" message-warning)
+                         'error
+                       'warning))))
+       file-message-pairs))))
+
+(flycheck-define-checker ocaml-ocamlc
+  "An OCaml syntax checker using the ocamlc compiler.
+
+See URL `http://caml.inria.fr/ocaml/index.en.html'."
+  :command ("ocamlc" "-w" "+A" "-c" source)
+  :error-parser flycheck-parse-ocamlc
+  :modes (tuareg-mode))
 
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3761,6 +3761,16 @@ Why not:
      "checkers/make.mk" 'makefile-bsdmake-mode
      '(2 nil error "Need an operator" :checker make))))
 
+(ert-deftest flycheck-define-checker/ocaml-ocamlc ()
+  :tags '(builtin-checker external-tool language-ocamlc)
+  (skip-unless (-all? #'flycheck-check-executable '(ocamlc)))
+  (flycheck-test-should-syntax-check
+   "checkers/ocamlOCamlc.ml" '(tuareg-mode)
+   '(7 4 warning "Warning 8: this pattern-matching is not exhaustive.\nHere is an example of a value that is not matched:\n2\n"
+       :checker ocaml-ocamlc)
+   '(11 0 error "Error: Unbound value undefined\n"
+       :checker ocaml-ocamlc)))
+
 (ert-deftest flycheck-define-checker/perl ()
   :tags '(builtin-checker external-tool language-perl)
   (skip-unless (-all? #'flycheck-check-executable '(perl perl-perlcritic)))

--- a/test/resources/checkers/ocamlcOCaml.ml
+++ b/test/resources/checkers/ocamlcOCaml.ml
@@ -1,0 +1,11 @@
+let test_member x tup =
+  match tup with
+  | (y, _) | (_, y) when y = x -> true
+  | _ -> false;;
+
+let is_even x =
+    match x mod 2 with
+    | 0 -> true
+    | 1 | -1 -> false;;
+
+undefined


### PR DESCRIPTION
Add Flycheck syntax checker for OCaml (see issue #254), use error / warning messages emitted from the ocamlc compiler.
