### PR TITLE
Show all error messages at point in help-echo

### DIFF
--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -706,7 +706,7 @@ Floating point numbers can express fractions of seconds.
 @end defopt
 
 You can set @code{flycheck-display-errors-function} to change how
-Flycheck displays error, and what information it displays:
+Flycheck displays errors, and what information it displays:
 
 @defopt flycheck-display-errors-function
 A function to display errors.  The function is called with a list of
@@ -729,6 +729,19 @@ information about the error list.
 The @ghref{flycheck/flycheck-pos-tip, flycheck-pos-tip} extension
 provides an alternative display function, which shows error messages in
 a graphical popup.
+
+In addition to this display mechanism, Flycheck adds a tooltip to each
+error.  Its contents are computed by @code{flycheck-help-echo-function}:
+
+@defopt flycheck-help-echo-function
+A function to compute the contents of the error tooltips.  The function
+is called with the list of errors to display as single argument.  It
+should return a string, which is displayed when the user hovers over an
+error.
+@end defopt
+
+The default is @code{flycheck-make-help-echo}, which displays contents
+similar to those produced by @code{flycheck-display-error-messages}.
 
 @node Killing errors
 @section Killing errors

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -376,7 +376,9 @@ ERROR is a Flycheck error object."
                    fringe-icon))
     (should (eq (overlay-get overlay 'category) category))
     (should (equal (overlay-get overlay 'flycheck-error) error))
-    (should (string= (overlay-get overlay 'help-echo) message))))
+    (save-excursion
+      (goto-char (overlay-start overlay))
+      (should (string= (help-at-pt-string) message)))))
 
 (defun flycheck-ert-should-errors (&rest errors)
   "Test that the current buffers has ERRORS.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2170,19 +2170,6 @@ and extension, as in `file-name-base'."
   :tags '(overlay)
   (should (eq (get 'flycheck-error-overlay 'face) 'flycheck-error)))
 
-(ert-deftest flycheck-info-overlay/default-help-echo ()
-  :tags '(overlay)
-  (should (string= (get 'flycheck-info-overlay 'help-echo) "Unknown info.")))
-
-(ert-deftest flycheck-warning-overlay/default-help-echo ()
-  :tags '(overlay)
-  (should (string= (get 'flycheck-warning-overlay 'help-echo)
-                   "Unknown warning.")))
-
-(ert-deftest flycheck-error-overlay/default-help-echo ()
-  :tags '(overlay)
-  (should (string= (get 'flycheck-error-overlay 'help-echo) "Unknown error.")))
-
 (ert-deftest flycheck-add-overlay/undefined-error-level ()
   :tags '(overlay)
   (let ((err (should-error (flycheck-add-overlay
@@ -2220,7 +2207,7 @@ and extension, as in `file-name-base'."
   (flycheck-ert-with-temp-buffer
     (let ((overlay (flycheck-add-overlay
                     (flycheck-error-new-at 1 1 'info "A bar message"))))
-      (should (string= (overlay-get overlay 'help-echo) "A bar message")))))
+      (should (eq (overlay-get overlay 'help-echo) #'flycheck-help-echo)))))
 
 (ert-deftest flycheck-add-overlay/has-flycheck-overlay-property ()
   :tags '(overlay)
@@ -2330,6 +2317,47 @@ and extension, as in `file-name-base'."
           :checker emacs-lisp-checkdoc)
      '(15 1 warning "`message' called with 0 args to fill 1 format field(s)"
           :checker emacs-lisp))))
+
+(ert-deftest flycheck-add-overlay/help-echo-is-error-message ()
+  :tags '(overlay)
+  "Check for default help at point."
+  (flycheck-ert-with-temp-buffer
+    (insert " ")
+    (goto-char 1)
+    (let ((overlay (flycheck-add-overlay
+                    (flycheck-error-new-at 1 1 'info "A bar message"))))
+      (should (string= (help-at-pt-string) "A bar message")))))
+
+(ert-deftest flycheck-add-overlay/can-suppress-help-echo ()
+  :tags '(overlay)
+  "Check that setting help-echo function to nil removes help echoes."
+  (flycheck-ert-with-temp-buffer
+    (insert " ")
+    (goto-char 1)
+    (let ((flycheck-help-echo-function nil)
+          (overlay (flycheck-add-overlay
+                    (flycheck-error-new-at 1 1 'info "info"))))
+      (should (string= (help-at-pt-string) nil)))))
+
+(ert-deftest flycheck-add-overlay/help-echo-for-nil-message-is-default ()
+  :tags '(overlay)
+  "Check that null error messages are replaced by 'Unkown [level]'."
+  (flycheck-ert-with-temp-buffer
+    (insert " ")
+    (goto-char 1)
+    (let ((overlay (flycheck-add-overlay (flycheck-error-new-at 1 1 'info))))
+      (should (string= (help-at-pt-string) "Unknown info")))))
+
+(ert-deftest flycheck-add-overlay/help-echo-stacks-errors ()
+  :tags '(overlay)
+  "Check that help-echo messages contain all error messages at point."
+  (flycheck-ert-with-temp-buffer
+    (insert " ")
+    (goto-char 1)
+    (flycheck-add-overlay (flycheck-error-new-at 1 1 'info "info"))
+    (flycheck-add-overlay (flycheck-error-new-at 1 1 'warning "warning"))
+    (flycheck-add-overlay (flycheck-error-new-at 1 1 'error "error"))
+    (should (string= (help-at-pt-string) "info\n\nwarning\n\nerror"))))
 
 
 ;;; Error navigation in the current buffer


### PR DESCRIPTION
Hi Sebastian,

Here's a draft implementation of #725; I've added a few tests, and modified the existing ones to use `help-at-point-string` instead of checking `'help-echo` explicitly. I've added the relevant docstrings, but I haven't updated the manual yet. Let me know what you think!

Cheers,
Clément.

Edit (lunaryorn): Connects to #725 (for Waffle)