### PR TITLE
Make go-build compile only current file

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6502,7 +6502,11 @@ See URL `http://golang.org/cmd/go'."
             (option-flag "-i" flycheck-go-build-install-deps)
             ;; multiple tags are listed as "dev debug ..."
             (option-list "-tags=" flycheck-go-build-tags concat)
-            "-o" temporary-file-name)
+            "-o" temporary-file-name
+            ;; Only compile current file, go-build failed if if current
+            ;; directory contains any C file.
+            ;; See https://github.com/dominikh/go-mode.el/issues/19
+            source)
   :error-patterns
   ((error line-start (file-name) ":" line ":"
           (optional column ":") " "


### PR DESCRIPTION
Currently, go-build checker treats all files in them same directory of current files as a Go project, `go-build` checker will fail to run if any C file present in directory:
```
$ ls
test.c test.go
$ go build -o /dev/null
can't load package: package .: C source files not allowed when not using cgo or SWIG: test.c
```

This pull request made `go-build` only compile the current file.