### PR TITLE
Made scss-lint install task install scss_lint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ master (in development)
   - Add `flycheck-perl-include-path` to set include directories for Perl
     [GH-621]
 
+- Improvements:
+
+  - Updated `scss-lint` install task to install scss_lint rather than scss-lint [GH-641]
+
 0.23 (Apr 6, 2015)
 ==================
 

--- a/playbooks/roles/language-scss/tasks/main.yml
+++ b/playbooks/roles/language-scss/tasks/main.yml
@@ -2,7 +2,7 @@
   gem: name={{item}} user_install=no state=latest
        executable={{ruby_gem_executable}}
   with_items:
-    - scss-lint
+    - scss_lint
     - scss_lint_reporter_checkstyle
   tags:
     - gem


### PR DESCRIPTION
The scss-lint ruby gem has changed name to scss_lint (note the
underscore instead of a hyphen). The binary command (with the hyphen)
has stayed the same, but the name of the gem to install has changed.

See https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md for
details

This commit just updates the install task to install the gem using the
new name.