### PR TITLE
Add c/c++-clang-check checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -205,6 +205,7 @@ attention to case differences."
 (defcustom flycheck-checkers
   '(ada-gnat
     asciidoc
+    c/c++-clang-check
     c/c++-clang
     c/c++-gcc
     c/c++-cppcheck
@@ -5238,6 +5239,41 @@ This function determines the directory by looking at
       (file-name-directory fn)
     ;; If the buffer has no file name, fall back to its default directory
     default-directory))
+
+(flycheck-define-checker c/c++-clang-check
+  "A C/C++ syntax checker using Clang libtooling checker.
+
+See URL `http://clang.llvm.org/'."
+  :command ("clang-check"
+            "--extra-arg=-Wno-unknown-warning-option" ; silence GCC options
+            "--extra-arg=-Wno-null-character"         ; silence null
+            "--extra-arg=-fno-color-diagnostics"      ; Do not include color codes in output
+            "--extra-arg=-fno-caret-diagnostics"      ; Do not visually indicate the source
+            "--extra-arg=-fno-diagnostics-show-option" ; Do not show the corresponding
+            source-original)
+  :error-patterns
+  ((error line-start
+          (message "In file included from") " " (file-name) ":" line ":"
+          line-end)
+   (info line-start (file-name) ":" line ":" column
+         ": note: " (optional (message)) line-end)
+   (warning line-start (file-name) ":" line ":" column
+            ": warning: " (optional (message)) line-end)
+   (error line-start (file-name) ":" line ":" column
+          ": " (or "fatal error" "error") ": " (optional (message)) line-end))
+  :error-filter
+  (lambda (errors)
+    (let ((errors (flycheck-sanitize-errors errors)))
+      (dolist (err errors)
+        ;; Clang will output empty messages for #error/#warning pragmas without
+        ;; messages.  We fill these empty errors with a dummy message to get
+        ;; them past our error filtering
+        (setf (flycheck-error-message err)
+              (or (flycheck-error-message err) "no message")))
+      (flycheck-fold-include-levels errors "In file included from")))
+  :modes (c-mode c++-mode)
+  :next-checkers ((warning . c/c++-clang))
+  :predicate flycheck-buffer-saved-p)
 
 (flycheck-define-checker c/c++-clang
   "A C/C++ syntax checker using Clang.


### PR DESCRIPTION
The clang project provides a clang-check binary which can utilise a
compilation database. In a transitional Makefile based system you create
it with a tool called bear:

  bear make

Which will leave a compile_commands.json file in the root of your build.
When clang-check is called it will re-use the compile directives from
the json database. This eliminates the need to manually add include
patch to your flycheck setup.

As clang-check uses the path of the file to find the json database this
checker uses `source_original` and adds the :predicate
flycheck-buffer-saved-p.

Signed-off-by: Alex Bennée <alex.bennee@linaro.org>