### PR TITLE
Added support to capture 'help' messages issued by rustc.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6127,6 +6127,9 @@ See URL `http://www.rust-lang.org'."
             (message) line-end)
    (info line-start (file-name) ":" line ":" column ": "
          (one-or-more digit) ":" (one-or-more digit) " note: "
+         (message) line-end)
+   (info line-start (file-name) ":" line ":" column ": "
+         (one-or-more digit) ":" (one-or-more digit) " help: "
          (message) line-end))
   :modes rust-mode
   :predicate (lambda ()

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -5219,6 +5219,16 @@ Why not:
    '(4 9 warning "unused variable: `x`, #[warn(unused_variable)] on by default"
        :checker rust)))
 
+(ert-deftest flycheck-define-checker/rust-help ()
+  :tags '(builtin-checker external-tool language-rust)
+  (skip-unless (flycheck-check-executable 'rust))
+  (flycheck-test-should-syntax-check
+   "checkers/rust-help.rs" 'rust-mode
+   '(3 1 error "not all control paths return a value"
+       :checker rust)
+   '(4 8 info "consider removing this semicolon:"
+       :checker rust)))
+
 (ert-deftest flycheck-define-checker/rust-test-crate-type-bin ()
   :tags '(builtin-checker external-tool language-rust)
   (skip-unless (flycheck-check-executable 'rust))

--- a/test/resources/checkers/rust-help.rs
+++ b/test/resources/checkers/rust-help.rs
@@ -1,0 +1,5 @@
+// test that 'help' messages from rustc appear correctly
+
+fn test() -> int {
+    32i;
+}


### PR DESCRIPTION
As of very recently, rustc has started to emit 'help' diagnostics
as well as 'error', 'warning', and 'info'. This change categorizes
'help' as info-level diagnostics and presents them and adds a new
test to check this new functionality.
