### PR TITLE
Add .perlcritic support

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -506,6 +506,7 @@ These syntax checkers checker provide the following options:
 @flycoption flycheck-perl-include-path
 A list of include directories for Perl, relative to the file being
 checked.
+@flycconfigfile{flycheck-perlcriticrc,perl-perlcritic}
 @flycoption flycheck-perlcritic-severity
 The severity level for Perl::Critic, as integer for the
 @option{--severity} option of Perl::Critic.

--- a/flycheck.el
+++ b/flycheck.el
@@ -7187,11 +7187,16 @@ the `--severity' option to Perl Critic."
 (define-obsolete-variable-alias 'flycheck-perlcritic-verbosity
   'flycheck-perlcritic-severity "0.22")
 
+(flycheck-def-config-file-var flycheck-perlcriticrc perl-perlcritic
+                              ".perlcriticrc"
+  :safe #'stringp)
+
 (flycheck-define-checker perl-perlcritic
   "A Perl syntax checker using Perl::Critic.
 
 See URL `https://metacpan.org/pod/Perl::Critic'."
   :command ("perlcritic" "--no-color" "--verbose" "%f/%l/%c/%s/%p/%m (%e)\n"
+            (config-file "--profile" flycheck-perlcriticrc)
             (option "--severity" flycheck-perlcritic-severity nil
                     flycheck-option-int))
   :standard-input t


### PR DESCRIPTION
It operates in the same way most of these files do, so just re-use the
standard support for this sort of thing.