### PR TITLE
Shut up byte compiler about unused var

### DIFF
--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -359,7 +359,7 @@ ERROR is a Flycheck error object."
                                               error))
                           (flycheck-overlays-in 0 (+ 1 (buffer-size)))))
          (region (flycheck-error-region-for-mode error 'symbols))
-         (message (flycheck-error-message error))
+         (_message (flycheck-error-message error))
          (level (flycheck-error-level error))
          (category (flycheck-error-level-overlay-category level))
          (face (get category 'face))


### PR DESCRIPTION
It doesn't seem like it's being used right now. It was annoying me when updating.