### PR TITLE
[Fix #680] Add a checker for Jade files

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -383,6 +383,13 @@ with the following option:
 
 @end itemize
 
+@flyclanguage{Jade}
+
+@itemize
+@item
+@flyc{jade} (using @uref{http://jade-lang.com/,Jade})
+@end itemize
+
 @flyclanguage{Javascript}
 
 @enumerate

--- a/flycheck.el
+++ b/flycheck.el
@@ -235,6 +235,7 @@ attention to case differences."
     haskell-ghc
     haskell-hlint
     html-tidy
+    jade
     javascript-jshint
     javascript-eslint
     javascript-gjslint
@@ -6342,6 +6343,20 @@ See URL `https://github.com/w3c/tidy-html5'."
             " column " column
             " - Warning: " (message) line-end))
   :modes (html-mode nxhtml-mode))
+
+(flycheck-define-checker jade
+  "A Jade syntax checker using the Jade compiler.
+
+See URL `http://jade-lang.com'."
+  :command ("jade" source)
+  :error-patterns
+  ;; The pattern is based on the pattern in
+  ;; https://github.com/tardyp/SublimeLinter-jade/blob/master/linter.py#L23;
+  ;; tweaked slightly to:
+  ;; Error: (\S+):(\d+).*\r?\n(?:.*\|.*\n)+.*\n(.*)
+  ((error line-start "Error: " (file-name) ":" line (zero-or-more not-newline)
+        (zero-or-one "\r") "\n" (one-or-more (and (zero-or-more not-newline) "|" (zero-or-more not-newline) "\n")) (zero-or-more not-newline) "\n" (message) line-end))
+  :modes jade-mode)
 
 (flycheck-def-config-file-var flycheck-jshintrc javascript-jshint ".jshintrc"
   :safe #'stringp)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4333,6 +4333,11 @@ Why not:
    '(8 5 warning "discarding unexpected <spam>"
        :checker html-tidy)))
 
+(flycheck-ert-def-checker-test jade jade nil
+   (flycheck-ert-should-syntax-check
+     "checkers/jade-error.jade" 'jade-mode
+     '(2 nil error "unexpected token \"indent\"" :checker jade)))
+
 (flycheck-ert-def-checker-test javascript-jshint javascript syntax-error
   :tags '(checkstyle-xml)
   ;; Silence JS2 and JS3 parsers

--- a/test/resources/checkers/jade-error.jade
+++ b/test/resources/checkers/jade-error.jade
@@ -1,0 +1,6 @@
+doctype html
+ html
+  head
+    title Jade Examples
+    body
+      h1 Markup example


### PR DESCRIPTION
Add a checker for Jade files …
Fix the lack of a checker for the Jade, a templating language
for Node.js (#680).

The jade compiler does not report column numbers. 

![image](https://cloud.githubusercontent.com/assets/23088/8666819/7847534a-29c4-11e5-96b1-d2055ec6cc6d.png)
