### PR TITLE
Feed syntax checkers from standard input

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,11 @@ This is a model commit message:
 
     - Use a hanging indent
 
-[Git Commit Mode][] and [Magit][] provide a major mode for Git commit messages,
-which helps you to comply to these guidelines.
+[Git Commit][] and [Magit][] provide Emacs mode for Git commit messages, which
+helps you to comply to these guidelines.
 
 [Tim Pope's guidelines]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
-[Git Commit Mode]: https://github.com/magit/git-modes/
+[Git Commit]: https://github.com/magit/magit/
 [Magit]: https://github.com/magit/magit/
 
 Contributing syntax checkers

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -37,6 +37,7 @@ substantial code to Flycheck:
 - [Mario Rodas](https://github.com/marsam)
 - [Mark Karpov](https://github.com/mrkkrp)
 - [Mark Hellewell](https://github.com/markhellewell)
+- [Matthew Curry](https://github.com/strawhatguy)
 - [Matthias Dahl](https://github.com/BinaryKhaos)
 - [Miro Bezjak](https://github.com/mbezjak)
 - [Mitch Tishmack](https://github.com/mitchty)

--- a/flycheck.el
+++ b/flycheck.el
@@ -7864,11 +7864,14 @@ See URL `http://sass-lang.com'."
   "A Bash syntax checker using the Bash shell.
 
 See URL `http://www.gnu.org/software/bash/'."
-  :command ("bash" "--norc" "-n" "--" source)
-  :error-patterns ((error line-start
-                          (file-name) ":" (one-or-more (not (any digit)))
-                          line (zero-or-more " ") ":" (zero-or-more " ")
-                          (message) line-end))
+  :command ("bash" "--norc" "-n")
+  :standard-input t
+  :error-patterns
+  ((error line-start
+          (one-or-more (not (any ":"))) ; Bash executable path
+          ":" (one-or-more (not (any digit)))
+          line (zero-or-more " ") ":" (zero-or-more " ")
+          (message) line-end))
   :modes sh-mode
   :predicate (lambda () (eq sh-shell 'bash))
   :next-checkers ((warning . sh-shellcheck)))
@@ -7877,9 +7880,12 @@ See URL `http://www.gnu.org/software/bash/'."
   "A POSIX Shell syntax checker using the Dash shell.
 
 See URL `http://gondor.apana.org.au/~herbert/dash/'."
-  :command ("dash" "-n" source)
+  :command ("dash" "-n")
+  :standard-input t
   :error-patterns
-  ((error line-start (file-name) ": " line ": " (backref 1) ": " (message)))
+  ((error line-start
+          (one-or-more (not (any ":"))) ; Dash executable path
+          ": " line ": " (backref 1) ": " (message)))
   :modes sh-mode
   :predicate (lambda () (eq sh-shell 'sh))
   :next-checkers ((warning . sh-shellcheck)))
@@ -7888,10 +7894,12 @@ See URL `http://gondor.apana.org.au/~herbert/dash/'."
   "A POSIX Shell syntax checker using the Bash shell.
 
 See URL `http://www.gnu.org/software/bash/'."
-  :command ("bash" "--posix" "--norc" "-n" "--" source)
+  :command ("bash" "--posix" "--norc" "-n")
+  :standard-input t
   :error-patterns
   ((error line-start
-          (file-name) ":" (one-or-more (not (any digit)))
+          (one-or-more (not (any ":"))) ; Bash executable path
+          ":" (one-or-more (not (any digit)))
           line (zero-or-more " ") ":" (zero-or-more " ")
           (message) line-end))
   :modes sh-mode
@@ -7902,6 +7910,8 @@ See URL `http://www.gnu.org/software/bash/'."
   "A Zsh syntax checker using the Zsh shell.
 
 See URL `http://www.zsh.org/'."
+  ;; We can't use standard input for Zsh, because Zsh doesn't include error
+  ;; positions when reading from standard input :(
   :command ("zsh" "--no-exec" "--no-globalrcs" "--no-rcs" source)
   :error-patterns
   ((error line-start (file-name) ":" line ": " (message) line-end))

--- a/flycheck.el
+++ b/flycheck.el
@@ -5547,16 +5547,18 @@ See URL `http://clang.llvm.org/'."
                   (pcase major-mode
                     (`c++-mode "c++")
                     (`c-mode "c")))
-            source)
+            ;; Read from standard input
+            "-")
+  :standard-input t
   :error-patterns
   ((error line-start
-          (message "In file included from") " " (file-name) ":" line ":"
-          line-end)
-   (info line-start (file-name) ":" line ":" column
+          (message "In file included from") " " (or "<stdin>" (file-name))
+          ":" line ":" line-end)
+   (info line-start (or "<stdin>" (file-name)) ":" line ":" column
          ": note: " (optional (message)) line-end)
-   (warning line-start (file-name) ":" line ":" column
+   (warning line-start (or "<stdin>" (file-name)) ":" line ":" column
             ": warning: " (optional (message)) line-end)
-   (error line-start (file-name) ":" line ":" column
+   (error line-start (or "<stdin>" (file-name)) ":" line ":" column
           ": " (or "fatal error" "error") ": " (optional (message)) line-end))
   :error-filter
   (lambda (errors)


### PR DESCRIPTION
Supersedes #673 

# Remaining tasks

- [ ] Change syntax checkers to use standard input as far as possible
- [ ] Add documentation
- [x] Adapt `flycheck-compile`
- [ ] Fix tests

Test failure:

```
Test flycheck-define-checker/sh-bash/default backtrace:
  signal(error ("Process flycheck-sh-bash not running"))
  (condition-case err (let* ((checker (flycheck-get-checker-for-buffer
  (if (flycheck-running-p) nil (run-hooks (quote flycheck-before-synta
  (if flycheck-mode (if (flycheck-running-p) nil (run-hooks (quote fly
  flycheck-buffer()
  flycheck-ert-buffer-sync()
```
 
# Updating syntax checkers

Checked syntax checkers use standard input, checkers which can't use standard input are struck through, with reasons explained.

- [x] ~~ada-gnat~~ (can't read from standard input)
- [ ] asciidoc
- [x] c/c++-clang
- [ ] c/c++-gcc
- [ ] c/c++-cppcheck
- [ ] cfengine
- [ ] chef-foodcritic
- [ ] coffee
- [ ] coffee-coffeelint
- [ ] coq
- [ ] css-csslint
- [ ] d-dmd
- [x] ~~emacs-lisp~~ (can't read from standard input)
- [x] emacs-lisp-checkdoc (can't read from standard input)
- [ ] erlang
- [ ] eruby-erubis
- [ ] fortran-gfortran
- [ ] go-gofmt
- [ ] go-golint
- [ ] go-vet
- [ ] go-build
- [ ] go-test
- [ ] go-errcheck
- [ ] groovy
- [ ] haml
- [ ] handlebars
- [x] ~~haskell-stack-ghc~~ (GHC can't read from standard input)
- [x] ~~haskell-ghc~~ (GHC can't read from standard input)
- [ ] haskell-hlint
- [ ] html-tidy
- [ ] jade
- [ ] javascript-jshint
- [ ] javascript-eslint
- [ ] javascript-gjslint
- [ ] javascript-jscs
- [ ] javascript-standard
- [ ] json-jsonlint
- [ ] less
- [ ] luacheck
- [ ] lua
- [ ] perl
- [ ] perl-perlcritic
- [ ] php
- [ ] php-phpmd
- [ ] php-phpcs
- [ ] puppet-parser
- [ ] puppet-lint
- [ ] python-flake8
- [ ] python-pylint
- [ ] python-pycompile
- [ ] r-lintr
- [ ] racket
- [ ] rpm-rpmlint
- [ ] rst
- [ ] rst-sphinx
- [x] ruby-rubocop
- [x] ~~ruby-rubylint~~ (can't read from stdin)
- [x] ruby
- [x] ruby-jruby
- [ ] rust
- [ ] sass
- [ ] scala
- [ ] scala-scalastyle
- [ ] scss-lint
- [ ] scss
- [ ] sh-bash
- [ ] sh-posix-dash
- [ ] sh-posix-bash
- [x] ~~sh-zsh~~ (zsh doesn't include column numbers when reading from standard input :disappointed:)
- [ ] sh-shellcheck
- [ ] slim
- [ ] sql-sqlint
- [ ] tex-chktex
- [ ] tex-lacheck
- [ ] texinfo
- [ ] verilog-verilator
- [ ] xml-xmlstarlet
- [ ] xml-xmllint
- [ ] yaml-jsyaml
- [ ] yaml-ruby