### PR TITLE
Remove mention about flycheck-scalastyle-jar

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8071,8 +8071,7 @@ See URL `http://www.scala-lang.org/'."
   "A Scala style checker using scalastyle.
 
 Note that this syntax checker is not used if
-`flycheck-scalastyle-jar' or `flycheck-scalastylerc' are nil or
-point to non-existing files.
+`flycheck-scalastylerc' is nil or point to non-existing files.
 
 See URL `http://www.scalastyle.org'."
   :command ("scalastyle"


### PR DESCRIPTION
http://www.flycheck.org/2015/11/14/flycheck-0.25.html

"The scala-stylestyle syntax checker now expects a scalastyle executable in exec-path now. The flycheck-scalastyle-jar option which used to provide the location of the Scalastyle JAR file was removed."