### PR TITLE
Add stylelint checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@
   - systemd-analyze with ``systemd-analyze`` [GH-1135]
   - Dockerfile with ``hadolint`` [GH-1194]
   - AsciiDoc with ``asciidoctor`` [GH-1167]
+  - CSS/SCSS/LESS with ``stylelint`` [GH-903]
 
 - New features:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -238,6 +238,18 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _CSSLint: https://github.com/CSSLint/csslint
 
+   .. syntax-checker:: css-stylelint
+
+      Syntax-check and lint CSS with stylelint_.
+
+      .. _stylelint: https://stylelint.io
+
+      .. syntax-checker-config-file:: flycheck-stylelintrc
+
+      .. defcustom:: flycheck-stylelint-quiet
+
+         Whether to run stylelint in quiet mode via ``--quiet``.
+
 .. supported-language:: D
 
    .. syntax-checker:: d-dmd
@@ -641,6 +653,18 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          This syntax checker requires lessc 1.4 or newer.
 
+   .. syntax-checker:: less-stylelint
+
+      Syntax-check and lint Less with stylelint_.
+
+      .. _stylelint: https://stylelint.io
+
+      .. syntax-checker-config-file:: flycheck-stylelintrc
+
+      .. defcustom:: flycheck-stylelint-quiet
+
+         Whether to run stylelint in quiet mode via ``--quiet``.
+
 .. supported-language:: Lua
 
    Flycheck checks Lua with `lua-luacheck`, falling back to `lua`.
@@ -995,8 +1019,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 .. supported-language:: Sass/SCSS
 
    Flycheck checks SASS with `sass/scss-sass-lint`, falling back to `sass`, and
-   SCSS with  `scss-lint`, falling back to `sass/scss-sass-lint` first and then
-   `scss` if neither is available.
+   SCSS with  `scss-lint` or `scss-stylelint` falling back to
+   `sass/scss-sass-lint` first and then `scss` if neither is available.
 
    .. syntax-checker:: scss-lint
 
@@ -1017,6 +1041,18 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. _SASS-Lint: https://github.com/sasstools/sass-lint
 
       .. syntax-checker-config-file:: flycheck-sass-lintrc
+
+   .. syntax-checker:: scss-stylelint
+
+      Syntax-check and lint SCSS with stylelint_.
+
+      .. _stylelint: https://stylelint.io
+
+      .. syntax-checker-config-file:: flycheck-stylelintrc
+
+      .. defcustom:: flycheck-stylelint-quiet
+
+         Whether to run stylelint in quiet mode via ``--quiet``.
 
    .. syntax-checker:: sass
                        scss

--- a/flycheck.el
+++ b/flycheck.el
@@ -171,6 +171,7 @@ attention to case differences."
     coffee-coffeelint
     coq
     css-csslint
+    css-stylelint
     d-dmd
     dockerfile-hadolint
     elixir-dogma
@@ -201,6 +202,7 @@ attention to case differences."
     json-jsonlint
     json-python-json
     less
+    less-stylelint
     lua-luacheck
     lua
     perl
@@ -232,6 +234,7 @@ attention to case differences."
     scala-scalastyle
     scheme-chicken
     scss-lint
+    scss-stylelint
     sass/scss-sass-lint
     sass
     scss
