### PR TITLE
Write go test output to temporary file

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6639,9 +6639,11 @@ See URL `http://golang.org/cmd/go'."
   "A Go syntax and type checker using the `go test' command.
 
 See URL `http://golang.org/cmd/go'."
-  ;; This command builds the test executable and leaves it in the current
-  ;; directory.  Unfortunately 'go test -c' does not have the '-o' option.
-  :command ("go" "test" "-c")
+  ;; This command builds the test executable and writes it to
+  ;; `temporary-file-name'.
+  ;; TODO: Switch to `null-device'` when < Go 1.6 support is removed.
+  ;; See: https://github.com/flycheck/flycheck/issues/838
+  :command ("go" "test" "-c" "-o" temporary-file-name)
   :error-patterns
   ((error line-start (file-name) ":" line ": "
           (message (one-or-more not-newline)


### PR DESCRIPTION
This avoids littering a project with `.test` executables..

The `-o` flag was added in Go 1.4 (https://github.com/golang/go/commit/ce143f25e625ce40f4655185372dc93661545df0).

I decided to keep using `temporary-file-name`, similar to the `go-build` check, as #838 hasn't been resolved yet.