### PR TITLE
Handle warnings in included files properly.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3380,11 +3380,12 @@ included file."
         (when (funcall sentinel current-error)
           ;; We found an error denoting errors in the included file:
           ;; 1. process all subsequent errors until faulty include file is found
-          ;; 2. process again all subsequent errors until an error has the
-          ;;    current file name again
+          ;; 2. process again all subsequent errors before the current file name appears again
           ;; 3. find the most severe error level
           (let ((current-filename (flycheck-error-filename current-error))
-                (current-level nil)
+                (saved-level nil)
+                (saved-message "")
+                (saved-filename "")
                 (faulty-include-filename nil)
                 (filename nil)
                 (done (null remaining-errors)))
@@ -3395,23 +3396,30 @@ included file."
                 (unless (string= filename current-filename)
                   (setq faulty-include-filename filename)))
 
-              (let* ((error-in-include (pop remaining-errors))
-                     (in-include-level (flycheck-error-level error-in-include)))
-                (unless (funcall sentinel error-in-include)
-                  ;; Ignore nested "included file" errors, we are only
-                  ;; interested in real errors because these define our level
-                  (when (or (not current-level)
-                            (> (flycheck-error-level-severity in-include-level)
-                               (flycheck-error-level-severity current-level)))
-                    (setq current-level in-include-level))))
+              (if (and faulty-include-filename (string= filename current-filename))
+                  (setq done t)
+                (let* ((error-in-include (pop remaining-errors))
+                       (in-include-level (flycheck-error-level error-in-include)))
+                  (unless (funcall sentinel error-in-include)
+                    ;; Ignore nested "included file" errors, we are only
+                    ;; interested in real errors because these define our level
+                    (when (or (not saved-level)
+                              (> (flycheck-error-level-severity in-include-level)
+                                 (flycheck-error-level-severity saved-level)))
+                      (setq saved-level in-include-level
+                            saved-message (flycheck-error-message error-in-include)
+                            saved-filename (flycheck-error-filename error-in-include))))))
 
-              (setq done (or (null remaining-errors)
-                             (and faulty-include-filename
-                                  (string= filename current-filename)))))
+              (unless done
+                (setq done (null remaining-errors))))
 
-            (setf (flycheck-error-level current-error) current-level
-                  (flycheck-error-message current-error)
-                  (format "In include %s" faulty-include-filename))))))
+            (if (equal current-filename saved-filename) ; false include file error in gcc
+                (setf (flycheck-error-level current-error) 'info
+                      (flycheck-error-message current-error)
+                      (format "In include %s" faulty-include-filename))
+              (setf (flycheck-error-level current-error) saved-level
+                    (flycheck-error-message current-error)
+                    (format "In include %s: %s" faulty-include-filename saved-message)))))))
     errors))
 
 (defun flycheck-dequalify-error-ids (errors)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1911,7 +1911,7 @@ and extension, as in `file-name-base'."
                                              :filename "foo.cpp"))))
     (should
      (equal (flycheck-fold-include-levels errors "In file included from")
-            (list (flycheck-error-new-at 1 0 'error "In include foo.h"
+            (list (flycheck-error-new-at 1 0 'info "In include foo.h"
                                          :filename "foo.cpp")
                   (flycheck-error-new-at 6 11 'error "b is not a member of hi"
                                          :filename "foo.cpp")


### PR DESCRIPTION
* Current code may mistake warnings in included files for errors, as
  demonstrated below:

        // foo.cpp
        #include "foo.h"
        int main(int argc, char *argv[]) {
            xx;
        }

        // foo.h
        #warning ok sfdsfsdf

* Improve included files' error message display in minibuffer. In above
  example, change "In include foo.h" to "In include foo.h: ok sfdsfsdf".