### PR TITLE
Add JSCS checker

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -384,6 +384,8 @@ with the following option:
 
 @flyclanguage{Javascript}
 
+@enumerate
+@item
 @itemize
 @item
 @flyc{javascript-jshint} (@uref{http://jshint.com/,JSHint})
@@ -393,6 +395,9 @@ Or @flyc{javascript-eslint} (@uref{http://eslint.org/,ESLint})
 Or @flyc{javascript-gjslint}
 (@uref{https://developers.google.com/closure/utilities,Closure Linter})
 @end itemize
+@item
+@flyc{javascript-jscs} (@uref{http://jscs.info/,JSCS})
+@end enumerate
 
 The @flyc{javascript-eslint} checker provides the following option:
 
@@ -402,12 +407,13 @@ A directory with custom rules for ESLint.
 @flycconfigfile{flycheck-eslintrc,ESLint}
 @end table
 
-@flyc{javascript-jshint} and @flyc{javascript-gjslint} read
-configuration files:
+@flyc{javascript-jshint}, @flyc{javascript-gjslint} and @flyc{javascript-jscs}
+read configuration files:
 
 @table @asis
 @flycconfigfile{flycheck-jshintrc,JSHint}
 @flycconfigfile{flycheck-gjslintrc,Closure Linter}
+@flycconfigfile{flycheck-jscsrc,JSCS}
 @end table
 
 @flyclanguage{JSON}

--- a/playbooks/roles/language-javascript/tasks/main.yml
+++ b/playbooks/roles/language-javascript/tasks/main.yml
@@ -11,3 +11,7 @@
     - http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz
   tags:
     - pip
+- name: Install JSCS
+  npm: name=jscs global=yes state=latest
+  tags:
+    - npm

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4402,12 +4402,14 @@ Why not:
 
 (flycheck-ert-def-checker-test javascript-jshint javascript error-disabled
   :tags '(checkstyle-xml)
-  (flycheck-ert-should-syntax-check
-   "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)))
+  (let ((flycheck-disabled-checkers '(javascript-jscs)))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode))))
 
 (flycheck-ert-def-checker-test javascript-jshint javascript nil
   :tags '(checkstyle-xml)
-  (let ((flycheck-jshintrc "jshintrc"))
+  (let ((flycheck-jshintrc "jshintrc")
+        (flycheck-disabled-checkers '(javascript-jscs)))
     (flycheck-ert-should-syntax-check
      "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)
      '(4 9 warning "'foo' is defined but never used." :id "W098"
@@ -4423,7 +4425,7 @@ Why not:
 (flycheck-ert-def-checker-test javascript-eslint javascript warning
   :tags '(checkstyle-xml)
   (let ((flycheck-eslintrc "eslint.json")
-        (flycheck-disabled-checkers '(javascript-jshint)))
+        (flycheck-disabled-checkers '(javascript-jshint javascript-jscs)))
     (flycheck-ert-should-syntax-check
      "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)
      '(3 1 warning "Missing \"use strict\" statement." :id "strict"
@@ -4432,13 +4434,72 @@ Why not:
          :checker javascript-eslint))))
 
 (flycheck-ert-def-checker-test javascript-gjslint javascript nil
-  (let ((flycheck-disabled-checkers '(javascript-jshint javascript-eslint)))
+  (let ((flycheck-disabled-checkers
+         '(javascript-jshint javascript-eslint javascript-jscs)))
     (flycheck-ert-should-syntax-check
      "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)
      '(4 nil warning "Single-quoted string preferred over double-quoted string."
          :id "0131" :checker javascript-gjslint)
      '(4 nil warning "Extra space before \"]\""
          :id "0001" :checker javascript-gjslint))))
+
+(flycheck-ert-def-checker-test javascript-jscs javascript nil
+  :tags '(checkstyle-xml)
+  (let ((flycheck-jscsrc "jscsrc")
+        (flycheck-disabled-checkers
+         '(javascript-jshint javascript-eslint javascript-gjslint)))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript-style.js" '(js-mode js2-mode js3-mode)
+     '(4 3 error "Expected indentation of 2 characters"
+         :checker javascript-jscs))))
+
+(flycheck-ert-def-checker-test javascript-jscs javascript no-config
+  :tags '(checkstyle-xml)
+  (let ((flycheck-disabled-checkers
+         '(javascript-jshint javascript-eslint javascript-gjslint)))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript-style.js" '(js-mode js2-mode js3-mode))))
+
+(flycheck-ert-def-checker-test (javascript-jshint javascript-jscs)
+    javascript complete-chain
+  :tags '(checkstyle-xml)
+  (let ((flycheck-jshintrc "jshintrc")
+        (flycheck-jscsrc "jscsrc"))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)
+     '(4 3 error "Expected indentation of 2 characters"
+         :checker javascript-jscs)
+     '(4 9 warning "'foo' is defined but never used." :id "W098"
+         :checker javascript-jshint))))
+
+(flycheck-ert-def-checker-test (javascript-eslint javascript-jscs)
+    javascript complete-chain
+  :tags '(checkstyle-xml)
+  (let ((flycheck-eslintrc "eslint.json")
+        (flycheck-jscsrc "jscsrc")
+        (flycheck-disabled-checkers '(javascript-jshint)))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)
+     '(3 1 warning "Missing \"use strict\" statement." :id "strict"
+         :checker javascript-eslint)
+     '(4 3 error "Expected indentation of 2 characters"
+         :checker javascript-jscs)
+     '(4 8 warning "foo is defined but never used" :id "no-unused-vars"
+         :checker javascript-eslint))))
+
+(flycheck-ert-def-checker-test (javascript-gjslint javascript-jscs)
+    javascript complete-chain
+  :tags '(checkstyle-xml)
+  (let ((flycheck-jscsrc "jscsrc")
+        (flycheck-disabled-checkers '(javascript-jshint javascript-eslint)))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)
+     '(4 nil warning "Single-quoted string preferred over double-quoted string."
+         :id "0131" :checker javascript-gjslint)
+     '(4 nil warning "Extra space before \"]\""
+         :id "0001" :checker javascript-gjslint)
+     '(4 3 error "Expected indentation of 2 characters"
+         :checker javascript-jscs))))
 
 (flycheck-ert-def-checker-test json-jsonlint json nil
   (flycheck-ert-should-syntax-check

--- a/test/resources/checkers/javascript-style.js
+++ b/test/resources/checkers/javascript-style.js
@@ -1,0 +1,5 @@
+/** Tab indentation */
+
+(function() {
+	var foo = ["Hello world"];
+}());

--- a/test/resources/config-files/jscsrc
+++ b/test/resources/config-files/jscsrc
@@ -1,0 +1,3 @@
+{
+    "validateIndentation": 2
+}


### PR DESCRIPTION
[JSCS](http://jscs.info/) is a code style linter for JavaScript.

JSHint has deprecated code style options and they will be removed in the next major release of JSHint.
JSCS is referred by [JSHint Options](http://jshint.com/docs/options/) page.