### PR TITLE
Don't overwrite minibuffer if cursor is not moved

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3747,7 +3747,9 @@ non-nil."
   ;; errors
   (with-demoted-errors "Flycheck error display error: %s"
     (flycheck-cancel-error-display-error-at-point-timer)
-    (when flycheck-mode
+    (when (and flycheck-mode
+               (not this-command)
+               (flycheck--message-command-p last-command))
       (-when-let (errors (flycheck-overlay-errors-at (point)))
         (flycheck-display-errors errors)))))
 
@@ -7249,6 +7251,60 @@ See URL `http://www.ruby-doc.org/stdlib-2.0.0/libdoc/yaml/rdoc/YAML.html'."
    (error line-start (file-name) ":" (zero-or-more not-newline) ":" (message)
           "at line " line " column " column  line-end))
   :modes yaml-mode)
+
+
+(defvar flycheck-message-commands-table-size 31
+  "Used by `flycheck-add-command' to initialize `flycheck-message-commands' obarray.
+It should probably never be necessary to do so, but if you
+choose to increase the number of buckets, you must do so before loading
+this file since the obarray is initialized at load time.
+Remember to keep it a prime number to improve hash performance.")
+
+(defvar flycheck-message-commands
+  ;; Don't define as `defconst' since it would then go to (read-only) purespace.
+  (make-vector flycheck-message-commands-table-size 0)
+  "Commands after which it is appropriate to print in the echo area.
+Flycheck does not try to print function arglists, etc., after just any command,
+because some commands print their own messages in the echo area and these
+functions would instantly overwrite them.  But `self-insert-command' as well
+as most motion commands are good candidates.
+This variable contains an obarray of symbols; do not manipulate it
+directly.  Instead, use `flycheck-add-command' and `flycheck-remove-command'.")
+
+(defun flycheck--message-command-p (command)
+  (and (symbolp command)
+       (intern-soft (symbol-name command) flycheck-message-commands)))
+
+(defun flycheck-add-command (&rest cmds)
+  (dolist (name cmds)
+    (and (symbolp name)
+         (setq name (symbol-name name)))
+    (set (intern name flycheck-message-commands) t)))
+
+(defun flycheck-add-command-completions (&rest names)
+  (dolist (name names)
+    (apply #'flycheck-add-command (all-completions name obarray 'commandp))))
+
+(defun flycheck-remove-command (&rest cmds)
+  (dolist (name cmds)
+    (and (symbolp name)
+         (setq name (symbol-name name)))
+    (unintern name flycheck-message-commands)))
+
+(defun flycheck-remove-command-completions (&rest names)
+  (dolist (name names)
+    (apply #'flycheck-remove-command
+           (all-completions name flycheck-message-commands))))
+
+;; Prime the command list.
+(flycheck-add-command-completions
+ "backward-" "beginning-of-" "delete-other-windows" "delete-window"
+ "down-list" "end-of-" "exchange-point-and-mark" "forward-" "goto-"
+ "handle-select-window" "indent-for-tab-command" "left-" "mark-page"
+ "mark-paragraph" "mouse-set-point" "move-" "move-beginning-of-"
+ "move-end-of-" "next-" "other-window" "pop-global-mark" "previous-"
+ "recenter" "right-" "scroll-" "self-insert-command" "split-window-"
+ "up-list")
 
 (provide 'flycheck)
 


### PR DESCRIPTION
This patch fixes a problem that flycheck always overwrites messages shown in the minibuffer immediately after running commands and users cannot get enough time to read the messages.
For example, when I point at an error by the cursor and find that the error says something like "not enough arguments in call to funcX", I would run the `go-def` command, which is provided by the go-mode, to check the definition of the "funcX" from `C-c C-d`. However, the `go-def` command shows the definition of the function in the minibuffer, and it immediately disappears as flycheck puts the same error message again in the minibuffer.
To solve this problem, this patch introduces a new local variable that stores the position of the cursor and  makes `flycheck-display-error-at-point-soon` invoke the timer only when the position is changed since the last time it was called.