### PR TITLE
Never show 0/0 in the modeline

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2995,10 +2995,10 @@ nil."
                 (`running "*")
                 (`errored "!")
                 (`finished
-                 (if flycheck-current-errors
-                     (let-alist (flycheck-count-errors flycheck-current-errors)
-                       (format ":%s/%s" (or .error 0) (or .warning 0)))
-                   ""))
+                 (let-alist (flycheck-count-errors flycheck-current-errors)
+                   (if (or .error .warning)
+                       (format ":%s/%s" (or .error 0) (or .warning 0))
+                     "")))
                 (`interrupted "-")
                 (`suspicious "?"))))
     (concat " FlyC" text)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1959,6 +1959,21 @@ and extension, as in `file-name-base'."
       (flycheck-report-failed-syntax-check)
       (should-not flycheck-current-errors))))
 
+(ert-deftest flycheck-mode-line/mentions-errors ()
+  :tags '(status-reporting)
+  (flycheck-ert-with-temp-buffer
+    (let ((flycheck-current-errors
+           (list (flycheck-error-new-at 1 1 'info "info")
+                 (flycheck-error-new-at 1 1 'error "error"))))
+      (should (string= (flycheck-mode-line-status-text 'finished) " FlyC:1/0")))))
+
+(ert-deftest flycheck-mode-line/ignores-info ()
+  :tags '(status-reporting)
+  (flycheck-ert-with-temp-buffer
+    (let ((flycheck-current-errors
+           (list (flycheck-error-new-at 1 1 'info "info"))))
+      (should (string= (flycheck-mode-line-status-text 'finished) " FlyC")))))
+
 
 ;;; Error levels
 ;; A level for the following unit tests


### PR DESCRIPTION
This is a very small change, so I'm not sure if it deserves a prior discussion in a separate issue. The idea is that if there are only info messages, then Flycheck will show `FlyC:0/0` instead of `FlyC`:

```elisp
(flycheck-ert-with-temp-buffer
  (let ((flycheck-current-errors
         (list (flycheck-error-new-at 1 1 'info "info"))))
    (should (string= (flycheck-mode-line-status-text 'finished) " FlyC"))))

(flycheck-ert-with-temp-buffer
  (let ((flycheck-current-errors
         (list (flycheck-error-new-at 1 1 'info "info")
               (flycheck-error-new-at 1 1 'error "error"))))
    (should (string= (flycheck-mode-line-status-text 'finished) " FlyC:1/0"))))
```