### PR TITLE
haskell-stack-ghc predicate on stack.yaml

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6814,7 +6814,13 @@ See URL `https://github.com/commercialhaskell/stack'."
   (lambda (errors)
     (flycheck-sanitize-errors (flycheck-dedent-error-messages errors)))
   :modes (haskell-mode literate-haskell-mode)
-  :next-checkers ((warning . haskell-hlint)))
+  :next-checkers ((warning . haskell-hlint))
+  :predicate (lambda ()
+               (let ((fs (mapcar (lambda (f)
+					(and f (locate-dominating-file (buffer-file-name) f)))
+				  (list "stack.yml" "stack.yaml" (getenv "STACK_YAML")))))
+                 (eval (append '(or) fs)))))
+
 
 (flycheck-define-checker haskell-ghc
   "A Haskell syntax and type checker using ghc.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6815,12 +6815,16 @@ See URL `https://github.com/commercialhaskell/stack'."
     (flycheck-sanitize-errors (flycheck-dedent-error-messages errors)))
   :modes (haskell-mode literate-haskell-mode)
   :next-checkers ((warning . haskell-hlint))
-  :predicate (lambda ()
-               (let ((fs (mapcar (lambda (f)
-					(and f (locate-dominating-file (buffer-file-name) f)))
-				  (list "stack.yml" "stack.yaml" (getenv "STACK_YAML")))))
-                 (eval (append '(or) fs)))))
-
+  :predicate
+  (lambda ()
+    (let ((fns (list "stack.yml" "stack.yaml" (getenv "STACK_YAML")))
+          (bfn (buffer-file-name)))
+      (and bfn (locate-dominating-file
+                bfn (lambda (dir)
+                      (cl-some (lambda (f)
+                                 (and f (file-exists-p
+                                         (expand-file-name f dir))))
+                               fns)))))))
 
 (flycheck-define-checker haskell-ghc
   "A Haskell syntax and type checker using ghc.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6817,14 +6817,15 @@ See URL `https://github.com/commercialhaskell/stack'."
   :next-checkers ((warning . haskell-hlint))
   :predicate
   (lambda ()
-    (let ((fns (list "stack.yml" "stack.yaml" (getenv "STACK_YAML")))
-          (bfn (buffer-file-name)))
-      (and bfn (locate-dominating-file
-                bfn (lambda (dir)
-                      (cl-some (lambda (f)
-                                 (and f (file-exists-p
-                                         (expand-file-name f dir))))
-                               fns)))))))
+    (let ((file-names (list "stack.yml" "stack.yaml" (getenv "STACK_YAML")))
+          (buf-file-name (buffer-file-name)))
+      (and buf-file-name
+           (locate-dominating-file
+            buf-file-name (lambda (dir)
+                            (seq-some (lambda (file)
+                                        (and file (file-exists-p
+                                                   (expand-file-name file dir))))
+                                      file-names)))))))
 
 (flycheck-define-checker haskell-ghc
   "A Haskell syntax and type checker using ghc.


### PR DESCRIPTION
For #847. Checks for 'stack.yml', 'stack.yaml' or environment $STACK_YAML.