### PR TITLE
Don't run .exs files through elixirc

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5643,7 +5643,7 @@ See URL `http://elixir-lang.org/'."
   :modes elixir-mode
   :predicate
   (lambda ()
-    (not (string-match "\.exs$" buffer-file-name))))
+    (not (string-equal "exs" (file-name-extension buffer-file-name)))))
 
 (defconst flycheck-this-emacs-executable
   (concat invocation-directory invocation-name)

--- a/flycheck.el
+++ b/flycheck.el
@@ -5640,7 +5640,10 @@ See URL `http://elixir-lang.org/'."
    (warning line-start (file-name) ":" line ": warning:" (message) line-end)
    ;; Warnings from older Elixir versions
    (warning line-start (file-name) ":" line ": " (message) line-end))
-  :modes elixir-mode)
+  :modes elixir-mode
+  :predicate
+  (lambda ()
+    (not (string-match "\.exs$" buffer-file-name))))
 
 (defconst flycheck-this-emacs-executable
   (concat invocation-directory invocation-name)


### PR DESCRIPTION
The elixirc tool does not compile .exs files, it evaluates them.  While
ultimately this is a problem with elixir, in the meantime I would like
to not evaluate code just because I have it open in a buffer.

Closes #627