### PR TITLE
set epg-gpg-home-directory

### DIFF
--- a/test/run.el
+++ b/test/run.el
@@ -120,7 +120,8 @@ Node `(ert)Test Selectors' for information about test selectors."
       (load (expand-file-name "flycheck-test"
                               (file-name-directory flycheck-runner-file)))))
 
-  (let ((debug-on-error t))
+  (let ((debug-on-error t)
+        (epg-gpg-home-directory "/tmp"))
     (flycheck-run-tests-batch-and-exit)))
 
 ;;; run.el ends here


### PR DESCRIPTION
gpg immediately dies with an error when invoked if the current user's
home directory does not exist (as is the case on a Debian package
autobuilder).  This causes all tests that invoke gpg to be skipped.
Setting `epg-gpg-home-directory` when running the test suite fixes the
problem, making the test suite more portable.