### PR TITLE
Add checker for groovy programming language.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ master (in development)
   - Javascript with `jscs` [GH-634] and `standard` [GH-644]
   - Jade [GH-686]
   - SQL with `sqllint` [GH-691]
+  - Groovy [GH-715]
 
 - New features:
 

--- a/Cask
+++ b/Cask
@@ -18,6 +18,7 @@
  (depends-on "erlang")
  (depends-on "ess")
  (depends-on "go-mode")
+ (depends-on "groovy-mode")
  (depends-on "haml-mode")
  (depends-on "handlebars-mode")
  (depends-on "haskell-mode")

--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -320,6 +320,14 @@ A list of print-like functions for go vet.  Go vet will check these
 functions for format string problems.
 @end table
 
+@flyclanguage{Groovy}
+
+@itemize
+@item
+@flyc{groovy} (syntax check using groovy compiler API (@uref{http://www.groovy-lang.org/}))
+
+@end itemize
+
 @flyclanguage{Haml}
 
 @itemize

--- a/flycheck.el
+++ b/flycheck.el
@@ -191,6 +191,7 @@ attention to case differences."
     go-build
     go-test
     go-errcheck
+    groovy
     haml
     handlebars
     haskell-ghc
@@ -6331,6 +6332,30 @@ See URL `https://github.com/kisielk/errcheck'."
     ;; We need a valid package name, since errcheck only works on entire
     ;; packages, and can't check individual Go files.
     (and (flycheck-buffer-saved-p) (flycheck-go-package-name))))
+
+(flycheck-define-checker groovy
+  "A groovy syntax checker using groovy compiler API.
+
+See `http://www.groovy-lang.org/mailing-lists.html#nabble-td365810'
+and `http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/CompilationUnit.html#compile%28int%29'."
+
+  :command ("groovy" "-e"
+            "import org.codehaus.groovy.control.*
+
+file = new File(args[0])
+unit = new CompilationUnit()
+unit.addSource(file)
+
+try {
+    unit.compile(Phases.CONVERSION)
+} catch (MultipleCompilationErrorsException e) {
+    e.errorCollector.write(new PrintWriter(System.out, true), null)
+}
+"
+            source)
+  :error-patterns
+  ((error line-start (file-name) ": " line ":" (message) " @ line " line ", column " column "." line-end))
+  :modes groovy-mode)
 
 (flycheck-define-checker haml
   "A Haml syntax checker using the Haml compiler.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4263,6 +4263,12 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
      '(9 9 warning "Ignored `error` returned from `os.Stat(\"enoent\")`"
          :checker go-errcheck))))
 
+(flycheck-ert-def-checker-test groovy groovy syntax-error
+  (require 'cl) ; workaround https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes/issues/11
+  (flycheck-ert-should-syntax-check
+   "checkers/groovy_error.groovy" 'groovy-mode
+   '(2 14 error "unexpected token: {" :checker groovy)))
+
 (flycheck-ert-def-checker-test haml haml nil
   (flycheck-ert-should-syntax-check
    "checkers/haml-error.haml" 'haml-mode

--- a/test/resources/checkers/groovy_error.groovy
+++ b/test/resources/checkers/groovy_error.groovy
@@ -1,0 +1,3 @@
+class Foo {
+    def foo( {}
+}


### PR DESCRIPTION
groovyc cannot be used here because it cannot be made to stop at syntax
check. Instead use groovy compiler API and compile up to the phase
`CONVERSION`.

References for an idea:

- http://www.groovy-lang.org/mailing-lists.html#nabble-td365810
- https://github.com/groovy/groovy-core/blob/master/src/main/org/codehaus/groovy/control/ErrorCollector.java

Fix #715.