### PR TITLE
Add OCaml checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -209,6 +209,7 @@ attention to case differences."
     less
     lua
     make
+    ocaml-ocamlc
     perl
     perl-perlcritic
     php
@@ -5562,6 +5563,24 @@ See URL `http://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html'."
    ;; http://www.openbsd.org/cgi-bin/man.cgi?query=make
    (error line-start (message) " (" (file-name) ":" line ")" line-end))
   :modes (makefile-mode makefile-gmake-mode makefile-bsdmake-mode))
+
+(flycheck-define-checker ocaml-ocamlc
+  "An OCaml syntax checker using the OCaml bytecode compiler.
+
+See URL `http://ocaml.org/'."
+  :command ("ocamlc" "-w" "+a" "-c" source)
+  :error-patterns
+  ((warning line-start
+            "File \"" (file-name) "\", line " line ", characters " column
+            "-" (one-or-more digit) ":\n"
+            "Warning " (one-or-more digit) ": " (message)
+            line-end)
+   (error line-start
+          "File \"" (file-name) "\", line " line ", characters " column
+          "-" (one-or-more digit) ":\n"
+          "Error: " (message)
+          line-end))
+  :modes (tuareg-mode))
 
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.


### PR DESCRIPTION
Here is a simple crack at OCaml #254.  This is more an RFC: just throwing
something out there,  not expecting to get pulled here.

I find in general the column OCaml reports is off by some arbitrary amount,
I don't know why.

I found another example[0] of tricky OCaml compiler output (which could be
added to a test file), where the first "File" message's info is useless, and
the actual location of the error is in a second message "File … line 1090" much
later.

```
ocamlopt -c -o wsi.cmx -I +lablGL wsi.ml
File "wsi.ml", line 1:
Error: The implementation wsi.ml does not match the interface wsi.cmi:
       Values do not match:
         val init :
           t -> int -> int -> int -> bool -> Unix.file_descr * int * int
       is not included in
         val init : t -> int -> int -> bool -> Unix.file_descr * int * int
       File "wsi.ml", line 1090, characters 4-8: Actual declaration
```

[0] This comes from the v20 tag of llpp http://repo.or.cz/w/llpp.git
