### PR TITLE
Add pylint error symbol to message

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -590,9 +590,14 @@ The maximum length of lines for Flake8.
 @flycconfigfile{flycheck-flake8rc,Flake8}
 @end table
 
-@flyc{python-pylint} reads a configuration file:
+@flyc{python-pylint} provides the following options:
 
 @table @asis
+@flycoption flycheck-pylint-use-symbolic-id
+A boolean indicating whether to report symbolic or numeric message identifiers.
+For example, whether to report a message type as no-name-in-module, or E0611.
+On by default.
+
 @flycconfigfile{flycheck-pylintrc,Pylint}
 @end table
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7101,6 +7101,16 @@ Requires Flake8 2.0 or newer. See URL
                               ".pylintrc"
   :safe #'stringp)
 
+(flycheck-def-option-var flycheck-pylint-use-symbolic-id t python-pylint
+  "Whether to use pylint message symbols or message codes.
+
+A pylint message has both an opaque identifying code (such as `F0401') and a
+more meaningful symbolic code (such as `import-error').  This option governs
+which should be used and reported to the user."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "0.24"))
+
 (flycheck-define-checker python-pylint
   "A Python syntax and style checker using Pylint.
 
@@ -7109,7 +7119,10 @@ This syntax checker requires Pylint 1.0 or newer.
 See URL `http://www.pylint.org/'."
   ;; -r n disables the scoring report
   :command ("pylint" "-r" "n"
-            "--msg-template" "{path}:{line}:{column}:{C}:{msg_id}:{msg}"
+            "--msg-template"
+            (eval (if flycheck-pylint-use-symbolic-id
+                      "{path}:{line}:{column}:{C}:{symbol}:{msg}"
+                    "{path}:{line}:{column}:{C}:{msg_id}:{msg}"))
             (config-file "--rcfile" flycheck-pylintrc)
             ;; Need `source-inplace' for relative imports (e.g. `from .foo
             ;; import bar'), see https://github.com/flycheck/flycheck/issues/280

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4870,10 +4870,60 @@ Why not:
         (python-indent-guess-indent-offset nil)) ; Silence Python Mode
     (flycheck-ert-should-syntax-check
      "checkers/python-syntax-error.py" 'python-mode
-     '(3 1 error "invalid syntax" :id "E0001" :checker python-pylint))))
+     '(3 1 error "invalid syntax" :id "syntax-error" :checker python-pylint))))
 
 (flycheck-ert-def-checker-test python-pylint python nil
   (let ((flycheck-disabled-checkers '(python-flake8)))
+    (flycheck-ert-should-syntax-check
+     "checkers/python/test.py" 'python-mode
+     '(1 1 info "Missing module docstring" :id "missing-docstring" :checker python-pylint)
+     '(4 1 error "Unable to import 'spam'" :id "import-error" :checker python-pylint)
+     '(5 1 error "No name 'antigravit' in module 'python'" :id "no-name-in-module"
+         :checker python-pylint)
+     '(5 1 warning "Unused import antigravit" :id "unused-import"
+         :checker python-pylint)
+     '(7 1 info "Missing class docstring" :id "missing-docstring" :checker python-pylint)
+     '(9 5 info "Invalid method name \"withEggs\"" :id "invalid-name"
+         :checker python-pylint)
+     '(9 5 info "Missing method docstring" :id "missing-docstring" :checker python-pylint)
+     '(9 5 warning "Method could be a function" :id "no-self-use"
+         :checker python-pylint)
+     '(10 16 warning "Used builtin function 'map'" :id "bad-builtin"
+          :checker python-pylint)
+     '(12 1 info "No space allowed around keyword argument assignment"
+          :id "bad-whitespace" :checker python-pylint)
+     '(12 5 info "Missing method docstring" :id "missing-docstring" :checker python-pylint)
+     '(12 5 warning "Method could be a function" :id "no-self-use"
+          :checker python-pylint)
+     '(14 16 error "Module 'sys' has no 'python_version' member" :id "no-member"
+          :checker python-pylint)
+     '(15 1 info "Unnecessary parens after u'print' keyword" :id "superfluous-parens"
+          :checker python-pylint)
+     '(17 1 info "Unnecessary parens after u'print' keyword" :id "superfluous-parens"
+          :checker python-pylint)
+     '(22 1 error "Undefined variable 'antigravity'" :id "undefined-variable"
+          :checker python-pylint))))
+
+(flycheck-ert-def-checker-test python-pylint python disabled-warnings
+  (let ((flycheck-pylintrc "pylintrc")
+        (flycheck-disabled-checkers '(python-flake8)))
+    (flycheck-ert-should-syntax-check
+     "checkers/python/test.py" 'python-mode
+     '(4 1 error "Unable to import 'spam'" :id "import-error" :checker python-pylint)
+     '(5 1 error "No name 'antigravit' in module 'python'" :id "no-name-in-module"
+         :checker python-pylint)
+     '(5 1 warning "Unused import antigravit" :id "unused-import"
+         :checker python-pylint)
+     '(10 16 warning "Used builtin function 'map'" :id "bad-builtin"
+          :checker python-pylint)
+     '(14 16 error "Module 'sys' has no 'python_version' member" :id "no-member"
+          :checker python-pylint)
+     '(22 1 error "Undefined variable 'antigravity'" :id "undefined-variable"
+          :checker python-pylint))))
+
+(flycheck-ert-def-checker-test python-pylint python no-symbolic-id
+  (let ((flycheck-disabled-checkers '(python-flake8))
+        (flycheck-pylint-use-symbolic-id nil))
     (flycheck-ert-should-syntax-check
      "checkers/python/test.py" 'python-mode
      '(1 1 info "Missing module docstring" :id "C0111" :checker python-pylint)
@@ -4900,23 +4950,6 @@ Why not:
      '(15 1 info "Unnecessary parens after u'print' keyword" :id "C0325"
           :checker python-pylint)
      '(17 1 info "Unnecessary parens after u'print' keyword" :id "C0325"
-          :checker python-pylint)
-     '(22 1 error "Undefined variable 'antigravity'" :id "E0602"
-          :checker python-pylint))))
-
-(flycheck-ert-def-checker-test python-pylint python disabled-warnings
-  (let ((flycheck-pylintrc "pylintrc")
-        (flycheck-disabled-checkers '(python-flake8)))
-    (flycheck-ert-should-syntax-check
-     "checkers/python/test.py" 'python-mode
-     '(4 1 error "Unable to import 'spam'" :id "F0401" :checker python-pylint)
-     '(5 1 error "No name 'antigravit' in module 'python'" :id "E0611"
-         :checker python-pylint)
-     '(5 1 warning "Unused import antigravit" :id "W0611"
-         :checker python-pylint)
-     '(10 16 warning "Used builtin function 'map'" :id "W0141"
-          :checker python-pylint)
-     '(14 16 error "Module 'sys' has no 'python_version' member" :id "E1101"
           :checker python-pylint)
      '(22 1 error "Undefined variable 'antigravity'" :id "E0602"
           :checker python-pylint))))


### PR DESCRIPTION
This pull request adds the pylint message symbol to the pylint checker.  After this change messages appear in emacs as:

    Unable to import 'spam' (import-error) [F0401]

instead of

    Unable to import 'spam' [F0401]

The motivation is following ... I sometimes need to add pylint directives to my code to suppress particular messages around particular snippets.  And its better practice to add those directives using meaningful message symbols rather than message ids, for the benefit of readers.  For example:

    ### pylint: disable=import-error
    <code>

With this change, users can see the symbol they want to disable right there in their emacs, without having to look it up.