### PR TITLE
Fix "Suspicious state" go-errcheck error

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6312,7 +6312,7 @@ See URL `https://github.com/kisielk/errcheck'."
   :command ("errcheck" (eval (flycheck-go-package-name)))
   :error-patterns
   ((warning line-start
-            (file-name) ":" line ":" column (one-or-more "\t")
+            (file-name) ":" line ":" column (or (one-or-more "\t") ": ")
             (message)
             line-end))
   :error-filter


### PR DESCRIPTION
`go-errcheck` requires the entire package that the file is in to build successfully in order for it to do its extra error checks.

`go-errcheck` does run after `go-build` by default.  But `go-build` only requires a single file to build.

So let's say you're editing a file which builds successfully, with another file in the same directory that doesn't build successfully.  `errcheck` will print out build error messages which correspond to the other file in the directory.

But here's the problem: build error messages printed by errcheck are formatted differently than errcheck's own errors!  This leads to messages like:

```
Suspicious state from syntax checker go-errcheck: Checker go-errcheck returned non-zero exit code 2, but no errors from output: /Users/glasser/go/src/github.com/foo/bar/baz/baz.go:156:69: too few arguments in call to someFunc
```

(where baz.go is a different file in the same directory as the current file)

Note that this has `: ` after the column name instead of a tab.

So this fix recognizes the build error format with `: ` in addition to the tab.  (Even though this should never match for the current file unless you have the `go-build` checker disabled.)

(Related to #391.  Maybe these errors used to be formatted differently?)