### PR TITLE
Changes eslint checker to use 1-based columns

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6528,7 +6528,7 @@ See URL `https://github.com/eslint/eslint'."
                                          (match-string 1 s))
                                    "")
                                  (flycheck-error-message err))))
-                        (flycheck-sanitize-errors (flycheck-increment-error-columns errors)))
+                        (flycheck-sanitize-errors errors))
                   errors)
   :modes (js-mode js2-mode js3-mode)
   :next-checkers ((warning . javascript-jscs)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4380,7 +4380,7 @@ Why not:
         (flycheck-disabled-checkers '(javascript-jshint javascript-jscs)))
     (flycheck-ert-should-syntax-check
      "checkers/javascript-warnings.js" '(js-mode js2-mode js3-mode)
-     '(3 2 warning "Missing \"use strict\" statement." :id "strict"
+     '(3 2 warning "Use the function form of \"use strict\"." :id "strict"
          :checker javascript-eslint)
      '(4 9 warning "foo is defined but never used" :id "no-unused-vars"
          :checker javascript-eslint))))


### PR DESCRIPTION
Eslint went from 0-based to 1-based columns in 1.0.0

- Reverts the code change in #640
- Updates the test case to match new warning message in Eslint 1.0.0