### PR TITLE
Update a variable name in CREDITS.rst.

### DIFF
--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -16,7 +16,7 @@ greatly appreciated.
   `verilator`.
 - `Doug MacEachern`_ added a Go syntax checker using `errcheck`.
 - `Fanael Linithien`_ added a C/C++ syntax checker using GCC, and implemented
-  `flycheck-cppcheck-enable-inconclusive` to make Cppcheck report more warnings,
+  `flycheck-cppcheck-inconclusive` to make Cppcheck report more warnings,
   at the risk of false positives.
 - `Gereon Frey`_ fixed the `go-build` syntax checker and improved its tests.
 - `Jimmy Yuen Ho Wong`_ added the HTML syntax checker and the jshint Javascript


### PR DESCRIPTION
`flycheck-cppcheck-inconclusive` was renamed in a4fc34bc07.
