### PR TITLE
Add option to specify Perl include path

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -450,6 +450,13 @@ interpreter})
 @uref{https://metacpan.org/pod/Perl::Critic, Perl::Critic})
 @end enumerate
 
+The @flyc{perl} checker provides the following options:
+
+@table @asis
+@flycoption flycheck-perl-include-path
+A list of include directories, relative to the file being checked.
+@end table
+
 The @flyc{perl-perlcritic} checker provides the following option:
 
 @table @asis

--- a/flycheck.el
+++ b/flycheck.el
@@ -6450,11 +6450,23 @@ See URL `http://www.lua.org/'."
           ":" line ": " (message) line-end))
   :modes lua-mode)
 
+(flycheck-def-option-var flycheck-perl-include-path nil perl
+  "A list of include directories for Perl.
+
+The value of this variable is a list of strings, where each
+string is a directory to add to the include path of Perl.
+Relative paths are relative to the file being checked."
+  :type '(repeat (directory :tag "Include directory"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.24"))
+
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.
 
 See URL `http://www.perl.org'."
-  :command ("perl" "-w" "-c" source)
+  :command ("perl" "-w" "-c"
+            (option-list "-I" flycheck-perl-include-path)
+            source)
   :error-patterns
   ((error line-start (minimal-match (message))
           " at " (file-name) " line " line


### PR DESCRIPTION
This adds support for specifying include paths for Perl with the `-I` command line option.

I've tried to write a test case for this, but as I've never used ERT before I've simply failed to do so properly. Sorry.

In order to reproduce this you can use two files like this: have a Perl package `TestBase/TestPackage.pm` and a script `TestBase/test_script.pl`. In `test_script.pl` simply `use TestBase::TestPackage;`.

This will generate a warning on the `use` line that the module is not found unless the directory that `TestBase` is located it is given as an include directory.