### PR TITLE
Add a code of conduct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 master (in development)
 =======================
 
+Flycheck now has a code of conduct (http://www.flycheck.org/conduct.html) (see
+`CONDUCT.md`) which defines the acceptable behaviour and the moderation
+guidelines for the Flycheck community.
+
 - New syntax checkers:
 
   - Processing [GH-793] [GH-812]

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,79 @@
+# The Flycheck Code of Conduct
+
+## Conduct
+
+**Contact**: [Any maintainer][maintainers]
+
+* We are committed to providing a friendly, safe and welcoming environment for
+  all, regardless of gender, sexual orientation, disability, ethnicity,
+  religion, or similar personal characteristic.
+* Please avoid using overtly sexual nicknames or other nicknames that might
+  detract from a friendly, safe and welcoming environment for all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Please do not curse or use bad words.  Foul language will not help us to build
+  a great product.
+* Respect that people have differences of opinion and that every design or
+  implementation choice carries a trade-off and numerous costs. There is seldom
+  a right answer.
+* Please keep unstructured critique to a minimum. If you have solid ideas you
+  want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass
+  anyone. That is not welcome behaviour. We interpret the term "harassment" as
+  including the definition in the
+  [Citizen Code of Conduct](http://citizencodeofconduct.org/); if you have any
+  lack of clarity about what might be included in that concept, please read
+  their definition. In particular, we don't tolerate behavior that excludes
+  people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel
+  you have been or are being harassed or made uncomfortable by a community
+  member, please contact one of the [Maintainers][] immediately. Whether you're
+  a regular contributor or a newcomer, we care about making this community a
+  safe place for you and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing
+  behaviour is not welcome.
+
+[maintainers]: http://www.flycheck.org/people.html#maintainers
+
+## Moderation
+
+These are the policies for upholding our community's standards of conduct in our
+communication channels, most notably in Flycheck’s Github organisation.
+
+1. Remarks that violate the Flycheck code of conduct, including hateful,
+   hurtful, oppressive, or exclusionary remarks, are not allowed.
+2. Remarks that moderators find inappropriate, whether listed in the code of
+   conduct or not, are also not allowed.
+3. Moderators will first respond to such remarks with a warning.
+4. If the warning is unheeded, the user will be "kicked," i.e., kicked out of
+   the communication channel to cool off.
+5. If the user comes back and continues to make trouble, they will be banned,
+   i.e., indefinitely excluded.
+6. Moderators may choose at their discretion to un-ban the user if it was a
+   first offense and they offer the offended party a genuine apology.
+7. If a moderator bans someone and you think it was unjustified, please take it
+   up with that moderator, or with a different moderator, **in
+   private**. Complaints about bans in-channel are not allowed.
+8. Moderators are held to a higher standard than other community members. If a
+   moderator creates an inappropriate situation, they should expect less leeway
+   than others.
+
+In the Flycheck community we strive to go the extra step to look out for each
+other. Don't just aim to be technically unimpeachable, try to be your best
+self. In particular, avoid flirting with offensive or sensitive issues,
+particularly if they're off-topic; this all too often leads to unnecessary
+fights, hurt feelings, and damaged trust; worse, it can drive people away from
+the community entirely.
+
+And if someone takes issue with something you said or did, resist the urge to be
+defensive. Just stop doing what it was they complained about and apologize. Even
+if you feel you were misinterpreted or unfairly accused, chances are good there
+was something you could've communicated better — remember that it's your
+responsibility to make your fellow Flycheck people comfortable. Everyone wants
+to get along and we are all here first and foremost because we want to talk
+about cool technology. You will find that people will be eager to assume good
+intent and forgive as long as you earn their trust.
+
+---
+
+*Adapted from the
+ [Rust Code of Conduct](https://www.rust-lang.org/conduct.html)*.


### PR DESCRIPTION
Based on the [Rust CoC](https://www.rust-lang.org/conduct.html), with the notable difference that our code of conduct disallows cursing and foul language (which I personally just don't like :blush:)  @cpitclaudel @purcell Please take a look :relaxed:  

Closes GH-819, connects to #819