### PR TITLE
Use standard input for Less checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7169,16 +7169,12 @@ At least version 1.4 of lessc is required.
 
 See URL `http://lesscss.org'."
   :command ("lessc" "--lint" "--no-color"
-            ;; We need `source-inplace' to resolve relative `data-uri' paths,
-            ;; see https://github.com/flycheck/flycheck/issues/471
-            source-inplace)
+            "-")
+  :standard-input t
   :error-patterns
   ((error line-start (one-or-more word) ":"
           (message)
-          " in "
-          (file-name)
-
-          " on line " line
+          " in - on line " line
           ", column " column ":"
           line-end))
   :modes less-css-mode)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3907,8 +3907,7 @@ Why not:
      '(1 44 error "Extra data" :checker json-python-json))))
 
 (flycheck-ert-def-checker-test less less file-error
-  (let* ((candidates (list (flycheck-ert-resource-filename "language/less/no-such-file.less")
-                           (flycheck-ert-resource-filename "language/less/no-such-file.less")
+  (let* ((candidates (list "no-such-file.less"
                            "no-such-file.less"))
          (message (string-join candidates ",")))
     (flycheck-ert-should-syntax-check


### PR DESCRIPTION
Make the Less checker use standard input. This prevent temporary files
to mess with Less watchers.

Standard input is supported in Less 1.4 and later, so this commit is
backward-compatible.

As far as I understand the issue #471 referenced in the deleted comment won't suffer from this change, as `lessc` will be executed in the buffer's working directory. I did some tests that confirm it.