### PR TITLE
Command wrapper function

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -418,7 +418,7 @@ If set to nil, do not show error tooltips."
   :risky t)
 
 (defcustom flycheck-command-wrapper-function
-  'cons
+  (lambda (cmd args) (cons cmd args))
   "Wraps checker commands and its arguments before it gets executed.
 
 The function is usefull to wrap a checker command, if the checker

--- a/flycheck.el
+++ b/flycheck.el
@@ -423,18 +423,10 @@ If set to nil, do not show error tooltips."
 
 The function is usefull to wrap a checker command, if the checker
 is only available in sandbox-like enviroments.  The default value
-does not modify the command or arguments.  In NixOS, checkers are
-usually only available in a project environement that can be
-accessed with the `nix-shell' command. An example for a
-`flycheck-command-wrapper-function' with `nix-shell' would be
+does not modify the command or arguments.
 
-    (defun nixos-command-wrapper-function (command)
-      (list \"nix-shell\" \"--run\"
-            (mapconcat 'identity command \" \"))
-
-`nix-shell' expects a single argument after the `--command' flag,
-therefor the example function concatenates the checker command
-and its arguments with spaces as separators."
+This function can be customized to run checkers in environments like
+cabal, bundle exec or NixOS sandboxes."
   :group 'flycheck
   :type '(choice (const :tag "Does not modify the command and arguments"
                         identity)
@@ -449,7 +441,8 @@ in `exec-path' for the executable. If the executable is present,
 `flycheck-executable-find' should return an absolute path to the
 executable, otherwise `nil'.
 
-This function can be customized to search for executables in sandboxes."
+This function can be customized to search for checkers in environments
+like cabal, bundle exec or NixOS sandboxes."
   :group 'flycheck
   :type '(choice (const :tag "Searches for an executable in `exec-path'"
                         executable-find)

--- a/flycheck.el
+++ b/flycheck.el
@@ -4731,7 +4731,7 @@ variable symbol for a syntax checker."
           (executable (if current-prefix-arg
                           nil
                         (read-file-name "Executable: " nil default-executable
-                                        nil nil #'flycheck-executable-find))))
+                                        nil nil flycheck-executable-find))))
      (list checker executable)))
   (when (and executable (not (funcall flycheck-executable-find executable)))
     (user-error "%s is no executable" executable))

--- a/flycheck.el
+++ b/flycheck.el
@@ -418,7 +418,7 @@ If set to nil, do not show error tooltips."
   :risky t)
 
 (defcustom flycheck-command-wrapper-function
-  (lambda (cmd args) (cons cmd args))
+  #'identity
   "Wraps checker commands and its arguments before it gets executed.
 
 The function is usefull to wrap a checker command, if the checker
@@ -428,16 +428,16 @@ usually only available in a project environement that can be
 accessed with the `nix-shell' command. An example for a
 `flycheck-command-wrapper-function' with `nix-shell' would be
 
-    (defun nixos-command-wrapper-function (cmd args)
+    (defun nixos-command-wrapper-function (command)
       (list \"nix-shell\" \"--run\"
-            (mapconcat 'identity (cons cmd args) \" \"))
+            (mapconcat 'identity command \" \"))
 
 `nix-shell' expects a single argument after the `--command' flag,
 therefor the example function concatenates the checker command
 and its arguments with spaces as separators."
   :group 'flycheck
   :type '(choice (const :tag "Does not modify the command and arguments"
-                        cons)
+                        identity)
                  (function :tag "Custom command wrapper function"))
   :risky t)
 
@@ -4530,8 +4530,8 @@ symbols in the command."
         (let* ((program (flycheck-checker-executable checker))
                (args (flycheck-checker-substituted-arguments checker))
                (command (funcall flycheck-command-wrapper-function
-                                 program
-                                 args))
+                                 (cons program
+                                       args)))
                ;; Use pipes to receive output from the syntax checker.  They are
                ;; more efficient and more robust than PTYs, which Emacs uses by
                ;; default, and since we don't need any job control features, we


### PR DESCRIPTION
This pull-request adds a customizable `flycheck-command-wrapper-function` and `flycheck-executable-find` function. The purpose of those is discussed in [this](https://github.com/flycheck/flycheck/issues/629) feature request. I'm open for suggestions and improvements.

Best,
Sven

Edit (lunaryorn): Connects to #629