### PR TITLE
Add ruby-reek support

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -671,6 +671,9 @@ Whether to emit warnings for all missing references in Sphinx.
 @item
 @flyc{ruby-rubylint} (syntax and style check using
 @uref{http://code.yorickpeterse.com/ruby-lint/latest/,ruby-lint})
+@item
+@flyc{ruby-reek} (code smell detection using
+@uref{https://github.com/troessner/reek,Reek})
 @end enumerate
 
 These checkers provide the following options
@@ -681,6 +684,7 @@ Whether to suppress warnings about style issues in Rubocop, via the
 @option{--lint} option.
 @flycconfigfile{flycheck-rubocoprc,Rubocop}
 @flycconfigfile{flycheck-rubylintrc,ruby-lint}
+@flycconfigfile{flycheck-reekrc,Reek}
 @end table
 
 If none of the above is available, Flycheck will fall back to one of the

--- a/flycheck.el
+++ b/flycheck.el
@@ -7892,7 +7892,9 @@ See URL `http://jruby.org/'."
   "A Ruby smell checker using reek
 
 See URL `https://github.com/troessner/reek'."
-  :command ("reek" "--format=xml" source)
+  :command ("reek" "--format=xml"
+            (config-file "--config" flycheck-reekrc)
+            source)
   :error-parser flycheck-parse-checkstyle
   :modes (enh-ruby-mode ruby-mode)
   :next-checkers ((info . ruby-rubocop)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -7889,13 +7889,10 @@ See URL `http://jruby.org/'."
   :safe #'stringp)
 
 (flycheck-define-checker ruby-reek
-  "A Ruby smeel checker using reek
+  "A Ruby smell checker using reek
 
 See URL `https://github.com/troessner/reek'."
-  :command ("reek" "--format=xml"
-            (config-file "--config" flycheck-reekrc)
-            source-original)
-  :standard-input t
+  :command ("reek" "--format=xml" source)
   :error-parser flycheck-parse-checkstyle
   :modes (enh-ruby-mode ruby-mode)
   :next-checkers ((info . ruby-rubocop)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -232,6 +232,7 @@ attention to case differences."
     ruby-rubylint
     ruby
     ruby-jruby
+    ruby-reek
     rust-cargo
     rust
     sass
@@ -7883,6 +7884,21 @@ See URL `http://jruby.org/'."
    (error line-start  "-:" line ": " (message) line-end))
   :modes (enh-ruby-mode ruby-mode)
   :next-checkers ((warning . ruby-rubylint)))
+
+(flycheck-def-config-file-var flycheck-reekrc ruby-reek "config.reek"
+  :safe #'stringp)
+
+(flycheck-define-checker ruby-reek
+  "A Ruby smeel checker using reek
+
+See URL `https://github.com/troessner/reek'."
+  :command ("reek" "--format=xml"
+            (config-file "--config" flycheck-reekrc)
+            source-original)
+  :standard-input t
+  :error-parser flycheck-parse-checkstyle
+  :modes (enh-ruby-mode ruby-mode)
+  :next-checkers ((info . ruby-rubocop)))
 
 (flycheck-def-args-var flycheck-rust-args (rust-cargo rust)
   :package-version '(flycheck . "0.24"))

--- a/flycheck.el
+++ b/flycheck.el
@@ -7889,7 +7889,7 @@ See URL `http://jruby.org/'."
   :safe #'stringp)
 
 (flycheck-define-checker ruby-reek
-  "A Ruby smell checker using reek
+  "A Ruby smell checker using reek.
 
 See URL `https://github.com/troessner/reek'."
   :command ("reek" "--format=xml"

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4134,6 +4134,19 @@ Why not:
      '(16 nil warning "Useless use of == in void context."
           :checker ruby-jruby))))
 
+(flycheck-ert-def-checker-test ruby-reek ruby warning
+  (let  ((flycheck-disabled-checkers '(ruby-rubocop)))
+    (flycheck-ert-should-syntax-check
+     "language/ruby/smell-warnings.rb" 'ruby-mode
+     '(1 nil warning "has no descriptive comment"
+         :id "IrresponsibleModule" :checker ruby-reek)
+     '(2 nil warning "doesn't depend on instance state (maybe move it to another class?)"
+         :id "UtilityFunction" :checker ruby-reek)
+     '(3 nil warning "calls object.save 2 times"
+         :id "DuplicateMethodCall" :checker ruby-reek)
+     '(4 nil warning "calls object.save 2 times"
+         :id "DuplicateMethodCall" :checker ruby-reek))))
+
 (flycheck-ert-def-checker-test rust-cargo rust warning
   (let ((flycheck-rust-crate-type "bin"))
     (flycheck-ert-should-syntax-check

--- a/test/resources/language/ruby/smell-warnings.rb
+++ b/test/resources/language/ruby/smell-warnings.rb
@@ -1,0 +1,6 @@
+class Smelly
+  def smell(object)
+    object.save
+    object.save
+  end
+end


### PR DESCRIPTION
Hi!

I've been trying to add support for reek to the ruby parsers https://github.com/troessner/reek

I managed to make it work by adding the linter to my emacs dotfiles. It shows the errors as expected. ~~However I cannot make it pass the test. This is the first time I write some elisp and I'm a bit lost. Would anybody mind giving some help with it? I would really appreciate it :)~~ The tests are passing on the CI, but I cannot manage to make `rake check:language[ruby]` work on my machine. Don't know if it can be something relevant or not.

The error I get is:

``` lisp
(ert-test-failed
  ((should
    (equal expected flycheck-current-errors))
  :form
  (equal
    ([cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 1 nil "has no descriptive comment" warning "IrresponsibleModule"]
    [cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 2 nil "doesn't depend on instance state (maybe move it to another class?)" warning "UtilityFunction"]
    [cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 3 nil "calls object.save 2 times" warning "DuplicateMethodCall"]
    [cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 4 nil "calls object.save 2 times" warning "DuplicateMethodCall"])
    nil)
  :value nil :explanation
  (different-types
    ([cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 1 nil "has no descriptive comment" warning "IrresponsibleModule"]
    [cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 2 nil "doesn't depend on instance state (maybe move it to another class?)" warning "UtilityFunction"]
    [cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 3 nil "calls object.save 2 times" warning "DuplicateMethodCall"]
    [cl-struct-flycheck-error #<killed buffer> ruby-reek "/my-flycheck-working-copy/test/resources/language/ruby/smell-warnings.rb" 4 nil "calls object.save 2 times" warning "DuplicateMethodCall"])
    nil)))
```

Would there be something else needed for this? Any documentation or other tests which would help?
