### PR TITLE
Fix for #675, Environment Names in puppet could contain underlines too

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6691,10 +6691,10 @@ See URL `http://puppetlabs.com/'."
   (
    ;; Patterns for Puppet 4
    (error line-start "Error: Could not parse for environment "
-          (one-or-more word) ":"
+          (one-or-more (in "a-z" "0-9" "_")) ":"
           (message) " at " (file-name) ":" line ":" column line-end)
    (error line-start "Error: Could not parse for environment "
-          (one-or-more word) ":"
+          (one-or-more (in "a-z" "0-9" "_")) ":"
           (message) " in file " (file-name) " at line " line ":" column
           line-end)
    ;; Errors from Puppet < 4


### PR DESCRIPTION
This would fix #675
The Name of Environments should match the regular Expression `\A[a-z0-9_]+\Z` (Ruby-notation) according to https://docs.puppetlabs.com/puppet/latest/reference/environments_creating.html#allowed-environment-names but `(one-or-more words)` doesnt allow underlines but whitespaces.