### PR TITLE
Rust cargo

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -707,6 +707,7 @@ Rust package manager}), with the following options:
 @flycoption flycheck-rust-args
 A list of additional arguments for the Rust compiler @command{rustc}.
 They will be passed through to @command{rustc} verbatim.
+
 @flycoption flycheck-rust-check-tests
 Whether to check test code in Rust. This translates to @option{--test}
 flag of @command{rustc}, not to @command{cargo build --test NAME}!
@@ -731,6 +732,7 @@ with the following options:
 @table @asis
 @flycoption flycheck-rust-args
 A list of additional arguments for the Rust compiler @command{rustc}.
+
 @flycoption flycheck-rust-check-tests
 Whether to check test code in Rust.
 

--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -700,6 +700,31 @@ interpreter}),
 
 @itemize
 @item
+@flyc{rust-cargo} (using the @uref{https://crates.io/,Cargo,
+Rust package manager}), with the following options:
+
+@table @asis
+@flycoption flycheck-rust-args
+A list of additional arguments for the Rust compiler @command{rustc}.
+They will be passed through to @command{rustc} verbatim.
+@flycoption flycheck-rust-check-tests
+Whether to check test code in Rust. This translates to @option{--test}
+flag of @command{rustc}, not to @command{cargo build --test NAME}!
+
+@flycoption flycheck-rust-crate-type
+The type of the crate to check, as string for the
+@option{--crate-type} option. This is compatible with usual rust
+checker (using @command{rustc} directly). Translates to either
+@option{--lib} in @command{cargo build} if it's a library, or to
+nothing if not.
+
+@flycoption flycheck-rust-library-path
+A list of additional library directories for Rust. Relative paths are
+relative to the buffer being checked. Note you won't normally need
+that as Cargo should figure all this out itself.
+@end table
+
+@item
 @flyc{rust} (using the @uref{http://www.rust-lang.org/,Rust compiler}),
 with the following options:
 

--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -712,6 +712,9 @@ They will be passed through to @command{rustc} verbatim.
 Whether to check test code in Rust. This translates to @option{--test}
 flag of @command{rustc}, not to @command{cargo build --test NAME}!
 
+@flycoption flycheck-rust-crate-root
+Unused by this checker.
+
 @flycoption flycheck-rust-crate-type
 The type of the crate to check, as string for the
 @option{--crate-type} option. This is compatible with usual rust

--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -701,7 +701,12 @@ interpreter}),
 @itemize
 @item
 @flyc{rust-cargo} (using the @uref{https://crates.io/,Cargo,
-Rust package manager}), with the following options:
+Rust package manager})
+
+@item
+@flyc{rust} (using the @uref{http://www.rust-lang.org/,Rust compiler})
+
+These checkers provide the following options
 
 @table @asis
 @flycoption flycheck-rust-args
@@ -713,43 +718,20 @@ Whether to check test code in Rust. This translates to @option{--test}
 flag of @command{rustc}, not to @command{cargo build --test NAME}!
 
 @flycoption flycheck-rust-crate-root
-Unused by this checker.
+A path to the crate root for the current buffer, or nil if the current
+buffer is a crate by itself. Used only by @flyc{rust} checker.
 
 @flycoption flycheck-rust-crate-type
 The type of the crate to check, as string for the
-@option{--crate-type} option. This is compatible with usual rust
-checker (using @command{rustc} directly). Translates to either
-@option{--lib} in @command{cargo build} if it's a library, or to
-nothing if not.
+@option{--crate-type} option. In @flyc{rust-cargo}, translates to
+either @option{--lib} in @command{cargo build} if it's a library, or
+to nothing if not.
 
 @flycoption flycheck-rust-library-path
 A list of additional library directories for Rust. Relative paths are
 relative to the buffer being checked. Note you won't normally need
-that as Cargo should figure all this out itself.
-@end table
-
-@item
-@flyc{rust} (using the @uref{http://www.rust-lang.org/,Rust compiler}),
-with the following options:
-
-@table @asis
-@flycoption flycheck-rust-args
-A list of additional arguments for the Rust compiler @command{rustc}.
-
-@flycoption flycheck-rust-check-tests
-Whether to check test code in Rust.
-
-@flycoption flycheck-rust-crate-root
-A path to the crate root for the current buffer, or nil if the current
-buffer is a crate by itself.
-
-@flycoption flycheck-rust-crate-type
-The type of the crate to check, as string for the @option{--crate-type}
-option.
-
-@flycoption flycheck-rust-library-path
-A list of library directories for Rust.  Relative paths are relative to
-the buffer being checked.
+this with @flyc{rust-cargo} checker as Cargo should figure all this
+out itself.
 @end table
 
 @end itemize

--- a/flycheck.el
+++ b/flycheck.el
@@ -7685,7 +7685,11 @@ Relative paths are relative to the file being checked."
 This syntax checker needs Cargo with rustc subcommand."
   :command ("cargo" "rustc"
             (eval (if (string= flycheck-rust-crate-type "lib") "--lib" nil))
-            "--" "-Z" "no-trans")
+            "--" "-Z" "no-trans"
+            (option-flag "--test" flycheck-rust-check-tests)
+            (option-list "-L" flycheck-rust-library-path concat)
+            (eval flycheck-rust-args)
+            )
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": "
           (one-or-more digit) ":" (one-or-more digit) " error: "

--- a/flycheck.el
+++ b/flycheck.el
@@ -7703,7 +7703,11 @@ This syntax checker needs Cargo with rustc subcommand."
          (message) line-end))
   :modes rust-mode
   :predicate (lambda ()
-               (or (not flycheck-rust-crate-root) (flycheck-buffer-saved-p))))
+               (let ((parent-dir (file-name-directory
+                                  (directory-file-name
+                                   (expand-file-name default-directory)))))
+                 ;; Cargo.toml
+                 (locate-dominating-file parent-dir "Cargo.toml"))))
 
 (flycheck-define-checker rust
   "A Rust syntax checker using Rust compiler.

--- a/flycheck.el
+++ b/flycheck.el
@@ -229,6 +229,7 @@ attention to case differences."
     ruby-rubylint
     ruby
     ruby-jruby
+    rust-cargo
     rust
     sass
     scala
@@ -7677,6 +7678,32 @@ Relative paths are relative to the file being checked."
   :type '(repeat (directory :tag "Library directory"))
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.18"))
+
+(flycheck-define-checker rust-cargo
+  "A Rust syntax checker using Cargo.
+
+This syntax checker needs Cargo with rustc subcommand."
+  :command ("cargo" "rustc"
+            (eval (if (string= flycheck-rust-crate-type "lib") "--lib" nil))
+            "--" "-Z" "no-trans")
+  :error-patterns
+  ((error line-start (file-name) ":" line ":" column ": "
+          (one-or-more digit) ":" (one-or-more digit) " error: "
+          (or
+           ;; Multiline errors
+           (and (message (minimal-match (one-or-more anything)))
+                " [" (id "E" (one-or-more digit)) "]")
+           (message))
+          line-end)
+   (warning line-start (file-name) ":" line ":" column ": "
+            (one-or-more digit) ":" (one-or-more digit) " warning: "
+            (message) line-end)
+   (info line-start (file-name) ":" line ":" column ": "
+         (one-or-more digit) ":" (one-or-more digit) " " (or "note" "help") ": "
+         (message) line-end))
+  :modes rust-mode
+  :predicate (lambda ()
+               (or (not flycheck-rust-crate-root) (flycheck-buffer-saved-p))))
 
 (flycheck-define-checker rust
   "A Rust syntax checker using Rust compiler.


### PR DESCRIPTION
Fix https://github.com/flycheck/flycheck-rust/issues/8

I'd appreciate a thorough code review: I'm not sure I did right with predicate, but then I'm also not sure if existing Rust checker has predicates right. I don't get why existing checker is invoked when `flycheck-rust-crate-root` is not defined.

Credits to @utkarshkukreti, @tomjakubowski for initial versions of the checker.