### PR TITLE
WIP: Add support for JavaScript Standard Style

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -390,6 +390,9 @@ Or @flyc{javascript-gjslint}
 @end itemize
 @item
 @flyc{javascript-jscs} (@uref{http://jscs.info/,JSCS})
+@item
+@flyc{javascript-standard}
+(@uref{https://github.com/feross/standard,JS Standard Style})
 @end enumerate
 
 The @flyc{javascript-eslint} checker provides the following option:

--- a/flycheck.el
+++ b/flycheck.el
@@ -206,6 +206,7 @@ attention to case differences."
     javascript-eslint
     javascript-gjslint
     javascript-jscs
+    javascript-standard
     json-jsonlint
     less
     luacheck
@@ -6388,6 +6389,14 @@ See URL `http://www.jscs.info'."
   :error-filter (lambda (errors)
                   (flycheck-remove-error-ids
                    (flycheck-sanitize-errors errors)))
+  :modes (js-mode js2-mode js3-mode))
+
+(flycheck-define-checker javascript-standard
+  "A code style linter for the JavaScript Standard Style.
+
+See URL `https://github.com/feross/standard'."
+  :command ("standard" source)
+  :error-patterns ((error line-start "  " (file-name) ":" line ":" column ":" (message) line-end))
   :modes (js-mode js2-mode js3-mode))
 
 (flycheck-define-checker json-jsonlint

--- a/playbooks/roles/language-javascript/tasks/main.yml
+++ b/playbooks/roles/language-javascript/tasks/main.yml
@@ -3,6 +3,7 @@
   with_items:
     - jshint
     - eslint
+    - standard
   tags:
     - npm
 - name: Install Closure linter

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4489,6 +4489,23 @@ Why not:
      '(4 3 error "Expected indentation of 2 characters"
          :checker javascript-jscs))))
 
+(flycheck-ert-def-checker-test javascript-standard javascript error
+  (let ((flycheck-checker 'javascript-standard))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript-style.js" '(js-mode js2-mode js3-mode)
+     '(3 9 error "Missing space before function parentheses."
+         :checker javascript-standard)
+     '(4 2 error "Expected indentation of 2 characters."
+         :checker javascript-standard)
+     '(4 5 error "foo is defined but never used"
+         :checker javascript-standard)
+     '(4 12 error "Strings must use singlequote."
+         :checker javascript-standard)
+     '(4 27 error "Extra semicolon."
+         :checker javascript-standard)
+     '(5 5 error "Extra semicolon."
+         :checker javascript-standard))))
+
 (flycheck-ert-def-checker-test json-jsonlint json nil
   (flycheck-ert-should-syntax-check
    "checkers/json-jsonlint-error.json" 'text-mode


### PR DESCRIPTION
**NOTE**: This is a work-in-progress. The pull-request is being temporarily
used to trigger Travis builds.

This commit introduces support for "standard", a tool to ensure code conforms
to the "JavaScript Standard Style" (https://github.com/feross/standard).