### PR TITLE
Better support for modules in rust

### DIFF
--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -455,6 +455,9 @@ Rust
    .. option:: flycheck-rust-library-path
       :auto:
 
+   .. option:: flycheck-rust-crate-root
+      :auto:
+
 Sass
 ====
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -4846,6 +4846,7 @@ See URL `https://github.com/zaach/jsonlint'."
 
 (flycheck-define-checker less
   "A LESS syntax checker using lessc.
+
 At least version 1.4 of lessc is required.
 
 See URL `http://lesscss.org'."
@@ -5318,7 +5319,7 @@ runner requires `std'."
   :package-version '("flycheck" . "0.19"))
 
 (flycheck-def-option-var flycheck-rust-crate-root nil rust
-  "A path to the crate root for the current buffer
+  "A path to the crate root for the current buffer.
 
 The value of this variable is either a string with the path to
 the crate root for the current buffer, or nil if the current buffer
@@ -5352,8 +5353,7 @@ See URL `http://www.rust-lang.org'."
   :predicate (lambda ()
                (or (not flycheck-rust-crate-root)
                    (and (buffer-file-name)
-                        (not (buffer-modified-p))))
-               ))
+                        (not (buffer-modified-p))))))
 
 (flycheck-def-option-var flycheck-sass-compass nil sass
   "Whether to enable the Compass CSS framework.


### PR DESCRIPTION
Rust's compilation model differs from some others in that, beyond the simple cases, individual files are not often compilable on their own.

Instead, they need to be considered as part of a larger crate (namespace) and that crate as a whole should be compiled.

This patch add an options to the rust checker to allow a file to specify the file that represents the entire crate.  It is this file that will be passed to rustc.

(Related to ticket #386)
