### PR TITLE
rust: Make --test flag to rustc configurable

### DIFF
--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -417,6 +417,9 @@ Rust
 
    .. rubric:: Options
 
+   .. option:: flycheck-rust-check-tests
+      :auto:
+
    .. option:: flycheck-rust-library-path
       :auto:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -5150,13 +5150,27 @@ Relative paths are relative to the file being checked."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.18"))
 
+(flycheck-def-option-var flycheck-rust-check-tests t rust
+  "Whether to check test code in Rust.
+
+When non-nil, `rustc' is passed the `--test' flag, which will
+check any code marked with the `#[cfg(test)]' attribute and any
+functions marked with `#[test]'. Otherwise, `rustc' is not passed
+`--test' and test code will not be checked.  Skipping `--test' is
+necessary when using `#![no_std]', because compiling the test
+runner requires `std'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '("flycheck" . "0.19"))
+
 (flycheck-define-checker rust
   "A Rust syntax checker using Rust compiler.
 
 This syntax checker needs Rust 0.10 or newer.
 
 See URL `http://www.rust-lang.org'."
-  :command ("rustc" "--crate-type=lib" "--no-trans" "--test"
+  :command ("rustc" "--crate-type=lib" "--no-trans"
+            (option-flag "--test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path s-prepend)
             source-inplace)
   :error-patterns

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4271,6 +4271,13 @@ Why not:
    "checkers/rust-test-syntax-error.rs" 'rust-mode
    '(5 5 error "unresolved name `bla`." :checker rust)))
 
+(ert-deftest flycheck-define-checker/rust-test-check-tests-disabled ()
+  :tags '(builtin-checker external-tool language-rust)
+  (skip-unless (flycheck-check-executable 'rust))
+  (let ((flycheck-rust-check-tests nil))
+    (flycheck-test-should-syntax-check
+     "checkers/rust-test-syntax-error.rs" 'rust-mode)))
+
 (ert-deftest flycheck-define-checker/rust-warning ()
   :tags '(builtin-checker external-tool language-rust)
   (skip-unless (flycheck-check-executable 'rust))


### PR DESCRIPTION
The `--test` flag is usually desirable for checking Rust code, but in
certain cases (like when `#![no_std]` is used in the current file) it
causes unexpected and difficult-to-trace errors in the checker.
