### PR TITLE
Catch error message for multiple Go packages

### DIFF
--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3462,6 +3462,18 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
                             go-root-pkg)
            :checker go-build)))))
 
+(flycheck-ert-def-checker-test go-build go directory-with-two-packages
+  (flycheck-ert-with-env
+      `(("GOPATH" . ,(flycheck-ert-resource-filename "checkers/go")))
+    (flycheck-ert-should-syntax-check
+     "checkers/go/src/multipkg/a.go" 'go-mode
+     `(1 nil info
+         ,(concat "can't load package: package multipkg: "
+                  "found packages a (a.go) and b (b.go) in "
+                  (flycheck-ert-resource-filename
+                   "checkers/go/src/multipkg"))
+         :checker go-build))))
+
 (flycheck-ert-def-checker-test go-test go nil
   (flycheck-ert-with-env
       `(("GOPATH" . ,(flycheck-ert-resource-filename "checkers/go")))

--- a/test/resources/checkers/go/src/multipkg/a.go
+++ b/test/resources/checkers/go/src/multipkg/a.go
@@ -1,0 +1,1 @@
+package a

--- a/test/resources/checkers/go/src/multipkg/b.go
+++ b/test/resources/checkers/go/src/multipkg/b.go
@@ -1,0 +1,1 @@
+package b


### PR DESCRIPTION
If there are multiple Go packages in a single directory, `go build` will
bail out.  Catch the error message printed by the tool and turn it into
an informational message because Flycheck can’t really syntax-check such
packages.

Because the error message doesn’t contain a line number, install an
error filter to fake a line number.  Otherwise the message would be
ignored.

Fixes GH-676 and closes GH-676.