### PR TITLE
Support checking for Rust test functions.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4869,7 +4869,7 @@ Relative paths are relative to the file being checked."
 This syntax checker needs Rust 0.10 or newer.
 
 See URL `http://rust-lang.org'."
-  :command ("rustc" "--crate-type=lib" "--no-trans"
+  :command ("rustc" "--crate-type=lib" "--no-trans" "--test"
             (option-list "-L" flycheck-rust-library-path s-prepend)
             source-inplace)
   :error-patterns

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4186,6 +4186,13 @@ Why not:
    "checkers/rust-syntax-error.rs" 'rust-mode
    '(4 5 error "unresolved name `bla`." :checker rust)))
 
+(ert-deftest flycheck-define-checker/rust-test-syntax-error ()
+  :tags '(builtin-checker external-tool language-rust)
+  (skip-unless (flycheck-check-executable 'rust))
+  (flycheck-test-should-syntax-check
+   "checkers/rust-test-syntax-error.rs" 'rust-mode
+   '(5 5 error "unresolved name `bla`." :checker rust)))
+
 (ert-deftest flycheck-define-checker/rust-warning ()
   :tags '(builtin-checker external-tool language-rust)
   (skip-unless (flycheck-check-executable 'rust))

--- a/test/resources/checkers/rust-test-syntax-error.rs
+++ b/test/resources/checkers/rust-test-syntax-error.rs
@@ -1,0 +1,6 @@
+// A syntax error in a test
+
+#[test]
+fn some_test() {
+    bla;
+}


### PR DESCRIPTION
Without the `--test` flag, functions marked as `#[test]` are not checked for errors. Previously a file like this:

``` rust
pub fn totally_fine() {
  println!("hey!");
}

#[test]
fn test_oops() {
  eirjgirogoregjrejgierjgorjgoerjgo // <-- error
}
```

would appear to be correct to Flycheck.
