### PR TITLE
Fix 'command' not found issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ PATTERN = .*
 EMACSBATCH = $(CASK) exec $(EMACS) -Q --batch -L . $(EMACSOPTS)
 
 # Program availability
-HAVE_CASK := $(shell command -v $(CASK))
+HAVE_CASK := $(shell sh -c "command -v $(CASK)")
 ifndef HAVE_CASK
 $(warning "$(CASK) is not available.  Please run make help")
 endif
-HAVE_INKSCAPE := $(shell command -v $(INKSCAPE))
-HAVE_CONVERT := $(shell command -v $(CONVERT))
-HAVE_OPTIPNG := $(shell command -v $(OPTIPNG))
+HAVE_INKSCAPE := $(shell sh -c "command -v $(INKSCAPE)")
+HAVE_CONVERT := $(shell sh -c "command -v $(CONVERT)")
+HAVE_OPTIPNG := $(shell sh -c "command -v $(OPTIPNG)")
 
 # Export Emacs to goals, mainly for CASK
 CASK_EMACS = $(EMACS)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,12 +24,12 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .
 
 .DEFAULT_GOAL := help
 
-HAVE_SPHINXBUILD := $(shell command -v $(SPHINXBUILD))
+HAVE_SPHINXBUILD := $(shell sh -c "command -v $(SPHINXBUILD)")
 ifndef HAVE_SPHINXBUILD
 $(warning "$(SPHINXBUILD) is not available.  Please run make help.")
 endif
-HAVE_SPHINXAUTOBUILD := $(shell command -v $(SPHINXAUTOBUILD))
-HAVE_PIP := $(shell command -v $(PIP))
+HAVE_SPHINXAUTOBUILD := $(shell sh -c "command -v $(SPHINXAUTOBUILD)")
+HAVE_PIP := $(shell sh -c "command -v $(PIP)")
 
 .PHONY: help
 help:


### PR DESCRIPTION
`command` is implemented as a shell builtin command on allmost all environments. Error occurs by `make` command on such platform, because builtin shell command cannot be used in Make `shell` function.

For example, I got following warnings by `make help` in `doc/` directory although I already install `pip3`, `sphinx-build`, `sphinx-autobuild`.

```
% make help
make: command: Command not found
Makefile:29: "sphinx-build is not available.  Please run make help."
make: command: Command not found
make: command: Command not found
Available targets:
  html: Build HTML documentation to _build/html
  html-auto: Like html, but automatically rebuild on changes
  linkcheck: Check all links and references
  clean: Remove generated documentation

To build the documentation you need sphinx-build.
For *-auto targets you also need sphinx-autobuild.

Available programs:
  sphinx-build: no
  sphinx-autobuild: no

You need Python 3.4 or newer to install Sphinx for Flycheck.

Run make init to install all missing tools.  It is recommended
that you use virtualenv (https://virtualenv.pypa.io/en/latest/)
to avoid a global installation of Python packages.  make init
will warn you if you do not.
```

With this change, I got following output by `make help`.

```
% make help
Available targets:
  html: Build HTML documentation to _build/html
  html-auto: Like html, but automatically rebuild on changes
  linkcheck: Check all links and references
  clean: Remove generated documentation

To build the documentation you need sphinx-build.
For *-auto targets you also need sphinx-autobuild.

Available programs:
  sphinx-build: yes
  sphinx-autobuild: yes

You need Python 3.4 or newer to install Sphinx for Flycheck.

Run make init to install all missing tools.  It is recommended
that you use virtualenv (https://virtualenv.pypa.io/en/latest/)
to avoid a global installation of Python packages.  make init
will warn you if you do not.
```