### PR TITLE
Fix flags passed to `rustc`.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6932,10 +6932,10 @@ Relative paths are relative to the file being checked."
 (flycheck-define-checker rust
   "A Rust syntax checker using Rust compiler.
 
-This syntax checker needs Rust 0.10 or newer.
+This syntax checker needs Rust 1.0.0 alpha or newer.
 
 See URL `http://www.rust-lang.org'."
-  :command ("rustc" "--no-trans"
+  :command ("rustc" "-Z" "no-trans"
             (option "--crate-type" flycheck-rust-crate-type)
             (option-flag "--test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path concat)


### PR DESCRIPTION
The flag `--no-trans` was replaced by `-Z no-trans` recently: https://github.com/rust-lang/rust/commit/953f294