@@ -6595,6 +6598,123 @@ See URL `https://github.com/CSSLint/csslint'."
   :error-filter flycheck-dequalify-error-ids
   :modes css-mode)
 
+(defconst flycheck-stylelint-args '("--formatter" "json")
+  "Common arguments to stylelint invocations.")
+
+(flycheck-def-config-file-var flycheck-stylelintrc
+    (css-stylelint scss-stylelint less-stylelint) nil
+  :safe #'stringp)
+
+(flycheck-def-option-var flycheck-stylelint-quiet
+    nil (css-stylelint scss-stylelint less-stylelint)
+  "Whether to run stylelint in quiet mode.
+
+When non-nil, enable quiet mode, via `--quiet'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . 26))
+
+(defconst flycheck-stylelint-error-re
+  (flycheck-rx-to-string
+   '(: line-start (id (one-or-more word)) ": " (message) line-end)))
+
+(defun flycheck-parse-stylelint (output checker buffer)
+  "Parse stylelint errors from OUTPUT.
+
+CHECKER and BUFFER denoted the CHECKER that returned OUTPUT and
+the BUFFER that was checked respectively.
+
+The CHECKER usually returns the errors as JSON.
+
+If the CHECKER throws an Error it returns an Error message with a stacktrace."
+  (condition-case nil
+      (flycheck-parse-stylelint-json output checker buffer)
+
+    ;; The output could not be parsed as JSON
+    (json-error
+
+     ;; Extract a flycheck error from the output (with a regular expression)
+     ;; For match-string 4/5 see flycheck-rx-message/flycheck-rx-id
+     (when (string-match flycheck-stylelint-error-re output)
+       (list (flycheck-error-new-at
+              1 nil 'error
+              (match-string 4 output)
+              :id (match-string 5 output)
+              :checker checker
+              :buffer buffer
+              :filename (buffer-file-name buffer)))))))
+
+(defun flycheck-parse-stylelint-json (output checker buffer)
+  "Parse stylelint JSON errors from OUTPUT.
+
+CHECKER and BUFFER denoted the CHECKER that returned OUTPUT and
+the BUFFER that was checked respectively.
+
+See URL `http://stylelint.io/developer-guide/formatters/' for information
+about the JSON format of stylelint."
+  (let ((json-object-type 'plist))
+
+    ;; stylelint returns a vector of result objects
+    ;; Since we only passed one file, the first element is enough
+    (let* ((stylelint-output (elt (json-read-from-string output) 0))
+           (filename (buffer-file-name buffer))
+
+           ;; Turn all deprecations into warnings
+           (deprecations
+            (mapcar (lambda (d)
+                      (flycheck-error-new-at
+                       1 nil 'warning
+                       (plist-get d :text)
+                       :id "Deprecation Warning"
+                       :checker checker
+                       :buffer buffer
+                       :filename filename))
+                    (plist-get stylelint-output :deprecations)))
+
+           ;; Turn all invalid options into errors
+           (invalid-options
+            (mapcar (lambda (io)
+                      (flycheck-error-new-at
+                       1 nil 'error
+                       (plist-get io :text)
+                       :id "Invalid Option"
+                       :checker checker
+                       :buffer buffer
+                       :filename filename))
+                    (plist-get stylelint-output :invalidOptionWarnings)))
+
+           ;; Read all linting warnings
+           (warnings
+            (mapcar (lambda (w)
+                      (flycheck-error-new-at
+                       (plist-get w :line) (plist-get w :column)
+                       (pcase (plist-get w :severity)
+                         (`"error"   'error)
+                         (`"warning" 'warning)
+                         ;; Default to info for unknown .severity
+                         (_          'info))
+                       (plist-get w :text)
+                       :id (plist-get w :rule)
+                       :checker checker
+                       :buffer buffer
+                       :filename filename))
+                    (plist-get stylelint-output :warnings))))
+
+      ;; Return the combined errors (deprecations, invalid options, warnings)
+      (append deprecations invalid-options warnings))))
+
+(flycheck-define-checker css-stylelint
+  "A CSS syntax and style checker using stylelint.
+
+See URL `http://stylelint.io/'."
+  :command ("stylelint"
+            (eval flycheck-stylelint-args)
+            (option-flag "--quiet" flycheck-stylelint-quiet)
+            (config-file "--config" flycheck-stylelintrc))
+  :standard-input t
+  :error-parser flycheck-parse-stylelint
+  :modes (css-mode))
+
 (defconst flycheck-d-module-re
   (rx "module" (one-or-more (syntax whitespace))
       (group (one-or-more (not (syntax whitespace))))
@@ -7894,6 +8014,19 @@ See URL `http://lesscss.org'."
           line-end))
   :modes less-css-mode)
 
+(flycheck-define-checker less-stylelint
+  "A LESS syntax and style checker using stylelint.
+
+See URL `http://stylelint.io/'."
+  :command ("stylelint"
+            (eval flycheck-stylelint-args)
+            "--syntax" "less"
+            (option-flag "--quiet" flycheck-stylelint-quiet)
+            (config-file "--config" flycheck-stylelintrc))
+  :standard-input t
+  :error-parser flycheck-parse-stylelint
+  :modes (less-css-mode))
+
 (flycheck-def-config-file-var flycheck-luacheckrc lua-luacheck ".luacheckrc"
   :safe #'stringp)
 
@@ -9172,6 +9305,19 @@ See URL `https://github.com/brigade/scss-lint'."
                   :face (if reporter-missing
                             '(bold error)
                           'success)))))))
+
+(flycheck-define-checker scss-stylelint
+  "A SCSS syntax and style checker using stylelint.
+
+See URL `http://stylelint.io/'."
+  :command ("stylelint"
+            (eval flycheck-stylelint-args)
+            "--syntax" "scss"
+            (option-flag "--quiet" flycheck-stylelint-quiet)
+            (config-file "--config" flycheck-stylelintrc))
+  :standard-input t
+  :error-parser flycheck-parse-stylelint
+  :modes (scss-mode))
 
 (flycheck-def-option-var flycheck-scss-compass nil scss
   "Whether to enable the Compass CSS framework.


### PR DESCRIPTION
These changes should enable the `css-stylelint` checker in `css-mode` and `scss-mode`.

It covers 3 different scenarios:

**1) Normal errors and warnings**

``` yaml
# .stylelintrc.yaml
rules:
  string-quotes: double
  indentation: [2, { "warn": true }]
```

``` css
/* style.css */
h1 {
  color: 'red'; /* error: single quote */
    margin: 0 auto; /* warning: wrong intentation */
}
```

stylelint output (missing error level information):

```
$ stylelint style.css
2:10    Expected double quotes (string-quotes)
3:5 Expected indentation of 2 spaces (indentation)
```

That's why I used the JSON formatter and wrote my own `:error-parser`

```
$ stylelint --formatter json style.css
[{"source":"style.css","deprecations":[],"errored":true,"warnings":[{"line":2,"column":10,"rule":"string-quotes","severity":"error","text":"Expected double quotes (string-quotes)"},{"line":3,"column":5,"rule":"indentation","severity":"warning","text":"Expected indentation of 2 spaces (indentation)"}]}]
```

**2) Syntax errors**

``` css
/* style.css */
h1 {
  color: 'red; /* syntax error: Unclosed quote */
    margin: 0 auto;
}
```

```
$ stylelint --formatter json style.css
CssSyntaxError: style.css:2:10: Unclosed quote
```

**3) Configuration errors**

``` yaml
# .stylelintrc.yaml
# should be rules instead of rles
rles:
  string-quotes: double
  indentation: [2, { "warn": true }]
```

```
$ stylelint --formatter json style.css
Error: No rules found within configuration. Have you provided a "rules" property?
```

The `:error-filter` function adds a line (line number 1) to these errors to be able to show them.

**Questions**
- What is the best way to define this checker for `css-mode` and `scss-mode`?
- What is the best way to use a combination of an `:error-parser` and some form of `:error-patterns`?
- Is it necessary to show the Syntax errors and Configuration Errors or should flycheck just fail if these happen?
- Should I rather try to create a PR at stylelint that changes their text formatter to output the error level and then create a simple checker that just uses `:error-patterns` for all 3 scenarios?

**Edit:** Connects to #785
