### PR TITLE
Handle included files

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5787,9 +5787,11 @@ Uses GCC's Fortran compiler gfortran.  See URL
             source)
   :error-patterns
   ((error line-start (file-name) ":" line "." column ":\n"
+          (zero-or-more (one-or-more blank) "Included at " (file-name) ":" line ":\n")
           (= 3 (zero-or-more not-newline) "\n")
           (or "Error" "Fatal Error") ": " (message) line-end)
    (warning line-start (file-name) ":" line "." column ":\n"
+          (zero-or-more (one-or-more blank) "Included at " (file-name) ":" line ":\n")
             (= 3 (zero-or-more not-newline) "\n")
             "Warning: " (message) line-end))
   :modes (fortran-mode f90-mode))


### PR DESCRIPTION
Note that the usual place for (file-name) is now the included file and
the main file is the last one in "Included at..."

```
gfortran -fsyntax-only -fshow-column -fno-diagnostics-show-caret -fno-diagnostics-show-option -iquote /Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/ -std\=f95 -Wall -Wextra -I/usr/local/include -I. /Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/depoupiv2.f90
```

```
declarations2.zoom.f90:2.62:
    Included at sub_depou_piv2.f90:12:
    Included at /Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/depoupiv2.f90:3:

  integer, parameter :: NXFILE=128, NYFILE=128, NPIV=1500,NPOD=30
                                                              1
Warning: Unused parameter 'npod' declared at (1)
sub_depou_piv2.f90:15.33:
    Included at /Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/depoupiv2.f90:3:

  real(kind=8) :: echelle,xoffset,yoffset,dt
                                 1
Warning: Unused variable 'xoffset' declared at (1)
sub_depou_piv2.f90:15.41:
    Included at /Volumes/CLOUD/JESSICA/KULITE_PIV/aqui24_040414-04/PROGRAM/depoupiv2.f90:3:

  real(kind=8) :: echelle,xoffset,yoffset,dt
                                         1
Warning: Unused variable 'yoffset' declared at (1)
```