### PR TITLE
Add a GCC C and C++ checker.

### DIFF
--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -59,6 +59,29 @@ C/C++
    .. option:: flycheck-clang-warnings
       :auto:
 
+.. flyc-checker:: c/c++-gcc
+   :auto:
+
+   .. rubric:: Options
+
+   .. option:: flycheck-gcc-definitions
+      :auto:
+
+   .. option:: flycheck-gcc-include-path
+      :auto:
+
+   .. option:: flycheck-gcc-includes
+      :auto:
+
+   .. option:: flycheck-gcc-language-standard
+      :auto:
+
+   .. option:: flycheck-gcc-no-rtti
+      :auto:
+
+   .. option:: flycheck-gcc-warnings
+      :auto:
+
 .. flyc-checker:: c/c++-cppcheck
    :auto:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -136,6 +136,7 @@ buffer-local wherever it is set."
 (defcustom flycheck-checkers
   '(asciidoc
     c/c++-clang
+    c/c++-gcc
     c/c++-cppcheck
     cfengine
     chef-foodcritic
@@ -3836,6 +3837,50 @@ information about warnings."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.14"))
 
+(defun flycheck-clang-gcc-error-filter (errors)
+  "Filter the ERRORS reported by Clang and GCC."
+  (let ((errors (flycheck-sanitize-errors errors)))
+    ;; Fold messages from faulty includes into the errors on the corresponding
+    ;; include lines.  The user still needs to visit the affected include to
+    ;; list and navigate these errors, but they can at least get an idea of
+    ;; what is wrong.
+    (let (including-filename          ; The name of the file including a
+                                        ; faulty include
+          include-error               ; The error on the include line
+          errors-in-include)          ; All errors in the include, as strings
+      (--each errors
+        (-when-let* ((message (flycheck-error-message it))
+                     (filename (flycheck-error-filename it)))
+          (cond
+           ((and (string= message "In file included from")
+                 ;; Don't handle faulty includes recursively, we are only
+                 ;; interested in “top-level” errors
+                 (not including-filename))
+            ;; We are looking at an error denoting a faulty include, so let's
+            ;; remember the error and the name of the include, and initialize
+            ;; our folded error message
+            (setq include-error it
+                  including-filename filename
+                  errors-in-include (list "Errors in included file:")))
+           ((and include-error (not (string= filename including-filename)))
+            ;; We are looking at an error *inside* the last faulty include, so
+            ;; let's record it, as human-readable string
+            (push (flycheck-error-format it) errors-in-include))
+           (include-error
+            ;; We are looking at an unrelated error, so fold all include
+            ;; errors, if there are any
+            (when (and include-error errors-in-include)
+              (setf (flycheck-error-message include-error)
+                    (s-join "\n" (nreverse errors-in-include))))
+            (setq include-error nil
+                  including-filename nil
+                  errors-in-include nil)))))
+      ;; If there are still pending errors to be folded, do so now
+      (when (and include-error errors-in-include)
+        (setf (flycheck-error-message include-error)
+              (s-join "\n" (nreverse errors-in-include))))))
+  errors)
+
 (flycheck-define-checker c/c++-clang
   "A C/C++ syntax checker using Clang.
 
@@ -3872,49 +3917,113 @@ See URL `http://clang.llvm.org/'."
             ": warning: " (message) line-end)
    (error line-start (file-name) ":" line ":" column
           ": " (or "fatal error" "error") ": " (message) line-end))
-  :error-filter
-  (lambda (errors)
-    (let ((errors (flycheck-sanitize-errors errors)))
-      ;; Fold messages from faulty includes into the errors on the corresponding
-      ;; include lines.  The user still needs to visit the affected include to
-      ;; list and navigate these errors, but they can at least get an idea of
-      ;; what is wrong.
-      (let (including-filename          ; The name of the file including a
-                                        ; faulty include
-            include-error               ; The error on the include line
-            errors-in-include)          ; All errors in the include, as strings
-        (--each errors
-          (-when-let* ((message (flycheck-error-message it))
-                       (filename (flycheck-error-filename it)))
-            (cond
-             ((and (string= message "In file included from")
-                   ;; Don't handle faulty includes recursively, we are only
-                   ;; interested in “top-level” errors
-                   (not including-filename))
-              ;; We are looking at an error denoting a faulty include, so let's
-              ;; remember the error and the name of the include, and initialize
-              ;; our folded error message
-              (setq include-error it
-                    including-filename filename
-                    errors-in-include (list "Errors in included file:")))
-             ((and include-error (not (string= filename including-filename)))
-              ;; We are looking at an error *inside* the last faulty include, so
-              ;; let's record it, as human-readable string
-              (push (flycheck-error-format it) errors-in-include))
-             (include-error
-              ;; We are looking at an unrelated error, so fold all include
-              ;; errors, if there are any
-              (when (and include-error errors-in-include)
-                (setf (flycheck-error-message include-error)
-                      (s-join "\n" (nreverse errors-in-include))))
-              (setq include-error nil
-                    including-filename nil
-                    errors-in-include nil)))))
-        ;; If there are still pending errors to be folded, do so now
-        (when (and include-error errors-in-include)
-          (setf (flycheck-error-message include-error)
-                (s-join "\n" (nreverse errors-in-include))))))
-    errors)
+  :error-filter (lambda (errors)
+                  (flycheck-clang-gcc-error-filter errors))
+  :modes (c-mode c++-mode)
+  :next-checkers ((warnings-only . c/c++-cppcheck)))
+
+(flycheck-def-option-var flycheck-gcc-definitions nil c/c++-gcc
+  "Additional preprocessor definitions for GCC.
+
+The value of this variable is a list of strings, where each
+string is an additional definition to pass to GCC, via the `-D'
+option."
+  :type '(repeat (string :tag "Definition"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.20"))
+
+(flycheck-def-option-var flycheck-gcc-include-path nil c/c++-gcc
+  "A list of include directories for GCC.
+
+The value of this variable is a list of strings, where each
+string is a directory to add to the include path of gcc.
+Relative paths are relative to the file being checked."
+  :type '(repeat (directory :tag "Include directory"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.20"))
+
+(flycheck-def-option-var flycheck-gcc-includes nil c/c++-gcc
+  "A list of additional include files for GCC.
+
+The value of this variable is a list of strings, where each
+string is a file to include before syntax checking.  Relative
+paths are relative to the file being checked."
+  :type '(repeat (file :tag "Include file"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.20"))
+
+(flycheck-def-option-var flycheck-gcc-language-standard nil c/c++-gcc
+  "The language standard to use in GCC.
+
+The value of this variable is either a string denoting a language
+standard, or nil, to use the default standard.  When non-nil,
+pass the language standard via the `-std' option."
+  :type '(choice (const :tag "Default standard" nil)
+                 (string :tag "Language standard"))
+  :safe #'stringp
+  :package-version '(flycheck . "0.20"))
+
+(flycheck-def-option-var flycheck-gcc-no-rtti nil c/c++-gcc
+  "Whether to disable RTTI in gcc.
+
+When non-nil, disable RTTI for syntax checks, via `-fno-rtti'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "0.20"))
+
+(flycheck-def-option-var flycheck-gcc-warnings '("all" "extra") c/c++-gcc
+  "A list of additional warnings to enable in gcc.
+
+The value of this variable is a list of strings, where each string
+is the name of a warning category to enable.  By default, all
+recommended warnings and some extra warnings are enabled (as by
+`-Wall' and `-Wextra' respectively).
+
+Refer to the gcc manual at URL
+`https://gcc.gnu.org/onlinedocs/gcc/' for more information about
+warnings."
+  :type '(choice (const :tag "No additional warnings" nil)
+                 (repeat :tag "Additional warnings"
+                         (string :tag "Warning name")))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.20"))
+
+(flycheck-define-checker c/c++-gcc
+  "A C/C++ syntax checker using GCC.
+
+Requires GCC 4.8 or newer.  See URL `https://gcc.gnu.org/'."
+  :command ("gcc"
+            "-fsyntax-only"
+            "-fshow-column"
+            "-fno-diagnostics-show-caret" ; Do not visually indicate the source location
+            "-fno-diagnostics-show-option" ; Do not show the corresponding
+                                        ; warning group
+            (option "-std=" flycheck-gcc-language-standard)
+            (option-flag "-fno-rtti" flycheck-gcc-no-rtti)
+            (option-list "-include" flycheck-gcc-includes)
+            (option-list "-W" flycheck-gcc-warnings s-prepend)
+            (option-list "-D" flycheck-gcc-definitions s-prepend)
+            (option-list "-I" flycheck-gcc-include-path)
+            "-x" (eval
+                  (pcase major-mode
+                    (`c++-mode "c++")
+                    (`c-mode "c")))
+            ;; We must stay in the same directory, to properly resolve #include
+            ;; with quotes
+            source-inplace)
+  :error-patterns
+  ((error line-start
+          (message "In file included from") " " (file-name) ":" line ":"
+          column ":"
+          line-end)
+   (info line-start (file-name) ":" line ":" column
+         ": note: " (message) line-end)
+   (warning line-start (file-name) ":" line ":" column
+            ": warning: " (message) line-end)
+   (error line-start (file-name) ":" line ":" column
+          ": " (or "fatal error" "error") ": " (message) line-end))
+  :error-filter (lambda (errors)
+                  (flycheck-clang-gcc-error-filter errors))
   :modes (c-mode c++-mode)
   :next-checkers ((warnings-only . c/c++-cppcheck)))
 

--- a/playbooks/tasks/packages.yml
+++ b/playbooks/tasks/packages.yml
@@ -9,6 +9,7 @@
     - ppa:ondrej/php5           # Recent PHP versions
     - ppa:plt/racket            # Racket
     - ppa:hvr/ghc               # Latest GHC and Cabal
+    - ppa:ubuntu-toolchain-r/test # GCC 4.8
     # Latest Erlang version
     - deb http://packages.erlang-solutions.com/debian precise contrib
     # CFEngine
@@ -51,6 +52,8 @@
     - chktex                      # tex-chktex
     - cppcheck                    # c/c++-cppcheck
     - dash                        # sh-posix-dash
+    - gcc-4.8                     # c/c++-gcc
+    - g++-4.8                     # c/c++-gcc
     - ghc-{{ghc_version}}         # haskell-ghc
     - hlint                       # haskell-hlint
     - lacheck                     # tex-lacheck
@@ -73,3 +76,8 @@
 - name: Install DMD
   apt: deb=/usr/src/dmd_{{dmd_version}}.0-0_amd64.deb state=installed
   ignore_errors: True
+- name: Make GCC 4.8 the default GCC
+  command : "{{item}}"
+  with_items:
+    - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+    - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3130,7 +3130,7 @@ of the file will be interrupted because there are too many #ifdef configurations
 (ert-deftest flycheck-define-checker/c/c++-clang-warning ()
   :tags '(builtin-checker external-tool language-c)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (let ((flycheck-disabled-checkers '(c/c++-cppcheck)))
+  (let ((flycheck-disabled-checkers '(c/c++-gcc c/c++-cppcheck)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-warning.c" 'c-mode
      '(5 10 warning "unused variable 'unused'" :checker c/c++-clang)
@@ -3143,7 +3143,7 @@ of the file will be interrupted because there are too many #ifdef configurations
   ;; Disable conversion checks by removing -Wextra, but additionally warn about
   ;; missing prototypes, which isn't included in -Wextra
   (let ((flycheck-clang-warnings '("all" "missing-prototypes"))
-        (flycheck-disabled-checkers '(c/c++-cppcheck)))
+        (flycheck-disabled-checkers '(c/c++-gcc c/c++-cppcheck)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-warning.c" 'c-mode
      '(3 5 warning "no previous prototype for function 'f'"
@@ -3153,22 +3153,25 @@ of the file will be interrupted because there are too many #ifdef configurations
 (ert-deftest flycheck-define-checker/c/c++-clang-fatal-error ()
   :tags '(builtin-checker external-tool language-c)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (flycheck-test-should-syntax-check
-   "checkers/c_c++-clang-fatal-error.c" 'c-mode
-   '(2 10 error "'c_c++-clang-library-header.h' file not found"
-       :checker c/c++-clang)))
+  (let ((flycheck-disabled-checkers '(c/c++-gcc)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-fatal-error.c" 'c-mode
+     '(2 10 error "'c_c++-clang-library-header.h' file not found"
+         :checker c/c++-clang))))
 
 (ert-deftest flycheck-define-checker/c/c++-clang-include-path ()
   :tags '(builtin-checker external-tool language-c)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (let ((flycheck-clang-include-path '("./c_c++-include")))
+  (let ((flycheck-clang-include-path '("./c_c++-include"))
+        (flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-fatal-error.c" 'c-mode)))
 
 (ert-deftest flycheck-define-checker/c/c++-clang-included-file-error ()
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (let ((flycheck-clang-include-path '("./c_c++-include")))
+  (let ((flycheck-clang-include-path '("./c_c++-include"))
+        (flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-included-file-error.cpp" 'c++-mode
      '(3 nil error "Errors in included file:
@@ -3182,7 +3185,8 @@ of the file will be interrupted because there are too many #ifdef configurations
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
   (let  ((flycheck-clang-includes (list (flycheck-test-resource-filename
-                                         "checkers/c_c++-include/c_c++-clang-library-header.h"))))
+                                         "checkers/c_c++-include/c_c++-clang-library-header.h")))
+         (flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-error.cpp" 'c++-mode
      '(10 16 error "use of undeclared identifier 'nullptr'"
@@ -3191,18 +3195,20 @@ of the file will be interrupted because there are too many #ifdef configurations
 (ert-deftest flycheck-define-checker/c/c++-clang-error ()
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (flycheck-test-should-syntax-check
-   "checkers/c_c++-clang-error.cpp" 'c++-mode
-   '(3 23 info "template is declared here" :checker c/c++-clang)
-   '(8 17 error "implicit instantiation of undefined template 'test<false>'"
-       :checker c/c++-clang)
-   '(10 16 error "use of undeclared identifier 'nullptr'"
-        :checker c/c++-clang)))
+  (let ((flycheck-disabled-checkers '(c/c++-gcc)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-error.cpp" 'c++-mode
+     '(3 23 info "template is declared here" :checker c/c++-clang)
+     '(8 17 error "implicit instantiation of undefined template 'test<false>'"
+         :checker c/c++-clang)
+     '(10 16 error "use of undeclared identifier 'nullptr'"
+          :checker c/c++-clang))))
 
 (ert-deftest flycheck-define-checker/c/c++-clang-error-language-standard ()
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (let ((flycheck-clang-language-standard "c++11"))
+  (let ((flycheck-clang-language-standard "c++11")
+        (flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-error.cpp" 'c++-mode
      '(3 23 info "template is declared here" :checker c/c++-clang)
@@ -3212,7 +3218,8 @@ of the file will be interrupted because there are too many #ifdef configurations
 (ert-deftest flycheck-define-checker/c/c++-clang-error-definitions ()
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (let ((flycheck-clang-definitions '("FLYCHECK_LIBRARY")))
+  (let ((flycheck-clang-definitions '("FLYCHECK_LIBRARY"))
+        (flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-error.cpp" 'c++-mode
      '(10 16 error "use of undeclared identifier 'nullptr'"
@@ -3241,16 +3248,136 @@ of the file will be interrupted because there are too many #ifdef configurations
 (ert-deftest flycheck-define-checker/c/c++-clang-error-no-rtti ()
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
-  (let ((flycheck-clang-no-rtti t))
+  (let ((flycheck-clang-no-rtti t)
+        (flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-clang-error-rtti.cpp" 'c++-mode
      '(11 18 error "cannot use dynamic_cast with -fno-rtti"
           :checker c/c++-clang))))
 
+(ert-deftest flycheck-define-checker/c/c++-gcc-warning ()
+  :tags '(builtin-checker external-tool language-c)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-disabled-checkers '(c/c++-clang c/c++-cppcheck)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-warning.c" 'c-mode
+     '(5 10 warning "unused variable ‘unused’" :checker c/c++-gcc)
+     '(7 15 warning "comparison between signed and unsigned integer expressions"
+         :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-warning-customized ()
+  :tags '(builtin-checker external-tool language-c)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  ;; Disable conversion checks by removing -Wextra, but additionally warn about
+  ;; missing prototypes, which isn't included in -Wextra
+  (let ((flycheck-gcc-warnings '("all" "missing-prototypes"))
+        (flycheck-disabled-checkers '(c/c++-clang c/c++-cppcheck)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-warning.c" 'c-mode
+     '(3 5 warning "no previous prototype for ‘f’"
+         :checker c/c++-gcc)
+     '(5 10 warning "unused variable ‘unused’" :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-fatal-error ()
+  :tags '(builtin-checker external-tool language-c)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-fatal-error.c" 'c-mode
+     '(2 40 error "c_c++-clang-library-header.h: No such file or directory"
+         :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-include-path ()
+  :tags '(builtin-checker external-tool language-c)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-gcc-include-path '("./c_c++-include"))
+        (flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-fatal-error.c" 'c-mode)))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-included-file-error ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-gcc-include-path '("./c_c++-include"))
+        (flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-included-file-error.cpp" 'c++-mode
+     '(3 nil error "Errors in included file:
+2:3:error: ‘this_is_bad’ does not name a type (c/c++-gcc)
+3:1:error: expected ‘;’ after class definition (c/c++-gcc)
+3:1:error: abstract declarator ‘<anonymous class>’ used as declaration (c/c++-gcc)"
+         :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-includes ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let  ((flycheck-gcc-includes (list (flycheck-test-resource-filename
+                                         "checkers/c_c++-include/c_c++-clang-library-header.h")))
+         (flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-error.cpp" 'c++-mode
+     '(10 5 warning "identifier ‘nullptr’ is a keyword in C++11"
+          :checker c/c++-gcc)
+     '(10 10 warning "unused variable ‘foo’"
+          :checker c/c++-gcc)
+     '(10 16 error "‘nullptr’ was not declared in this scope"
+          :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-error ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-error.cpp" 'c++-mode
+     '(8 17 error "aggregate ‘test<false> t’ has incomplete type and cannot be defined"
+         :checker c/c++-gcc)
+     '(10 5 warning "identifier ‘nullptr’ is a keyword in C++11"
+          :checker c/c++-gcc)
+     '(10 10 warning "unused variable ‘foo’"
+          :checker c/c++-gcc)
+     '(10 16 error "‘nullptr’ was not declared in this scope"
+          :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-error-language-standard ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-gcc-language-standard "c++11")
+        (flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-error.cpp" 'c++-mode
+     '(8 17 error "aggregate ‘test<false> t’ has incomplete type and cannot be defined"
+         :checker c/c++-gcc)
+     '(10 10 warning "unused variable ‘foo’"
+          :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-error-definitions ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-gcc-definitions '("FLYCHECK_LIBRARY"))
+        (flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-error.cpp" 'c++-mode
+     '(10 5 warning "identifier ‘nullptr’ is a keyword in C++11"
+          :checker c/c++-gcc)
+     '(10 10 warning "unused variable ‘foo’"
+          :checker c/c++-gcc)
+     '(10 16 error "‘nullptr’ was not declared in this scope"
+          :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-error-no-rtti ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-disabled-checkers '(c/c++-clang))
+        (flycheck-gcc-no-rtti t))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-clang-error-rtti.cpp" 'c++-mode
+     '(11 42 error "‘dynamic_cast’ not permitted with -fno-rtti"
+          :checker c/c++-gcc))))
+
 (ert-deftest flycheck-define-checker/c/c++-cppcheck-error ()
   :tags '(builtin-checker external-tool language-c)
   (skip-unless (flycheck-check-executable 'c/c++-cppcheck))
-  (let ((flycheck-disabled-checkers '(c/c++-clang)))
+  (let ((flycheck-disabled-checkers '(c/c++-clang c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-cppcheck-error.c" 'c-mode
      '(4 nil error "Null pointer dereference" :checker c/c++-cppcheck))))
@@ -3258,7 +3385,7 @@ of the file will be interrupted because there are too many #ifdef configurations
 (ert-deftest flycheck-define-checker/c/c++-cppcheck-warning ()
   :tags '(builtin-checker external-tool language-c)
   (skip-unless (flycheck-check-executable 'c/c++-cppcheck))
-  (let ((flycheck-disabled-checkers '(c/c++-clang)))
+  (let ((flycheck-disabled-checkers '(c/c++-clang c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-cppcheck-warning.c" 'c-mode
      '(2 nil warning "The expression \"x\" is of type 'bool' and it is compared against a integer value that is neither 1 nor 0."
@@ -3267,7 +3394,7 @@ of the file will be interrupted because there are too many #ifdef configurations
 (ert-deftest flycheck-define-checker/c/c++-cppcheck-style ()
   :tags '(builtin-checker external-tool language-c)
   (skip-unless (flycheck-check-executable 'c/c++-cppcheck))
-  (let ((flycheck-disabled-checkers '(c/c++-clang)))
+  (let ((flycheck-disabled-checkers '(c/c++-clang c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-cppcheck-style.c" 'c-mode
      '(3 nil warning "Unused variable: unused" :checker c/c++-cppcheck))))
@@ -3276,7 +3403,7 @@ of the file will be interrupted because there are too many #ifdef configurations
   :tags '(builtin-checker external-tool language-c)
   (skip-unless (flycheck-check-executable 'c/c++-cppcheck))
   (let ((flycheck-cppcheck-checks nil)
-        (flycheck-disabled-checkers '(c/c++-clang)))
+        (flycheck-disabled-checkers '(c/c++-clang c/c++-gcc)))
     (flycheck-test-should-syntax-check "checkers/c_c++-cppcheck-style.c"
                                        'c-mode)))
 
@@ -3288,7 +3415,7 @@ of the file will be interrupted because there are too many #ifdef configurations
   (skip-unless (version< "1.53" (flycheck-test-cppcheck-version)))
   (let ((flycheck-cppcheck-checks '("style"))
         (flycheck-cppcheck-inconclusive t)
-        (flycheck-disabled-checkers '(c/c++-clang)))
+        (flycheck-disabled-checkers '(c/c++-clang c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-cppcheck-inconclusive.cpp" 'c++-mode
      '(1 nil warning "Boolean variable 'a' is used in bitwise operation. Did you mean '&&'?"
@@ -3302,7 +3429,7 @@ of the file will be interrupted because there are too many #ifdef configurations
   (skip-unless (version< "1.53" (flycheck-test-cppcheck-version)))
   (let ((flycheck-cppcheck-checks '("style"))
         (flycheck-cppcheck-inconclusive nil)
-        (flycheck-disabled-checkers '(c/c++-clang)))
+        (flycheck-disabled-checkers '(c/c++-clang c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-cppcheck-inconclusive.cpp" 'c++-mode)))
 
@@ -3310,7 +3437,7 @@ of the file will be interrupted because there are too many #ifdef configurations
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-cppcheck))
   (let ((flycheck-cppcheck-checks '("performance" "portability"))
-        (flycheck-disabled-checkers '(c/c++-clang)))
+        (flycheck-disabled-checkers '(c/c++-clang c/c++-gcc)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-cppcheck-multiple-checks.cpp" 'c++-mode
      '(2 nil warning "Extra qualification 'A::' unnecessary and considered an error by many compilers."


### PR DESCRIPTION
A GCC C and C++ checker, for those who don't have Clang, or who prefer GCC diagnostics, or who use GCC extensions Clang doesn't implement, or who use GCC to target a platform which Clang doesn't and want platform-specific warnings.

**Currently far from complete**, not yet ready to merge by any means. Here's why:
- Tests? What tests?
- Documentation? What documentation?
- How are Clang and GCC checkers supposed to coexist? It doesn't make sense to use both. `flycheck-disabled-checkers` is a bit clunky solution, IMO, as without user intervention both will be enabled by default due to both being in `flycheck-checkers`. Hilarity will ensue when both Clang and GCC are installed.
- What is the right way to handle options that are required by newer versions, but make older versions choke, such as `-fno-diagnostics-show-caret` which is recognized only by GCC 4.8 and newer?
