### PR TITLE
add correct info level for `compilation-error-regexp-alist'

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4672,7 +4672,8 @@ Return a list representing PATTERN, suitable as element in
          (level (cdr pattern))
          (level-no (pcase level
                      (`error 2)
-                     (`warning 1))))
+                     (`warning 1)
+                     (`info 0))))
     (list regexp 1 2 3 level-no)))
 
 (defun flycheck-checker-compilation-error-regexp-alist (checker)


### PR DESCRIPTION
without this any info-level message gets a _TYPE_ of `nil` and this means the same as `2` (error):

> TYPE is 2 or nil for a real error or 1 for warning or 0 for info.

(from the documentation of `compilation-error-regexp-alist`)