### PR TITLE
Add options to define system include paths for Clang and GCC.

### DIFF
--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -59,6 +59,9 @@ C/C++
    .. option:: flycheck-clang-standard-library
       :auto:
 
+   .. option:: flycheck-clang-system-include-path
+      :auto:
+
    .. option:: flycheck-clang-warnings
       :auto:
 
@@ -83,6 +86,9 @@ C/C++
       :auto:
 
    .. option:: flycheck-gcc-no-rtti
+      :auto:
+
+   .. option:: flycheck-gcc-system-include-path
       :auto:
 
    .. option:: flycheck-gcc-warnings

--- a/flycheck.el
+++ b/flycheck.el
@@ -3851,6 +3851,16 @@ Relative paths are relative to the file being checked."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.14"))
 
+(flycheck-def-option-var flycheck-clang-system-include-path nil c/c++-clang
+  "A list of system include directories for Clang.
+
+The value of this variable is a list of strings, where each
+string is a directory to add to the system include path of Clang.
+Relative paths are relative to the file being checked."
+  :type '(repeat (directory :tag "Include directory"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.20"))
+
 (flycheck-def-option-var flycheck-clang-includes nil c/c++-clang
   "A list of additional include files for Clang.
 
@@ -3950,6 +3960,7 @@ See URL `http://clang.llvm.org/'."
             (option-list "-W" flycheck-clang-warnings s-prepend)
             (option-list "-D" flycheck-clang-definitions s-prepend)
             (option-list "-I" flycheck-clang-include-path)
+            (option-list "-isystem" flycheck-clang-system-include-path)
             "-x" (eval
                   (pcase major-mode
                     (`c++-mode "c++")
@@ -3989,6 +4000,16 @@ option."
 
 The value of this variable is a list of strings, where each
 string is a directory to add to the include path of gcc.
+Relative paths are relative to the file being checked."
+  :type '(repeat (directory :tag "Include directory"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.20"))
+
+(flycheck-def-option-var flycheck-gcc-system-include-path nil c/c++-gcc
+  "A list of system include directories for GCC.
+
+The value of this variable is a list of strings, where each
+string is a directory to add to the system include path of gcc.
 Relative paths are relative to the file being checked."
   :type '(repeat (directory :tag "Include directory"))
   :safe #'flycheck-string-list-p
@@ -4066,6 +4087,7 @@ Requires GCC 4.8 or newer.  See URL `https://gcc.gnu.org/'."
             (option-list "-W" flycheck-gcc-warnings s-prepend)
             (option-list "-D" flycheck-gcc-definitions s-prepend)
             (option-list "-I" flycheck-gcc-include-path)
+            (option-list "-isystem" flycheck-gcc-system-include-path)
             "-x" (eval
                   (pcase major-mode
                     (`c++-mode "c++")

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3224,6 +3224,14 @@ of the file will be interrupted because there are too many #ifdef configurations
     (flycheck-test-should-syntax-check
      "checkers/c_c++-fatal-error.c" 'c-mode)))
 
+(ert-deftest flycheck-define-checker/c/c++-clang-system-include-path ()
+  :tags '(builtin-checker external-tool language-c)
+  (skip-unless (flycheck-check-executable 'c/c++-clang))
+  (let ((flycheck-clang-system-include-path '("."))
+        (flycheck-disabled-checkers '(c/c++-gcc)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-system-include-path.c" 'c-mode)))
+
 (ert-deftest flycheck-define-checker/c/c++-clang-included-file-error ()
   :tags '(builtin-checker external-tool language-c++)
   (skip-unless (flycheck-check-executable 'c/c++-clang))
@@ -3361,6 +3369,14 @@ of the file will be interrupted because there are too many #ifdef configurations
         (flycheck-disabled-checkers '(c/c++-clang)))
     (flycheck-test-should-syntax-check
      "checkers/c_c++-fatal-error.c" 'c-mode)))
+
+(ert-deftest flycheck-define-checker/c/c++-gcc-system-include-path ()
+  :tags '(builtin-checker external-tool language-c)
+  (skip-unless (flycheck-check-executable 'c/c++-gcc))
+  (let ((flycheck-gcc-system-include-path '("."))
+        (flycheck-disabled-checkers '(c/c++-clang)))
+    (flycheck-test-should-syntax-check
+     "checkers/c_c++-system-include-path.c" 'c-mode)))
 
 (ert-deftest flycheck-define-checker/c/c++-gcc-included-file-error ()
   :tags '(builtin-checker external-tool language-c++)

--- a/test/resources/checkers/c_c++-system-include-path.c
+++ b/test/resources/checkers/c_c++-system-include-path.c
@@ -1,0 +1,1 @@
+#include <c_c++-warning.c>


### PR DESCRIPTION
Warnings inside files from system include paths are silenced, reducing the amount of warnings reported in `#include`d header files. This is especially useful for third party C++ header only libraries, which may contain code that compilers find questionable.
