### PR TITLE
Add clang check

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -54,15 +54,30 @@ of a warning category to enable.
 
 @flyclanguage{C/C++}
 
+Flycheck offers a number of different checkers for C/C++. One of the
+complications with these languages is the compilation environment can
+have a significant effect on the final code. The
+@flyc{c/c++-clang-check} checker offers perhaps the most automatic
+solution. The other checkers allow you to configure include paths and
+other compilation environment settings by way of customisation variables. 
+
 @enumerate
 @item
+@flyc{c/c++-clang-check} (syntax and semantic checking with
+@uref{http://clang.llvm.org/ClangCheck.html,clang-check})
+@item
 @flyc{c/c++-clang} (syntax and type check with
-@uref{http://clang.llvm.org/,Clang}) or @flyc{c/c++-gcc} (syntax and
-type check with @uref{https://gcc.gnu.org/, GCC}), and
+@uref{http://clang.llvm.org/,Clang})
+@item
+@flyc{c/c++-gcc} (syntax and type check with @uref{https://gcc.gnu.org/, GCC})
 @item
 @flyc{c/c++-cppcheck} (style and error check with
 @uref{http://cppcheck.sourceforge.net/,cppcheck}).
 @end enumerate
+
+@flyc{c/c++-clang-check} requires the creating of a
+@uref{http://clang.llvm.org/docs/JSONCompilationDatabase.html,compilation
+database}.
 
 @flyc{c/c++-clang} and @flyc{c/c++-gcc} provide the following options:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -205,6 +205,7 @@ attention to case differences."
 (defcustom flycheck-checkers
   '(ada-gnat
     asciidoc
+    c/c++-clang-check
     c/c++-clang
     c/c++-gcc
     c/c++-cppcheck
@@ -5238,6 +5239,53 @@ This function determines the directory by looking at
       (file-name-directory fn)
     ;; If the buffer has no file name, fall back to its default directory
     default-directory))
+
+(defun flycheck-can-run-clang-check-p ()
+  "Check if clang-check can be run.
+
+For clang-check to run we need both a compile_commands.json database
+and for the buffer to be saved"
+  (and (flycheck-buffer-saved-p)
+       (eq 0 (call-process "clang-check" nil nil nil "dummy_file.c"))))
+
+(flycheck-define-checker c/c++-clang-check
+  "A C/C++ syntax checker using Clang libtooling checker.
+
+See URL `http://clang.llvm.org/docs/ClangCheck.html'.
+
+This checker works best if you create a compilation database to hold
+all the compile options for each file. See the URL
+`http://clang.llvm.org/docs/JSONCompilationDatabase.html' for details.
+"
+  :command ("clang-check"
+            "--extra-arg=-Wno-unknown-warning-option" ; silence GCC options
+            "--extra-arg=-Wno-null-character"         ; silence null
+            "--extra-arg=-fno-color-diagnostics"      ; Do not include color codes in output
+            "--extra-arg=-fno-caret-diagnostics"      ; Do not visually indicate the source
+            "--extra-arg=-fno-diagnostics-show-option" ; Do not show the corresponding
+            source-original)
+  :error-patterns
+  ((error line-start
+          (message "In file included from") " " (file-name) ":" line ":"
+          line-end)
+   (info line-start (file-name) ":" line ":" column
+         ": note: " (optional (message)) line-end)
+   (warning line-start (file-name) ":" line ":" column
+            ": warning: " (optional (message)) line-end)
+   (error line-start (file-name) ":" line ":" column
+          ": " (or "fatal error" "error") ": " (optional (message)) line-end))
+  :error-filter
+  (lambda (errors)
+    (let ((errors (flycheck-sanitize-errors errors)))
+      (dolist (err errors)
+        ;; Clang will output empty messages for #error/#warning pragmas without
+        ;; messages.  We fill these empty errors with a dummy message to get
+        ;; them past our error filtering
+        (setf (flycheck-error-message err)
+              (or (flycheck-error-message err) "no message")))
+      (flycheck-fold-include-levels errors "In file included from")))
+  :modes (c-mode c++-mode)
+  :predicate flycheck-can-run-clang-check-p)
 
 (flycheck-define-checker c/c++-clang
   "A C/C++ syntax checker using Clang.


### PR DESCRIPTION
Here is v2 of the pull request (github wouldn't let me re-open the old one).

Changes:
  - adds some documentation
  - don't chain to the "legacy" checkers (which would get confusing)
  - add a proper predicate for testing for the compilation database
