### PR TITLE
Alter behaviour of flycheck-rust-check-tests

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5304,12 +5304,9 @@ Relative paths are relative to the file being checked."
 (flycheck-def-option-var flycheck-rust-check-tests t rust
   "Whether to check test code in Rust.
 
-When non-nil, `rustc' is passed the `--test' flag, which will
-check any code marked with the `#[cfg(test)]' attribute and any
-functions marked with `#[test]'. Otherwise, `rustc' is not passed
-`--test' and test code will not be checked.  Skipping `--test' is
-necessary when using `#![no_std]', because compiling the test
-runner requires `std'."
+When non-nil, `rustc' will check any code marked with the
+`#[cfg(test)]' attribute and any functions marked with `#[test]'.
+Otherwise, test code will not be checked."
   :type 'boolean
   :safe #'booleanp
   :package-version '("flycheck" . "0.19"))
@@ -5334,7 +5331,8 @@ This syntax checker needs Rust 0.10 or newer.
 
 See URL `http://www.rust-lang.org'."
   :command ("rustc" "--crate-type=lib" "--no-trans"
-            (option-flag "--test" flycheck-rust-check-tests)
+            (option-flag "--cfg" flycheck-rust-check-tests)
+            (option-flag "test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path s-prepend)
             (eval (or flycheck-rust-crate-root
                       (flycheck-substitute-argument 'source-inplace 'rust))))


### PR DESCRIPTION
- stop passing `--test` to `rustc` in favour of simply passing `--cfg test`
- the former approach causes `rustc` to add a test harness, effectively
  removing any existing `main()`, meaning `main()` is not checked for errors.
- this approach also means that such test code can live happily with crates
  using `#![nostd]` as the test harness is no longer introduced.
