### PR TITLE
Added scss-lint checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ master (in development)
 - New syntax checkers:
 
   - R with `lintr` [GH-512]
+  - SCSS with `scss-lint` [GH-598]
 
 - New features:
 

--- a/doc/guide/languages.rst
+++ b/doc/guide/languages.rst
@@ -650,6 +650,9 @@ Scss
    .. option:: flycheck-scss-compass
       :auto:
 
+.. flyc-checker:: scss-lint
+   :auto:
+
 Shell script languages
 ======================
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -233,6 +233,7 @@ attention to case differences."
     scala
     scala-scalastyle
     scss
+    scss-lint
     sh-bash
     sh-posix-dash
     sh-posix-bash
@@ -7050,6 +7051,16 @@ See URL `http://sass-lang.com'."
           (optional "\r") "\n" (one-or-more " ") "on line " line " of " (file-name)
           line-end))
   :modes scss-mode)
+
+(flycheck-define-checker scss-lint
+  "A SCSS syntax checker using SCSS-Lint.
+
+See URL `https://github.com/causes/scss-lint'."
+  :command ("scss-lint" "--formatter" "default" source)
+  :error-patterns
+  ((error line-start (file-name) ":" line "[E]" (message) line-end)
+   (warning line-start (file-name) ":" line "[W]" (message) line-end))
+   :modes scss-mode)
 
 (flycheck-define-checker sh-bash
   "A Bash syntax checker using the Bash shell.

--- a/playbooks/roles/language-scss/tasks/main.yml
+++ b/playbooks/roles/language-scss/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Install SCSS linters
+  gem: name={{item}} user_install=no state=latest
+       executable={{ruby_gem_executable}}
+  with_items:
+    - scss-lint
+  tags:
+    - gem

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -5027,6 +5027,13 @@ Why not:
     (flycheck-ert-should-syntax-check
      "checkers/scss-compass.scss" 'scss-mode)))
 
+(flycheck-ert-def-checker-test scss-lint scss nil
+  (let ((flycheck-disabled-checkers '(scss)))
+    (flycheck-ert-should-syntax-check
+     "checkers/scss-error.scss" 'scss-mode
+     '(3 nil error "Syntax Error: Invalid CSS after \"...    c olor: red\": expected \"{\", was \";\""
+         :checker scss-lint))))
+
 (flycheck-ert-def-checker-test sh-bash (sh sh-bash) nil
   (flycheck-ert-should-syntax-check
    "checkers/sh-bash-syntax-error.bash" 'sh-mode


### PR DESCRIPTION
This adds scss-lint (https://github.com/causes/scss-lint) as a linter for scss-mode. It's far more powerful than scss itself (which is the only scss linter in flycheck at present).

The implementation is largely based on the existing scss linter.

Fixes #582