### PR TITLE
Make `flycheck-{gcc,clang}-args' safe buffer local variables

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5053,6 +5053,7 @@ See URL `http://www.methods.co.nz/asciidoc'."
   :modes adoc-mode)
 
 (flycheck-def-args-var flycheck-clang-args c/c++-clang
+  :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.22"))
 
 (flycheck-def-option-var flycheck-clang-blocks nil c/c++-clang
@@ -5232,6 +5233,7 @@ See URL `http://clang.llvm.org/'."
   :next-checkers ((warning . c/c++-cppcheck)))
 
 (flycheck-def-args-var flycheck-gcc-args c/c++-gcc
+  :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.22"))
 
 (flycheck-def-option-var flycheck-gcc-definitions nil c/c++-gcc


### PR DESCRIPTION
Variables `flycheck-{gcc,clang}-args` need to be safe buffer local variables
because different project may needs different values.