### PR TITLE
Fix haskell-module-re to exclude following paren

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6656,7 +6656,7 @@ See URL `http://handlebarsjs.com/'."
 (defconst flycheck-haskell-module-re
   (rx line-start (zero-or-more (or "\n" (any space)))
       "module" (one-or-more (or "\n" (any space)))
-      (group (one-or-more (not (any space "\n")))))
+      (group (one-or-more (not (any space "(" "\n")))))
   "Regular expression for a Haskell module name.")
 
 (flycheck-def-args-var flycheck-ghc-args (haskell-stack-ghc haskell-ghc)


### PR DESCRIPTION
It is legal and not overly uncommon in haskell to start a module with:

    module Foo.Bar(
      quux,
      baz) where

That is, the module name can be terminated with an open paren as well as with a space.