### PR TITLE
Set cppcheck -x param based on major-mode

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5969,6 +5969,10 @@ See URL `http://cppcheck.sourceforge.net/'."
             (option-flag "--inconclusive" flycheck-cppcheck-inconclusive)
             (option-list "-I" flycheck-cppcheck-include-path)
             (option "--std=" flycheck-cppcheck-language-standard concat)
+            "-x" (eval
+                  (pcase major-mode
+                    (`c++-mode "c++")
+                    (`c-mode "c")))
             source)
   :error-parser flycheck-parse-cppcheck
   :modes (c-mode c++-mode))


### PR DESCRIPTION
cppcheck treats a header file as a C header file by default. We can make
it recognize C++ header files with `-x` command line parameter so we set
up the parameter to `c++` when we visit a C++ file in c++-mode.