### PR TITLE
Handle `Unexpected end of file`

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5792,7 +5792,7 @@ Uses GCC's Fortran compiler gfortran.  See URL
    (warning line-start (file-name) ":" line "." column ":\n"
             (= 3 (zero-or-more not-newline) "\n")
             "Warning: " (message) line-end)
-   (error line-start "Error: " (message) in "'" (file-name) "'" "\n"))
+   (error line-start "Error: " (message) " in '" (file-name) "'\n")
   :modes (fortran-mode f90-mode))
 
 (flycheck-define-checker go-gofmt

--- a/flycheck.el
+++ b/flycheck.el
@@ -5791,7 +5791,8 @@ Uses GCC's Fortran compiler gfortran.  See URL
           (or "Error" "Fatal Error") ": " (message) line-end)
    (warning line-start (file-name) ":" line "." column ":\n"
             (= 3 (zero-or-more not-newline) "\n")
-            "Warning: " (message) line-end))
+            "Warning: " (message) line-end)
+   (error line-start "Error: " (message) in "'" (file-name) "'" "\n"))
   :modes (fortran-mode f90-mode))
 
 (flycheck-define-checker go-gofmt


### PR DESCRIPTION
It's useless though since there is no line number to point to,
but should remove the `suspicious` waring from `flycheck` if there is no other errors

```
gfortran -fsyntax-only -fshow-column -fno-diagnostics-show-caret -fno-diagnostics-show-option -iquote /Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/ -std\=f95 -Wall -Wextra -I/usr/local/include -I. /Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/declarations2.f90
Error: Unexpected end of file in '/Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/declarations2.f90'
```

```
Suspicious state from syntax checker fortran-gfortran: Checker fortran-gfortran returned non-zero exit code 1, but no errors from output: Error: Unexpected end of file in '/var/folders/jy/nw9d_y3s5kz3jk2z0mg_pfm00000gn/T/flycheck4738SUw/declarations2.f90'
```