### PR TITLE
Use the right syntax table for Emacs Lisp checkdoc

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6224,6 +6224,9 @@ See Info Node `(elisp)Byte Compilation'."
 (defconst flycheck-emacs-lisp-checkdoc-form
   (flycheck-prepare-emacs-lisp-form
     (require 'checkdoc)
+    ;; elisp-mode provides the elisp syntax table
+    (unless (require 'elisp-mode nil t)
+      (require 'lisp-mode))
 
     (let ((source (car command-line-args-left))
           ;; Remember the default directory of the process
@@ -6239,7 +6242,10 @@ See Info Node `(elisp)Byte Compilation'."
         ;; back-substutition work
         (setq default-directory process-default-directory)
         (with-demoted-errors "Error in checkdoc: %S"
-          (checkdoc-current-buffer t)
+          ;; Checkdoc needs the right syntax table
+          ;; See https://github.com/flycheck/flycheck/issues/833
+          (with-syntax-table emacs-lisp-mode-syntax-table
+            (checkdoc-current-buffer t))
           (with-current-buffer checkdoc-diagnostic-buffer
             (princ (buffer-substring-no-properties (point-min) (point-max)))
             (kill-buffer)))))))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3833,6 +3833,13 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
         :checker emacs-lisp )))
 
 (flycheck-ert-def-checker-test (emacs-lisp emacs-lisp-checkdoc) emacs-lisp
+                               right-syntax-table
+  (flycheck-ert-should-syntax-check
+   "language/emacs-lisp/checkdoc-syntax-table-regression.el" 'emacs-lisp-mode
+   '(11 nil warning "All variables and subroutines might as well have a documentation string"
+        :checker emacs-lisp-checkdoc)))
+
+(flycheck-ert-def-checker-test (emacs-lisp emacs-lisp-checkdoc) emacs-lisp
                                checks-compressed-file
   (flycheck-ert-should-syntax-check
    "language/emacs-lisp/compressed.el.gz" 'emacs-lisp-mode
@@ -3844,7 +3851,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
                     "the function ‘dummy-package-foo’ is not known to be defined.")
         :checker emacs-lisp)))
 
-(flycheck-ert-def-checker-test emacs-lisp emacs-lisp sytnax-error
+(flycheck-ert-def-checker-test emacs-lisp emacs-lisp syntax-error
   (let ((flycheck-disabled-checkers '(emacs-lisp-checkdoc)))
     (flycheck-ert-should-syntax-check
      "language/emacs-lisp/syntax-error.el" 'emacs-lisp-mode

--- a/test/resources/language/emacs-lisp/checkdoc-syntax-table-regression.el
+++ b/test/resources/language/emacs-lisp/checkdoc-syntax-table-regression.el
@@ -1,0 +1,14 @@
+;;; checkdoc-syntax-table-regression.el -- This file will confuse an improperly configured checkdoc -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Checkdoc uses the syntax table of the current buffer; if not set properly, it
+;; gets confused by the code below.
+
+;;; Code:
+
+(defun confusing ()
+  ?{)
+
+(provide 'checkdoc-syntax-table-regression)
+;;; checkdoc-syntax-table-regression.el ends here


### PR DESCRIPTION
Looks like `with-syntax-table is enough` :)
Fixes #833