### PR TITLE
Clean up dependency list

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9,7 +9,7 @@
 ;; URL: https://www.flycheck.org
 ;; Keywords: convenience, languages, tools
 ;; Version: 0.26-cvs
-;; Package-Requires: ((dash "2.12.1") (pkg-info "0.4") (let-alist "1.0.4") (cl-lib "0.5") (seq "1.11") (emacs "24.3"))
+;; Package-Requires: ((dash "2.12.1") (pkg-info "0.4") (let-alist "1.0.4") (seq "1.11") (emacs "24.3"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
cl-lib was bundled since Emacs 24.3.