### PR TITLE
add tags and i options to go build

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -315,6 +315,14 @@ respectively)
 @flyc{go-vet} provides the following option:
 
 @table @asis
+@flycoption flycheck-go-build-install-deps
+Install dependencies of the target package being built. Installing
+dependencies can dramatically speed up builds that have slow
+building dependent packages.
+
+@flycoption flycheck-go-build-tags
+Tags are a list of build tags to consider satisified during a build.
+
 @flycoption flycheck-go-vet-print-functions
 A list of print-like functions for go vet.  Go vet will check these
 functions for format string problems.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6330,14 +6330,30 @@ See URL `http://golang.org/cmd/go/' and URL
                    :message (if have-vet "present" "missing")
                    :face (if have-vet 'success '(bold error)))))))
 
+(flycheck-def-option-var flycheck-go-build-install-deps nil go-build
+  "Instruct go build to install dependencies `go build -i'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "0.24"))
+
+(flycheck-def-option-var flycheck-go-build-tags nil go-build
+  "Instruct go build to apply build sentinels `go build -tags 'dev debug'."
+  :type '(repeat (string :tag "Tag"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "0.24"))
+
 (flycheck-define-checker go-build
   "A Go syntax and type checker using the `go build' command.
 
 See URL `http://golang.org/cmd/go'."
-  ;; We need to use `temporary-file-name' instead of `null-device', because Go
-  ;; can't write to the null device.  It's “too magic”.  See
-  ;; https://code.google.com/p/go/issues/detail?id=4851 for details.
-  :command ("go" "build" "-o" temporary-file-name)
+  ;; We need to use `temporary-file-name' instead of `null-device',
+  ;; because Go can't write to the null device.
+  ;; See https://github.com/golang/go/issues/4851
+  :command ("go" "build"
+            (option-flag "-i" flycheck-go-build-install-deps)
+            ;; multiple tags are listed as "dev debug ..."
+            (option-list "-tags=" flycheck-go-build-tags concat)
+            "-o" temporary-file-name)
   :error-patterns
   ((error line-start (file-name) ":" line ":"
           (optional column ":") " "

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4364,6 +4364,18 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
                  (flycheck-ert-resource-filename
                   "checkers/emacs-lisp-syntax-error.el")))))
 
+(flycheck-ert-def-checker-test go-build go build-tags
+  (let* ((go-root (or (getenv "GOROOT") "/usr/local/go"))
+         (go-root-pkg (concat go-root "/src"))
+         (flycheck-go-build-tags '("dev")))
+    (flycheck-ert-with-env '(("GOPATH" . nil))
+      (flycheck-ert-should-syntax-check
+       "checkers/go/src/tags/main.go" 'go-mode
+       `(4 2 error ,(format "it ran)"
+                            go-root-pkg)
+           :checker go-build)))))
+
+
 (ert-deftest flycheck-go-package-name/package-file ()
   :tags '(language-go)
   (flycheck-ert-with-env

--- a/test/resources/checkers/go/src/tags/main.go
+++ b/test/resources/checkers/go/src/tags/main.go
@@ -1,0 +1,9 @@
+// +build dev
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("it ran")
+}


### PR DESCRIPTION
Adds some arguments to `go build` fixes #503 

`go build` supported flags:
- [x] tags: The -i flag installs the packages that are dependencies of the target.
- [x] i: a list of build tags to consider satisfied during the build

Unsupported
- race: enable data race detection.
- v: print the names of packages as they are compiled.
- x: print the commands.

These are useful, but highly project specific. It would be difficult to make these flags useful in a general case.
- ldflags
- asmflags