### PR TITLE
go-vet: add support for -shadow and -shadowstrict options

### DIFF
--- a/doc/languages.texi
+++ b/doc/languages.texi
@@ -308,6 +308,12 @@ A list of tags for @code{go build}.
 @flycoption flycheck-go-vet-print-functions
 A list of print-like functions for go vet.  Go vet will check these
 functions for format string problems.
+
+@flycoption flycheck-go-vet-shadow
+Whether to enable `go tool vet' check for shadowed variables. If set
+to @code{strict} be strict about shadowing. This option requires Go
+1.6 or newer.
+
 @end table
 
 @flyclanguage{Groovy}

--- a/flycheck.el
+++ b/flycheck.el
@@ -6562,14 +6562,29 @@ take an io.Writer as their first argument, like Fprintf,
                  (string :tag "function"))
   :safe #'flycheck-string-list-p)
 
+(flycheck-def-option-var flycheck-go-vet-shadow nil go-vet
+  "Whether to enable `go tool vet' check for shadowed variables.
+
+When nil, do not check for shadowed variables.  When `strict'
+enable shadow check and be strict about shadowing; can be
+noisy.  When any other non-nil value enable shadow check.
+
+This option requires Go 1.6 or newer."
+  :type '(choice (const :tag "Disable" nil)
+                 (const :tag "Enable" t)
+                 (const :tag "Enable and be strict about shadowing" strict)))
+
 (flycheck-define-checker go-vet
   "A Go syntax checker using the `go tool vet' command.
 
 See URL `http://golang.org/cmd/go/' and URL
 `http://godoc.org/golang.org/x/tools/cmd/vet'."
   :command ("go" "tool" "vet"
+            "-all"
             (option "-printfuncs=" flycheck-go-vet-print-functions concat
                     flycheck-option-comma-separated-list)
+            (option-flag "-shadow" flycheck-go-vet-shadow)
+            (eval (when (eq flycheck-go-vet-shadow 'strict) "-shadowstrict"))
             source)
   :error-patterns
   ((warning line-start (file-name) ":" line ": " (message) line-end))


### PR DESCRIPTION
Starting from Go 1.6 `go vet -all -shadow' means all default checkers and also
shadow checker. This allows to add options to enable shadow check.

The discussion in #765 has more details.