### PR TITLE
Add faces for non-zero error / warning counts in the mode line

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -831,6 +831,18 @@ This variable is a normal hook.  See Info node `(elisp)Hooks'."
   :package-version '(flycheck . "0.15")
   :group 'flycheck-faces)
 
+(defface flycheck-mode-line-errors
+  '((t :inherit mode-line))
+  "Flycheck face to highlight a non-zero error count in the mode line."
+  :package-version '(flycheck . "0.25")
+  :group 'flycheck-faces)
+
+(defface flycheck-mode-line-warnings
+  '((t :inherit mode-line))
+  "Flycheck face to highlight a non-zero warning count in the mode line."
+  :package-version '(flycheck . "0.25")
+  :group 'flycheck-faces)
+
 (defvar flycheck-command-map
   (let ((map (make-sparse-keymap)))
     (define-key map "c"         #'flycheck-buffer)
@@ -3059,7 +3071,12 @@ nil."
                 (`finished
                  (let-alist (flycheck-count-errors flycheck-current-errors)
                    (if (or .error .warning)
-                       (format ":%s/%s" (or .error 0) (or .warning 0))
+                       (concat ":"
+                               (apply 'propertize (number-to-string (or .error 0))
+                                      (if .error '(face flycheck-mode-line-errors)))
+                               "/"
+                               (apply 'propertize (number-to-string (or .warning 0))
+                                      (if .warning '(face flycheck-mode-line-warnings))))
                      "")))
                 (`interrupted "-")
                 (`suspicious "?"))))


### PR DESCRIPTION
I've been working on this change, but while the face properties are added to (at least) flycheck's mode line string, the colours don't show up in the modeline even when I customize the faces to use bright colours. Can you see what I'm doing wrong?