### PR TITLE
Never show error buffer in currently active window

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4135,7 +4135,7 @@ In the latter case, show messages in
   (when (and errors (flycheck-may-use-echo-area-p))
     (let ((messages (seq-map #'flycheck-error-format-message-and-id errors)))
       (display-message-or-buffer (string-join messages "\n\n")
-                                 flycheck-error-message-buffer))))
+                                 flycheck-error-message-buffer t))))
 
 (defun flycheck-display-error-messages-unless-error-list (errors)
   "Show messages of ERRORS unless the error list is visible.


### PR DESCRIPTION
Investigating #648 led me to another small bug, I think. This should fix it, but since I'm not too familiar with window configuration stuff I'd like a second opinion :)

In short, the error message buffer is sometimes opened in the current window, masking the source code buffer. To reproduce:

* Follow the instructions in #648 (including the checker definition) and open test1.txt
* Wait for the error buffer to pop up
* Move to the window displaying the error buffer with `C-x o`
* Display test1.txt in that buffer as well (using `C-x b`)
* Wait for the error buffer to pop up again.

On my machine, without the patch, the error buffer pops up and replaces the source buffer that the point was in:

![bug](https://cloud.githubusercontent.com/assets/8181630/11844722/3d52d388-a3de-11e5-9c44-0a30e5a562f4.gif)

Btw, how do you record good gifs?