### PR TITLE
Add a 'filter' command to the error list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ master (in development)
 
 - New features:
 
+  - The error list can now be filtered by error level by pressing <kbd>f</kbd>
+  - Add `flycheck-error-list-minimum-level` to restrict error levels displayed
+    in the error list [GH-698] [GH-701]
   - Add `flycheck-perl-include-path` to set include directories for Perl
     [GH-621]
   - Add `flycheck-rust-args` to pass additional arguments to `rustc`

--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -779,6 +779,11 @@ In the error list window the following keybindings are available:
 Move to the next error.
 @item p
 Move to the previous error.
+@item f
+Filter the list, showing only errors whose level is above a threshold of
+your choice.
+@item F
+Remove all filters.
 @item q
 Hide the error list window.
 @item RET
@@ -794,6 +799,18 @@ For instance, you can sort errors by their level by moving the point
 onto the text of the @samp{Level} column, and then pressing @kbd{S}.
 You can achieve the same effect by clicking on the column header.
 @end table
+
+By default, the error list shows all errors in the current buffer.  In
+addition to filtering manually, you can restrict it to errors
+above certain levels with @code{flycheck-error-list-minimum-level}:
+
+@defopt flycheck-error-list-minimum-level
+The minimum level of errors to display in the error list.
+
+If set to an error level, only displays errors whose error level
+is at least as severe as this one in the error list.  If nil,
+display all errors.
+@end defopt
 
 @vindex flycheck-error-list-highlight
 


### PR DESCRIPTION
Pressing "f" in the error list now prompts for an error level. All
errors whose severity level is below that level are hidden. Pressing "F"
resets the filter. The current filter is shown in the mode line. The
docs mention the two new commands.

Changing filter levels scrolls back to the top of the error list. This
is to avoid confusing behavior when filters are removed. Filtering out
the first entry of the error list, for example, moves the second entry
to the top. If we didn't scroll back up, removing the filter would leave
the first entry invisible, causing confusion.

Closes #698.

Should closing and reopening the error list reset the filter? If so 
```
  (unless (get-buffer flycheck-error-list-buffer)
    (with-current-buffer (get-buffer-create flycheck-error-list-buffer)
      (flycheck-error-list-mode)))
```
should be changed to 
```
  (unless (get-buffer flycheck-error-list-buffer)
    (setq flycheck-error-list-minimum-level nil)
    (with-current-buffer (get-buffer-create flycheck-error-list-buffer)
      (flycheck-error-list-mode)))
```