### PR TITLE
Fix regex stack overflow in haskell-hlint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6681,14 +6681,12 @@ See URL `https://github.com/ndmitchell/hlint'."
   ((warning line-start
             (file-name) ":" line ":" column
             ": Warning: "
-            (message (one-or-more not-newline)
-                     (one-or-more "\n" (one-or-more not-newline)))
+            (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
             line-end)
    (error line-start
           (file-name) ":" line ":" column
           ": Error: "
-          (message (one-or-more not-newline)
-                   (one-or-more "\n" (one-or-more not-newline)))
+          (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
           line-end))
   :modes (haskell-mode literate-haskell-mode))
 


### PR DESCRIPTION
Some background: Emacs's regex engine is ["not very clever"](https://groups.google.com/forum/#!original/gnu.emacs.help/pxfMC5f7JHg/lhMNJ0tx6nwJ); in particular, the `.` atom induces recursion, which when combined with a long enough string, will overflow the [regex failure stack](http://vovick.blogspot.com/2013/04/fixing-stack-overflow-in-regexp-matcher.html). This is particularly bad when working with [multi-line strings](http://www.emacswiki.org/emacs/MultilineRegexp), as Flycheck often is.

The `haskell-hlint` checker was susceptible to this when given a big enough string; we solve the issue by using `[^\n]` instead of `.` when we want to match any non-newline character.