### PR TITLE
flycheck-list-errors: keep buffer input focus

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3821,8 +3821,8 @@ non-nil."
     (with-current-buffer (get-buffer-create flycheck-error-list-buffer)
       (flycheck-error-list-mode)))
   (flycheck-error-list-set-source (current-buffer))
-  ;; Show the error list in a window, and re-select the old window
-  (display-buffer flycheck-error-list-buffer)
+  ;; Show the error list in a window and select it
+  (pop-to-buffer flycheck-error-list-buffer)
   ;; Finally, refresh the error list to show the most recent errors
   (flycheck-error-list-refresh))
 


### PR DESCRIPTION
### Problem

After pressing `C-c ! l` (=`flycheck-list-errors`), the input focus is currently switched back to the original source code window.  In my workflow, the main motivation behind `C-c ! l` is to be able to see the global picture of various findings and to be able to quickly jump around to even distant errors easily.  Keeping input focus in the original source code window goes counter this use case.
### Proposal

This PR proposes to alter current behaviour in order to keep the focus in the `*Flycheck errors*` buffer, so that users could immediately navigate in the findings right after pressing `C-c ! l`. 

This behaviour would seem more consistent with other usual goodies such as `C-x v g` (=`vc-annotate`), or various `magit` operations, that usually switch input focus to the new window.   It would also ressemble to what `helm-flycheck` does.
### Note

If you don't like alterting default behaviour in this hard way, what about creating new custom settings that people could tweak? (say `flycheck-list-errors-keep-input-focus`) 
