### PR TITLE
Enable Flycheck Mode even if there's no syntax checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2466,13 +2466,12 @@ Flycheck mode is not enabled for
 - or if no suitable syntax checker exists.
 
 Return t if Flycheck mode may be enabled, and nil otherwise."
-  (and (not (or (derived-mode-p 'special-mode)
-                (derived-mode-p 'comint-mode)
-                (flycheck-ephemeral-buffer-p)
-                (flycheck-encrypted-buffer-p)
-                (and (buffer-file-name)
-                     (file-remote-p (buffer-file-name) 'method))))
-       (flycheck-get-checker-for-buffer)))
+  (not (or (derived-mode-p 'special-mode)
+           (derived-mode-p 'comint-mode)
+           (flycheck-ephemeral-buffer-p)
+           (flycheck-encrypted-buffer-p)
+           (and (buffer-file-name)
+                (file-remote-p (buffer-file-name) 'method)))))
 
 (defun flycheck-mode-on-safe ()
   "Enable `flycheck-mode' if it is safe to do so.

--- a/flycheck.el
+++ b/flycheck.el
@@ -2459,15 +2459,19 @@ Return t if so, or nil otherwise."
 
 Flycheck mode is not enabled for
 
+- buffers in a `special-mode' or `comint-mode'
 - ephemeral buffers (see `flycheck-ephemeral-buffer-p'),
 - encrypted buffers (see `flycheck-encrypted-buffer-p'),
 - remote files (see `file-remote-p'),
 - or if no suitable syntax checker exists.
 
 Return t if Flycheck mode may be enabled, and nil otherwise."
-  (and (not (flycheck-ephemeral-buffer-p))
-       (not (flycheck-encrypted-buffer-p))
-       (not (and (buffer-file-name) (file-remote-p (buffer-file-name) 'method)))
+  (and (not (or (derived-mode-p 'special-mode)
+                (derived-mode-p 'comint-mode)
+                (flycheck-ephemeral-buffer-p)
+                (flycheck-encrypted-buffer-p)
+                (and (buffer-file-name)
+                     (file-remote-p (buffer-file-name) 'method))))
        (flycheck-get-checker-for-buffer)))
 
 (defun flycheck-mode-on-safe ()

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -334,14 +334,12 @@ and extension, as in `file-name-base'."
       (should (flycheck-get-checker-for-buffer))
       (should-not (flycheck-may-enable-mode)))))
 
-(ert-deftest flycheck-may-enable-mode/not-if-no-checker-is-found ()
+(ert-deftest flycheck-may-enable-mode/not-in-special-mode ()
   :tags '(global-mode)
   (flycheck-ert-with-temp-buffer
     (setq buffer-file-name "foo")
     (rename-buffer "foo")
-    (text-mode)
-    (should-not (string-prefix-p " " (buffer-name)))
-    (should-not (flycheck-get-checker-for-buffer))
+    (special-mode)
     (should-not (flycheck-may-enable-mode))))
 
 (ert-deftest flycheck-may-enable-mode/checker-found ()
@@ -374,12 +372,11 @@ and extension, as in `file-name-base'."
         (emacs-lisp-mode)
         (should-not flycheck-mode)))))
 
-(ert-deftest global-flycheck-mode/does-not-enable-if-no-checker-is-found ()
+(ert-deftest global-flycheck-mode/does-not-enable-in-special-mode ()
   :tags '(global-mode)
   (flycheck-ert-with-global-mode
     (flycheck-ert-with-temp-buffer
-      (rename-buffer "foo")
-      (text-mode)
+      (special-mode)
       (should-not flycheck-mode))))
 
 (ert-deftest global-flycheck-mode/checker-found ()


### PR DESCRIPTION
With Global Flycheck Mode, enable Flycheck Mode even if there's no syntax checker for the buffer currently, because a checker might become available later on, e.g. if a linter tool is installed, if a minor mode is enabled, etc.

Currently, users would have to explicitly enable Flycheck Mode, but with this PR Flycheck will automatically start to work.

Follow up of https://github.com/clojure-emacs/squiggly-clojure/issues/17