### PR TITLE
Add Ada syntax checker with GNAT

### DIFF
--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -21,6 +21,23 @@ a syntax checker.
 .. contents:: Supported languages
    :local:
 
+Ada
+===
+
+.. flyc-checker:: ada-gnat
+   :auto:
+
+   .. rubric:: Options
+
+   .. option:: flycheck-gnat-include-path
+      :auto:
+
+   .. option:: flycheck-gnat-language-standard
+      :auto:
+
+   .. option:: flycheck-gnat-warnings
+      :auto:
+
 AsciiDoc
 ========
 

--- a/playbooks/tasks/packages.yml
+++ b/playbooks/tasks/packages.yml
@@ -54,6 +54,7 @@
     - dash                        # sh-posix-dash
     - g++-4.8                     # c/c++-gcc
     - gfortran-4.8                # fortran-gfortran
+    - gnat                        # ada-gnat
     - ghc-{{ghc_version}}         # haskell-ghc
     - hlint                       # haskell-hlint
     - lacheck                     # tex-lacheck

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3232,6 +3232,30 @@ of the file will be interrupted because there are too many #ifdef configurations
 (defvar js3-mode-show-parse-errors)
 (defvar python-indent-guess-indent-offset)
 
+(ert-deftest flycheck-define-checker/ada-gnat-syntax-error ()
+  :tags '(builtin-checker external-tool language-ada)
+  (skip-unless (flycheck-check-executable 'ada-gnat))
+  (flycheck-test-should-syntax-check
+   "checkers/ada/syntaxerror.adb" 'ada-mode
+   '(7  32 error "missing \";\"" :checker ada-gnat)
+   '(8 5 error "misspelling of \"SYNTAXERROR\"" :checker ada-gnat)))
+
+(ert-deftest flycheck-define-checker/ada-gnat-warnings ()
+  :tags '(builtin-checker external-tool language-ada)
+  (skip-unless (flycheck-check-executable 'ada-gnat))
+  (flycheck-test-should-syntax-check
+   "checkers/ada/hello.adb" 'ada-mode
+   '(   6 4 warning "variable \"Name\" is not referenced" :checker ada-gnat)
+   '(8  11 warning "unrecognized pragma \"Foo\"" :checker ada-gnat)))
+
+(ert-deftest flycheck-define-checker/ada-gnat-disable-warnings ()
+  :tags '(builtin-checker external-tool language-ada)
+  (skip-unless (flycheck-check-executable 'ada-gnat))
+  (let ((flycheck-gnat-warnings nil))
+    (flycheck-test-should-syntax-check
+     "checkers/ada/hello.adb" 'ada-mode
+     '(8  11 warning "unrecognized pragma \"Foo\"" :checker ada-gnat))))
+
 (ert-deftest flycheck-define-checker/asciidoc ()
   :tags '(builtin-checker external-tool language-asciidoc)
   (skip-unless (flycheck-check-executable 'asciidoc))

--- a/test/resources/checkers/ada/hello.adb
+++ b/test/resources/checkers/ada/hello.adb
@@ -1,0 +1,11 @@
+with Ada.Text_IO;
+with Ada.Command_Line;
+
+procedure Hello is
+   package IO renames Ada.Text_IO;
+   Name : String :=  Ada.Command_Line.Argument (1);
+begin
+   pragma Foo;
+   IO.Put_Line("Hello, world!");
+   IO.New_Line;
+end Hello;

--- a/test/resources/checkers/ada/syntaxerror.adb
+++ b/test/resources/checkers/ada/syntaxerror.adb
@@ -1,0 +1,8 @@
+with Ada.Text_IO;
+with Ada.Command_Line;
+
+procedure SyntaxError is
+   package IO renames Ada.Text_IO;
+begin
+   IO.Put_Line("Hello, world!")
+end SyntaxErro;


### PR DESCRIPTION
Based on #414, but with some changes
- Use `gnatmake` directly instead of `gnat compile`
- Move generated files to a temporary directory with `-D`
- Hardcode `-gnatef` and `-gnatf` options. Imho these shouldn't be in `flycheck-gnat-warnings`
- Remove `wu` from `flycheck-gnat-warnings`, since it's included in `gnatwa` anyway.

@nordlow Comments?
