### PR TITLE
Use source-inplace for chef-foodcritic checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5334,7 +5334,7 @@ See URL `http://cfengine.com/'."
   "A Chef cookbooks syntax checker using Foodcritic.
 
 See URL `http://acrmp.github.io/foodcritic/'."
-  :command ("foodcritic" source)
+  :command ("foodcritic" source-inplace)
   :error-patterns
   ((error line-start (message) ": " (file-name) ":" line line-end))
   :modes (enh-ruby-mode ruby-mode)


### PR DESCRIPTION
Otherwise foodcritic won't find related files such as templates and will
report errors.