### PR TITLE
Removed "-Z notrans" option from rustchecker since it no longer works

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6910,7 +6910,7 @@ Relative paths are relative to the file being checked."
 This syntax checker needs Rust 1.0.0 alpha or newer.
 
 See URL `http://www.rust-lang.org'."
-  :command ("rustc" "-Z" "no-trans"
+  :command ("rustc"
             (option "--crate-type" flycheck-rust-crate-type)
             (option-flag "--test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path concat)


### PR DESCRIPTION
The rust checker was not showing any errors and throwing messages similar to the following: `error: Unrecognized option: 'no-trans'.` I simply removed the `"-Z" "notrans"` options from the `:command` parameter to `flycheck-define-checker rust`. Now, error checking works again.