### PR TITLE
Force format to be 'default' for flake8

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6790,6 +6790,7 @@ Update the error level of ERR according to
 Requires Flake8 2.0 or newer. See URL
 `https://pypi.python.org/pypi/flake8'."
   :command ("flake8"
+            "--format=default"
             (config-file "--config" flycheck-flake8rc)
             (option "--max-complexity" flycheck-flake8-maximum-complexity nil
                     flycheck-option-int)


### PR DESCRIPTION
It is possible if specifying a config file that the config will set 'format'  equal to 'pylint'

this creates errors like:

```
Suspicious state from syntax checker python-flake8: Checker python-flake8 returned non-zero exit code 1, but no errors from output: /tmp/flycheck3327LqN/s3_dataset.py:132: [E303] too many blank lines (2)
    @access.public
    ^
/tmp/flycheck3327LqN/s3_dataset.py:137: [E501] line too long (84 > 80 characters)
        params['selectedItems'] = json_util.loads(params.get("selectedItems", "[]"))
                                                                                ^
/tmp/flycheck3327LqN/s3_dataset.py:149: [E501] line too long (85 > 80 characters)
        if len(set([i for i in minerva_metadata.items() if i[0] not in valid_keys]) ^
                                                                                ^
/tmp/flycheck3327LqN/s3_dataset.py:160: [E303] too many blank lines (2)
    updateDataset.description = (
    ^
```

by adding '--format=default' to the flake8 ```:command``` list this overrides the configuration specific value and forces the correct output format.