### PR TITLE
Add luacheck syntax checker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ master (in development)
 - New syntax checkers:
 
   - R with `lintr` [GH-512]
+  - Lua with `luacheck` [GH-591] [GH-609]
 
 - New features:
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,7 +40,8 @@ substantial code to Flycheck:
 - [Per Nordlöw](https://github.com/nordlow) (syntax checkers for Ada, Fortran
   and Python, syntax checker name in error list)
 - [Peter Eisentraut](https://github.com/petere) (improvements to foodcritic)
-- [Peter Vasil](https://github.com/ptrv) (Lua and Go build/test syntax checkers)
+- [Peter Vasil](https://github.com/ptrv) (Lua, Luacheck and Go build/test
+  syntax checkers)
 - [Robert Zaremba](https://github.com/robert-zaremba) (gofmt syntax checker)
 - [Sean Gillespie](https://github.com/swgillespie) (help messages in Rust)
 - [Sean Salmon](https://github.com/phatcabbage) (platform-independent directory

--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -415,6 +415,14 @@ configuration files:
 
 @itemize
 @item
+@flyc{luacheck} (@uref{https://github.com/mpeterv/luacheck,Luacheck})
+with the following option:
+
+@table @asis
+@flycconfigfile{flycheck-luacheckrc,Luacheck}
+@end table
+
+@item
 @flyc{lua} (@uref{http://www.lua.org/,Lua compiler})
 @end itemize
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -208,6 +208,7 @@ attention to case differences."
     javascript-gjslint
     json-jsonlint
     less
+    luacheck
     lua
     perl
     perl-perlcritic
@@ -6355,6 +6356,28 @@ See URL `http://lesscss.org'."
           ", column " column ":"
           line-end))
   :modes less-css-mode)
+
+(flycheck-def-config-file-var flycheck-luacheckrc luacheck ".luacheckrc"
+  :safe #'stringp
+  :package-version '(flycheck . "0.23"))
+
+(flycheck-define-checker luacheck
+  "A Lua syntax checker using luacheck.
+
+See URL `https://github.com/mpeterv/luacheck'."
+  :command ("luacheck"
+            (config-file "--config" flycheck-luacheckrc)
+            "--formatter" "plain"
+            "--codes"                   ; Show warning codes
+            "--no-color"
+            source)
+  :error-patterns
+  ((warning line-start (file-name)
+            ":" line ":" column ": (" (id (and "W" (one-or-more digit)))
+            ") " (message) line-end)
+   (error line-start (file-name)
+          ":" line ":" column ":" (message) line-end))
+  :modes lua-mode)
 
 (flycheck-define-checker lua
   "A Lua syntax checker using the Lua compiler.

--- a/playbooks/roles/language-lua/defaults/main.yml
+++ b/playbooks/roles/language-lua/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+luacheck_version: '0.10.0'

--- a/playbooks/roles/language-lua/tasks/luacheck.yml
+++ b/playbooks/roles/language-lua/tasks/luacheck.yml
@@ -1,0 +1,10 @@
+- name: Download luacheck
+  get_url: url=https://github.com/mpeterv/luacheck/archive/{{luacheck_version}}.zip
+           dest=/usr/src/luacheck-{{luacheck_version}}.zip
+- name: Extract luacheck
+  unarchive: src=/usr/src/luacheck-{{luacheck_version}}.zip copy=no
+             dest=/opt
+- name: Install luacheck
+  command: /usr/bin/lua /opt/luacheck-{{luacheck_version}}/install.lua /usr/local
+  args:
+    chdir: /opt/luacheck-{{luacheck_version}}

--- a/playbooks/roles/language-lua/tasks/main.yml
+++ b/playbooks/roles/language-lua/tasks/main.yml
@@ -1,3 +1,5 @@
 - name: Install Lua
   apt: name='lua5.2' state=latest install_recommends=false
   sudo: true
+- include: luacheck.yml
+  sudo: true

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4418,11 +4418,35 @@ Why not:
    "checkers/less-syntax-error.less" 'less-css-mode
    '(1 1 error "Unrecognised input" :checker less)))
 
-(flycheck-ert-def-checker-test lua lua nil
+(flycheck-ert-def-checker-test luacheck lua syntax-error
   (flycheck-ert-should-syntax-check
    "checkers/lua-syntax-error.lua" 'lua-mode
-   '(5 nil error "unfinished string near '\"oh no'"
-       :checker lua)))
+   '(5 7 error "unfinished string"
+       :checker luacheck)))
+
+(flycheck-ert-def-checker-test luacheck lua warnings
+  (flycheck-ert-should-syntax-check
+   "checkers/lua-warnings.lua" 'lua-mode
+   '(1 1 warning "setting non-standard global variable 'global_var'"
+       :id "W111" :checker luacheck)
+   '(3 16 warning "unused function 'test'"
+       :id "W211" :checker luacheck)
+   '(3 21 warning "unused argument 'arg'"
+       :id "W212" :checker luacheck)
+   '(4 11 warning "variable 'var2' is never set"
+       :id "W221" :checker luacheck)))
+
+(flycheck-ert-def-checker-test luacheck lua no-warnings
+  (let ((flycheck-luacheckrc "luacheckrc"))
+    (flycheck-ert-should-syntax-check
+     "checkers/lua-warnings.lua" 'lua-mode)))
+
+(flycheck-ert-def-checker-test lua lua nil
+  (let ((flycheck-disabled-checkers '(luacheck)))
+    (flycheck-ert-should-syntax-check
+     "checkers/lua-syntax-error.lua" 'lua-mode
+     '(5 nil error "unfinished string near '\"oh no'"
+         :checker lua))))
 
 (flycheck-ert-def-checker-test perl perl nil
   (flycheck-ert-should-syntax-check

--- a/test/resources/checkers/lua-warnings.lua
+++ b/test/resources/checkers/lua-warnings.lua
@@ -1,0 +1,6 @@
+global_var = 1
+
+local function test(arg)
+    local var2
+    return var2
+end

--- a/test/resources/config-files/luacheckrc
+++ b/test/resources/config-files/luacheckrc
@@ -1,0 +1,2 @@
+global = false
+unused = false


### PR DESCRIPTION
Adding `luackeck` to the test VM is very simple:

After lua52 is installed you need following steps
1. Download and unpack latest luacheck from https://github.com/mpeterv/luacheck/archive/0.10.0.tar.gz
2. Run `sudo lua install.lua /usr/local` inside luacheck source folder

Now the `luacheck` executable is in `/usr/local/bin` which is probably in `PATH`