### PR TITLE
Fix Coq error pattern.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5736,7 +5736,7 @@ See URL `http://coq.inria.fr/'."
   ((error line-start "File \"" (file-name) "\", line " line
           ;; TODO: Parse the end column, once Flycheck supports that
           ", characters " column "-" (one-or-more digit) ":\n"
-          (or "Syntax error: " "Error: ")
+          (or "Syntax error:" "Error:")
           ;; Most Coq error messages span multiple lines, and end with a dot.
           ;; There are simple one-line messages, too, though.
           (message (or (and (one-or-more (or not-newline "\n")) ".")
@@ -5744,7 +5744,7 @@ See URL `http://coq.inria.fr/'."
           line-end))
   :error-filter
   (lambda (errors)
-    (dolist (err errors)
+    (dolist (err (flycheck-sanitize-errors errors))
       (setf (flycheck-error-message err)
             (replace-regexp-in-string (rx (1+ (syntax whitespace)) line-end)
                                       "" (flycheck-error-message err)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3963,6 +3963,18 @@ n' : nat
 The term \"1\" has type \"nat\" while it is expected to have type
 \"bool\"." :checker coq)))
 
+(flycheck-ert-def-checker-test coq coq error
+  (flycheck-ert-should-syntax-check
+   "checkers/coq-error-2.v" 'coq-mode
+   '(4 58 error "In environment
+A : Set
+P : A -> Prop
+Q : A -> Prop
+R : A -> A -> Prop
+The term \"(fun (R : A -> A -> Prop) (a b : A) => R b a) R\" has type
+ \"A -> A -> Prop\" while it is expected to have type
+ \"(forall a b : A, R a b) -> forall a b : A, R b a\".")))
+
 (flycheck-ert-def-checker-test css-csslint css nil
   :tags '(checkstyle-xml)
   (flycheck-ert-should-syntax-check

--- a/test/resources/checkers/coq-error-2.v
+++ b/test/resources/checkers/coq-error-2.v
@@ -1,0 +1,5 @@
+Section A_declared.
+  Variables (A : Set) (P Q : A -> Prop) (R : A -> A -> Prop).
+  Theorem all_perm : (forall a b : A, R a b) -> forall a b : A, R b a.
+  Proof ((fun (R : A -> A -> Prop) (a:A) (b:A) => R b a) R).
+End Section A.


### PR DESCRIPTION
This fixes an error with the error pattern for Coq. Before, the matching
was done on `Error: ' as start of error message, but there can also be a
newline directly after `Error:'.Now it matches on `Error:' and `Syntax
error:' and removes all leading whitespace before in error-filter.