### PR TITLE
Accept suggestions from haskell-lint as 'info'

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6949,7 +6949,12 @@ See URL `https://github.com/ndmitchell/hlint'."
             (eval flycheck-hlint-args)
             source-inplace)
   :error-patterns
-  ((warning line-start
+  ((info line-start
+         (file-name) ":" line ":" column
+         ": Suggestion: "
+         (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
+         line-end)
+   (warning line-start
             (file-name) ":" line ":" column
             ": Warning: "
             (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3566,14 +3566,14 @@ In the expression: putStrLn True" :checker haskell-stack-ghc))))
   (let ((flycheck-disabled-checkers '(haskell-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Warnings.hs" 'haskell-mode
-     '(4 1 error "Eta reduce
+     '(4 1 warning "Eta reduce
 Found:
   spam eggs = map lines eggs
 Why not:
   spam = map lines" :checker haskell-hlint)
      '(4 1 warning "Top-level binding with no type signature:
   spam :: [String] -> [[String]]" :checker haskell-stack-ghc)
-     '(7 8 warning "Redundant bracket
+     '(7 8 info "Redundant bracket
 Found:
   (putStrLn \"hello world\")
 Why not:
@@ -3607,7 +3607,7 @@ In the expression: putStrLn True" :checker haskell-ghc))))
   (let ((flycheck-disabled-checkers '(haskell-stack-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Warnings.hs" 'haskell-mode
-     '(4 1 error "Eta reduce
+     '(4 1 warning "Eta reduce
 Found:
   spam eggs = map lines eggs
 Why not:
@@ -3615,7 +3615,7 @@ Why not:
      '(4 1 warning "Top-level binding with no type signature:
   spam :: [String] -> [[String]]"
          :checker haskell-ghc)
-     '(7 8 warning "Redundant bracket
+     '(7 8 info "Redundant bracket
 Found:
   (putStrLn \"hello world\")
 Why not:


### PR DESCRIPTION
In hint-1.9.28 a bunch of warnings were changed to 'suggestions'.  Without this change any suggestion will result in:

`
Suspicious state from syntax checker haskell-hlint: Checker haskell-hlint returned non-zero exit code 1, but no errors from output:
`