### PR TITLE
Add options to flag C++ exception handling as an error.

### DIFF
--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -50,6 +50,9 @@ C/C++
    .. option:: flycheck-clang-ms-extensions
       :auto:
 
+   .. option:: flycheck-clang-no-exceptions
+      :auto:
+
    .. option:: flycheck-clang-no-rtti
       :auto:
 
@@ -74,6 +77,9 @@ C/C++
       :auto:
 
    .. option:: flycheck-gcc-language-standard
+      :auto:
+
+   .. option:: flycheck-gcc-no-exceptions
       :auto:
 
    .. option:: flycheck-gcc-no-rtti

--- a/flycheck.el
+++ b/flycheck.el
@@ -3849,6 +3849,15 @@ When non-nil, enable Microsoft extensions to C/C++ via
   :safe #'booleanp
   :package-version '(flycheck . "0.16"))
 
+(flycheck-def-option-var flycheck-clang-no-exceptions nil c/c++-clang
+  "Whether to disable exceptions in Clang.
+
+When non-nil, disable exceptions for syntax checks, via
+`-fno-exceptions'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "0.20"))
+
 (flycheck-def-option-var flycheck-clang-no-rtti nil c/c++-clang
   "Whether to disable RTTI in Clang.
 
@@ -3903,6 +3912,7 @@ See URL `http://clang.llvm.org/'."
             (option "-std=" flycheck-clang-language-standard)
             (option "-stdlib=" flycheck-clang-standard-library)
             (option-flag "-fms-extensions" flycheck-clang-ms-extensions)
+            (option-flag "-fno-exceptions" flycheck-clang-no-exceptions)
             (option-flag "-fno-rtti" flycheck-clang-no-rtti)
             (option-list "-include" flycheck-clang-includes)
             (option-list "-W" flycheck-clang-warnings s-prepend)
@@ -3973,6 +3983,15 @@ pass the language standard via the `-std' option."
   :safe #'stringp
   :package-version '(flycheck . "0.20"))
 
+(flycheck-def-option-var flycheck-gcc-no-exceptions nil c/c++-gcc
+  "Whether to disable exceptions in gcc.
+
+When non-nil, disable exceptions for syntax checks, via
+`-fno-exceptions'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "0.20"))
+
 (flycheck-def-option-var flycheck-gcc-no-rtti nil c/c++-gcc
   "Whether to disable RTTI in gcc.
 
@@ -4009,6 +4028,7 @@ Requires GCC 4.8 or newer.  See URL `https://gcc.gnu.org/'."
             "-fno-diagnostics-show-option" ; Do not show the corresponding
                                         ; warning group
             (option "-std=" flycheck-gcc-language-standard)
+            (option-flag "-fno-exceptions" flycheck-gcc-no-exceptions)
             (option-flag "-fno-rtti" flycheck-gcc-no-rtti)
             (option-list "-include" flycheck-gcc-includes)
             (option-list "-W" flycheck-gcc-warnings s-prepend)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3245,6 +3245,16 @@ of the file will be interrupted because there are too many #ifdef configurations
      '(7 5 warning "anonymous structs are a Microsoft extension"
          :checker c/c++-clang))))
 
+(ert-deftest flycheck-define-checker/c/c++-clang-error-no-exceptions ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-clang))
+  (let ((flycheck-disabled-checkers '(c/c++-gcc))
+        (flycheck-clang-no-exceptions t))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-error-exceptions.cpp" 'c++-mode
+     '(1 14 error "cannot use 'throw' with exceptions disabled"
+          :checker c/c++-clang))))
+
 (ert-deftest flycheck-define-checker/c/c++-clang-error-no-rtti ()
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
@@ -3362,6 +3372,16 @@ of the file will be interrupted because there are too many #ifdef configurations
      '(10 10 warning "unused variable ‘foo’"
           :checker c/c++-gcc)
      '(10 16 error "‘nullptr’ was not declared in this scope"
+          :checker c/c++-gcc))))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-error-no-exceptions ()
+  :tags '(builtin-checker external-tool language-c++)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-disabled-checkers '(c/c++-clang))
+        (flycheck-gcc-no-exceptions t))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-error-exceptions.cpp" 'c++-mode
+     '(1 20 error "exception handling disabled, use -fexceptions to enable"
           :checker c/c++-gcc))))
 
 (ert-deftest flycheck-define-checker/c/c++-gcc-error-no-rtti ()

--- a/test/resources/checkers/c_c++-error-exceptions.cpp
+++ b/test/resources/checkers/c_c++-error-exceptions.cpp
@@ -1,0 +1,1 @@
+void foo() { throw 5; }


### PR DESCRIPTION
This serves pretty much the same purpose as the options to flag C++ RTTI as an error, being useful mostly in freestanding and/or embedded environments where linking in the required runtime support is infeasible. Adding an option to disable exception handling makes it easier to catch a mistake early.
