### PR TITLE
Add an option to enable inconclusive cppcheck checks.

### DIFF
--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -67,6 +67,9 @@ C/C++
    .. option:: flycheck-cppcheck-checks
       :auto:
 
+   .. option:: flycheck-cppcheck-enable-inconclusive
+      :auto:
+
 CFEngine
 ========
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -3936,6 +3936,17 @@ including a list of supported checks."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.14"))
 
+(flycheck-def-option-var flycheck-cppcheck-enable-inconclusive nil c/c++-cppcheck
+  "Whether to enable Cppcheck inconclusive checks.
+
+When non-nil, enable Cppcheck inconclusive checks.  This allows Cppcheck to
+report warnings it's not certain of, but it may result in false positives.
+
+This will have no effect when using Cppcheck 1.53 and older."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "0.19"))
+
 (flycheck-define-checker c/c++-cppcheck
   "A C/C++ checker using cppcheck.
 
@@ -3943,6 +3954,7 @@ See URL `http://cppcheck.sourceforge.net/'."
   :command ("cppcheck" "--quiet" "--xml-version=2" "--inline-suppr"
             (option "--enable=" flycheck-cppcheck-checks
                     flycheck-option-comma-separated-list)
+            (option-flag "--inconclusive" flycheck-cppcheck-enable-inconclusive)
             source)
   :error-parser flycheck-parse-cppcheck
   :modes (c-mode c++-mode))

--- a/test/resources/checkers/c_c++-cppcheck-inconclusive.cpp
+++ b/test/resources/checkers/c_c++-cppcheck-inconclusive.cpp
@@ -1,0 +1,1 @@
+bool foo(bool a, bool b) { return a & b; }


### PR DESCRIPTION
This allows Cppcheck to report warnings it's not certain of, but it may result in false positives.
