### PR TITLE
Add support for a configurable puppet-lint config file

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -548,8 +548,11 @@ command-line tool})
 @item
 @flyc{puppet-parser} (syntax check with @uref{http://puppetlabs.com/, Puppet})
 @item
-@flyc{puppet-lint} (style check with @uref{http://puppet-lint.com/,
-Puppet Lint})
+@flyc{puppet-lint} (style check with @uref{http://puppet-lint.com/, Puppet Lint}),
+with the following option:
+@table @asis
+@flycconfigfile{flycheck-puppet-lint-rc,puppet-lint}
+@end table
 @end itemize
 
 @flyclanguage{Python}

--- a/flycheck.el
+++ b/flycheck.el
@@ -7303,6 +7303,9 @@ See URL `http://puppetlabs.com/'."
   :modes puppet-mode
   :next-checkers ((warning . puppet-lint)))
 
+(flycheck-def-config-file-var flycheck-puppet-lint-rc puppet-lint ".puppet-lint.rc"
+  :safe #'stringp)
+
 (flycheck-define-checker puppet-lint
   "A Puppet DSL style checker using puppet-lint.
 
@@ -7313,6 +7316,7 @@ See URL `http://puppet-lint.com/'."
   ;; required to be in a file foo/bar.pp.  Any other place, such as a Flycheck
   ;; temporary file will cause an error.
   :command ("puppet-lint"
+            (config-file "--config" flycheck-puppet-lint-rc)
             "--log-format" "%{path}:%{linenumber}:%{kind}: %{message} (%{check})"
             source-original)
   :error-patterns


### PR DESCRIPTION
I have several puppet repos I work on, some with different configurations for puppet-lint. I'm adding some rudimentary support for a customizable puppet-lint configuration file so that I can set it in a dir-locals file on a per-project basis.