### PR TITLE
Fix source arguments of JSHint and JSCS checkers

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6359,7 +6359,7 @@ See URL `http://jade-lang.com'."
 See URL `http://www.jshint.com'."
   :command ("jshint" "--checkstyle-reporter"
             (config-file "--config" flycheck-jshintrc)
-            source)
+            source-inplace)
   :error-parser flycheck-parse-checkstyle
   :error-filter flycheck-dequalify-error-ids
   :modes (js-mode js2-mode js3-mode)
@@ -6454,7 +6454,7 @@ error."
 See URL `http://www.jscs.info'."
   :command ("jscs" "--reporter=checkstyle"
             (config-file "--config" flycheck-jscsrc)
-            source)
+            source-inplace)
   :error-parser flycheck-parse-jscs
   :error-filter (lambda (errors)
                   (flycheck-remove-error-ids

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4367,6 +4367,12 @@ Why not:
      '(4 9 warning "'foo' is defined but never used." :id "W098"
          :checker javascript-jshint))))
 
+(flycheck-ert-def-checker-test javascript-jshint javascript ignored
+  :tags '(checkstyle-xml)
+  (let ((flycheck-disabled-checkers '(javascript-jscs)))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript/ignored/warnings.js" '(js-mode js2-mode js3-mode))))
+
 (flycheck-ert-def-checker-test javascript-eslint javascript error
   :tags '(checkstyle-xml)
   (let ((flycheck-disabled-checkers '(javascript-jshint)))
@@ -4413,6 +4419,13 @@ Why not:
      "checkers/javascript-style.js" '(js-mode js2-mode js3-mode)
      '(1 nil warning "No JSCS configuration found.  Set `flycheck-jscsrc' for JSCS"
          :checker javascript-jscs))))
+
+(flycheck-ert-def-checker-test javascript-jscs javascript ignored
+  :tags '(checkstyle-xml)
+  (let ((flycheck-disabled-checkers
+         '(javascript-jshint javascript-eslint javascript-gjslint)))
+    (flycheck-ert-should-syntax-check
+     "checkers/javascript/ignored/style.js" '(js-mode js2-mode js3-mode))))
 
 (flycheck-ert-def-checker-test (javascript-jshint javascript-jscs)
     javascript complete-chain

--- a/test/resources/checkers/javascript/.jscsrc
+++ b/test/resources/checkers/javascript/.jscsrc
@@ -1,0 +1,4 @@
+{
+    "validateIndentation": 2,
+    "excludeFiles": ["ignored/*.js"]
+}

--- a/test/resources/checkers/javascript/.jshintignore
+++ b/test/resources/checkers/javascript/.jshintignore
@@ -1,0 +1,1 @@
+ignored/*.js

--- a/test/resources/checkers/javascript/.jshintrc
+++ b/test/resources/checkers/javascript/.jshintrc
@@ -1,0 +1,3 @@
+{
+    "unused": "strict"
+}

--- a/test/resources/checkers/javascript/ignored/style.js
+++ b/test/resources/checkers/javascript/ignored/style.js
@@ -1,0 +1,5 @@
+/** Tab indentation */
+
+(function() {
+	var foo = ["Hello world"];
+}());

--- a/test/resources/checkers/javascript/ignored/warnings.js
+++ b/test/resources/checkers/javascript/ignored/warnings.js
@@ -1,0 +1,5 @@
+/** An unused variable, and some invalid spacing */
+
+(function() {
+    var foo = ["Hello world" ];
+}());


### PR DESCRIPTION
It is necessary to use `source-inplace` instead of `source` to support [.jshintignore](http://jshint.com/docs/cli/#ignoring-files) file in JSHint and [excludeFiles](http://jscs.info/overview.html#excludefiles) option in JSCS, for example.

This is same fix as ESLint checker (see #447).