### PR TITLE
Make perl checker smarter about include directories, remove impossible perl critic rule.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4486,11 +4486,24 @@ See URL `http://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html'."
    (error line-start (message) " (" (file-name) ":" line ")" line-end))
   :modes (makefile-mode makefile-gmake-mode makefile-bsdmake-mode))
 
+(defconst flycheck-perl-module-re
+  "^package\\s-+\\([^ ]+\\)\\s-*;"
+  "Regular expression to match a perl module declaration.")
+
+(defun flycheck-perl-base-directory ()
+  "Get the relative base directory path for this module."
+    (flycheck-module-root-directory
+     (replace-regexp-in-string "::" "."
+                               (flycheck-find-in-buffer flycheck-perl-module-re))))
+
+
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.
 
 See URL `http://www.perl.org'."
-  :command ("perl" "-w" "-c" source)
+  :command ("perl" "-w" "-c"
+            (eval (s-concat "-I" (flycheck-perl-base-directory)))
+            source)
   :error-patterns
   ((error line-start (minimal-match (message))
           " at " (file-name) " line " line
@@ -4512,6 +4525,7 @@ the `--severity' option to Perl Critic."
 
 See URL `http://search.cpan.org/~thaljef/Perl-Critic/'."
   :command ("perlcritic" "--no-color" "--verbose" "%f:%l:%c:%s:%m (%e)\n"
+             "--exclude=RequireFilenameMatchesPackage"
             (option "--severity" flycheck-perlcritic-verbosity
                     flycheck-option-int)
             source)


### PR DESCRIPTION
Add support to find the top level module directory when editing perl modules
that are part of a package with multiple layers. For instance you have

package Test;
package Test::Foo;
package Test::Foo::Bar;

And you're editing Bar.pm this code will find the directory where Test.pm lives and
add it to the perl include path with -I.  It works much like the code for D.

This is required because if you have multiple packages and they include each other
you will get compilation errors saying perl couldn't find the module, which is sad.

As a second change,
Since flycheck changes the filename when it creates a temporary file, it seems that
we will never be able to pass the test that the perl module's filename matches
the declared package name.  So disable that rule in perl critic by default on the
command line.
