### PR TITLE
Removing dependencies to s and dash

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6,7 +6,7 @@
 ;; URL: https://flycheck.readthedocs.org
 ;; Keywords: convenience languages tools
 ;; Version: 0.19-cvs
-;; Package-Requires: ((f "0.11.0") (pkg-info "0.4") (cl-lib "0.3") (emacs "24.1"))
+;; Package-Requires: ((f "0.11.0") (dash "2.4.0") (s "1.9.0") (pkg-info "0.4") (cl-lib "0.3") (emacs "24.1"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Hello,

I have an issue when installing flycheck from MELPA; when I package-install <RET> flycheck on a clean GNU Emacs 24.3.1 whose only configuration is

(require 'package)
(add-to-list 'package-archives '("melpa" . "http://melpa.milkbox.net/packages/") t)

The packages are downloaded and compiled in this order:
- epl
- pkg-info
- f (which has an unresolved dependency to s)
- dash
- s
- flycheck

If I manually install either f or s before flycheck, everything is fine.

I guess that the problem comes from the order in which flycheck declares its dependencies; the dependency line is

;; Package-Requires: ((s "1.9.0") (dash "2.4.0") (f "0.11.0") (pkg-info "0.4") (cl-lib "0.3") (emacs "24.1"))

Which, I assume, is treated from right to left (but I have found anything on the order of the dependencies in Emacs manual so it may be a bug in Emacs itself). Removing s and dash from the list or changing the order to (f dash s pkg-info cl-lib emacs) solve my problem. This pull request implements the removal.
