### PR TITLE
ruby-lint: removed the analyze sub command.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5085,7 +5085,7 @@ See URL `http://batsov.com/rubocop/'."
   "A Ruby syntax and code analysis checker using ruby-lint.
 
 See URL `https://github.com/YorickPeterse/ruby-lint'."
-  :command ("ruby-lint" "analyze" "--presenter=syntastic" source)
+  :command ("ruby-lint" "--presenter=syntastic" source)
   :error-patterns
   ((info line-start
          (file-name) ":I:" line ":" column ": " (message) line-end)


### PR DESCRIPTION
Starting with version 2.0 of ruby-lint the "analyze" sub command no longer
exists.
