### PR TITLE
Clean up go-errcheck checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6695,7 +6695,7 @@ part of any package or if GOPATH is nil."
 Requires an errcheck version from commit 8515d34 (made on August 28 2015) or newer.
 
 See URL `https://github.com/kisielk/errcheck'."
-  :command ("errcheck" "-abspath" (eval (flycheck-go-package-name)))
+  :command ("errcheck" "-abspath" ".")
   :error-patterns
   ((warning line-start
             (file-name) ":" line ":" column (or (one-or-more "\t") ": ")
@@ -6716,7 +6716,7 @@ See URL `https://github.com/kisielk/errcheck'."
   (lambda ()
     ;; We need a valid package name, since errcheck only works on entire
     ;; packages, and can't check individual Go files.
-    (and (flycheck-buffer-saved-p) (flycheck-go-package-name))))
+    (and (flycheck-buffer-saved-p))))
 
 (flycheck-define-checker groovy
   "A groovy syntax checker using groovy compiler API.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6671,24 +6671,6 @@ See URL `http://golang.org/cmd/go'."
                   (string-suffix-p "_test.go" (buffer-file-name))))
   :next-checkers ((warning . go-errcheck)))
 
-(defun flycheck-go-package-name (&optional file-name gopath)
-  "Determine the package name for FILE-NAME and GOPATH.
-
-FILE-NAME defaults to function `buffer-file-name'.  GOPATH
-defaults to $GOPATH.
-
-Return the package name for FILE-NAME, or nil if FILE-NAME is not
-part of any package or if GOPATH is nil."
-  (-when-let* ((gopath (or gopath (getenv "GOPATH")))
-               (file-name (or file-name (buffer-file-name))))
-    (let ((gosrc (file-name-as-directory (expand-file-name "src/" gopath)))
-          (file-name (expand-file-name file-name)))
-      (when (string-prefix-p gosrc file-name)
-        ;; The file is part of a package, so determine the package name, as
-        ;; relative file name to the GO source directory
-        (directory-file-name            ; Remove trailing /
-         (file-relative-name (file-name-directory file-name) gosrc))))))
-
 (flycheck-define-checker go-errcheck
   "A Go checker for unchecked errors.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -6692,8 +6692,10 @@ part of any package or if GOPATH is nil."
 (flycheck-define-checker go-errcheck
   "A Go checker for unchecked errors.
 
+Requires an errcheck version from commit 8515d34 (made on August 28 2015) or newer.
+
 See URL `https://github.com/kisielk/errcheck'."
-  :command ("errcheck" (eval (flycheck-go-package-name)))
+  :command ("errcheck" "-abspath" (eval (flycheck-go-package-name)))
   :error-patterns
   ((warning line-start
             (file-name) ":" line ":" column (or (one-or-more "\t") ": ")
@@ -6704,15 +6706,6 @@ See URL `https://github.com/kisielk/errcheck'."
     (let ((errors (flycheck-sanitize-errors errors))
           (gosrc (expand-file-name "src/" (getenv "GOPATH"))))
       (dolist (err errors)
-        ;; File names are relative to the Go source directory, so we need to
-        ;; unexpand and re-expand them
-        (setf (flycheck-error-filename err)
-              (expand-file-name
-               ;; Get the relative name back, since Flycheck has already
-               ;; expanded the name for us
-               (file-relative-name (flycheck-error-filename err))
-               ;; And expand it against the Go source directory
-               gosrc))
         (-when-let (message (flycheck-error-message err))
           ;; Improve the messages reported by errcheck to make them more clear.
           (setf (flycheck-error-message err)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3469,30 +3469,6 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
      "language/go/src/test/test-error_test.go" 'go-mode
      '(8 nil error "undefined: fmt in fmt.Println" :checker go-test))))
 
-(ert-deftest flycheck-go-package-name/no-gopath ()
-  :tags '(language-go)
-  (flycheck-ert-with-env '(("GOPATH" . nil))
-    (should-not (flycheck-go-package-name
-                 (flycheck-ert-resource-filename
-                  "language/go/src/errcheck/errcheck.go")))))
-
-(ert-deftest flycheck-go-package-name/no-package-file ()
-  :tags '(language-go)
-  (flycheck-ert-with-env
-      `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
-    (should-not (flycheck-go-package-name
-                 (flycheck-ert-resource-filename
-                  "language/emacs-lisp-syntax-error.el")))))
-
-(ert-deftest flycheck-go-package-name/package-file ()
-  :tags '(language-go)
-  (flycheck-ert-with-env
-      `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
-    (should (equal "errcheck"
-                   (flycheck-go-package-name
-                    (flycheck-ert-resource-filename
-                     "language/go/src/errcheck/errcheck.go"))))))
-
 (flycheck-ert-def-checker-test go-errcheck go nil
   (flycheck-ert-with-env
       `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))


### PR DESCRIPTION
errcheck has a new flag and fixed a bug that makes the checker implementation a lot simpler. The bug was fixed late February 2015, the flag was added late August 2015.

/cc @lunaryorn 