### PR TITLE
add option ‘flycheck-hlint-args’

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -362,6 +362,9 @@ and @flyc{haskell-hlint} (style checker with
 following options:
 
 @table @asis
+@flycoption flycheck-hlint-args
+A list of additional arguments for Hlint.
+
 @flycoption flycheck-hlint-language-extensions
 Extensions list.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -6666,6 +6666,9 @@ See URL `http://www.haskell.org/ghc/'."
 (flycheck-def-config-file-var flycheck-hlintrc haskell-hlint "HLint.hs"
   :safe #'stringp)
 
+(flycheck-def-args-var flycheck-hlint-args haskell-hlint
+  :package-version '(flycheck . "0.25"))
+
 (flycheck-def-option-var flycheck-hlint-language-extensions
     nil haskell-hlint
   "Extensions list to enable for hlint.
@@ -6714,6 +6717,7 @@ See URL `https://github.com/ndmitchell/hlint'."
             (option-list "-i=" flycheck-hlint-ignore-rules concat)
             (option-list "-h" flycheck-hlint-hint-packages concat)
             (config-file "-h" flycheck-hlintrc)
+            (eval flycheck-hlint-args)
             source-inplace)
   :error-patterns
   ((warning line-start


### PR DESCRIPTION
Closes #713.

This should hopefully allow to pass additional arguments specified by user to `hlint` utility.

This *seems to work*, however, check the diff yourself, maybe I'm missing something.

Edit (lunaryorn): Connects to #713
