### PR TITLE
Add :standard-input option to define-checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4306,8 +4306,10 @@ symbols in the command."
                                nil program args))
           (when (and (flycheck-checker-standard-input-p checker)
                      (process-live-p process))
-            (process-send-region process (point-min) (point-max))
-            (process-send-eof    process))
+            (save-restriction
+              (widen)
+              (process-send-region process (point-min) (point-max))
+              (process-send-eof    process)))
           (set-process-sentinel process 'flycheck-handle-signal)
           (set-process-filter process 'flycheck-receive-checker-output)
           (set-process-query-on-exit-flag process nil)


### PR DESCRIPTION
Merge either this PR or #671 , not both.

Adds :standard-input option to pass the buffer's contents into the lint process instead of creating a temporary file on disk.

Change eslint to use this new stdin process.

The rationale for this was the fact that we run a grunt watch, that gets confused with temporary files flycheck creates. You can change the filename flycheck creates, and grunt watch ignore files with a leading dot "." (i.e. a dotfile), however there is NO way for eslint to lint a dotfile. It's actually hard-coded to not allow reading dotfiles.

In any case, this avoids creating temporary files at all, and thus solves the problem.