### PR TITLE
Pass relevant settings to checkdoc subprocess

### DIFF
--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -385,6 +385,8 @@ resource directory."
       (ert-skip (format "%S missing" mode)))
     (flycheck-ert-with-resource-buffer resource-file
       (funcall mode)
+      ;; Load file-local variables, because some tests depend on them
+      (hack-local-variables)
       ;; Configure config file locating for unit tests
       (let ((process-hook-called 0))
         (add-hook 'flycheck-process-error-functions

--- a/flycheck.el
+++ b/flycheck.el
@@ -6368,11 +6368,33 @@ See Info Node `(elisp)Byte Compilation'."
             (princ (buffer-substring-no-properties (point-min) (point-max)))
             (kill-buffer)))))))
 
+(defconst flycheck-emacs-lisp-checkdoc-variables
+  '(checkdoc-symbol-words
+    checkdoc-arguments-in-order-flag
+    checkdoc-force-history-flag
+    checkdoc-permit-comma-termination-flag
+    checkdoc-force-docstrings-flag
+    checkdoc-package-keywords-flag
+    checkdoc-spellcheck-documentation-flag
+    checkdoc-verb-check-experimental-flag
+    checkdoc-max-keyref-before-warn)
+  "Variables inherited by the checkdoc subprocess.")
+
+(defun flycheck-emacs-lisp-checkdoc-variables-form ()
+  "Make a sexp to pass relevant variables to a checkdoc subprocess.
+
+Variables are taken from `flycheck-emacs-lisp-checkdoc-variables'."
+  `(progn
+     ,@(seq-map (lambda (opt) `(setq-default ,opt ,(symbol-value opt)))
+                (seq-filter #'boundp flycheck-emacs-lisp-checkdoc-variables))))
+
 (flycheck-define-checker emacs-lisp-checkdoc
   "An Emacs Lisp style checker using CheckDoc.
 
 The checker runs `checkdoc-current-buffer'."
   :command ("emacs" (eval flycheck-emacs-args)
+            "--eval" (eval (flycheck-sexp-to-string
+                            (flycheck-emacs-lisp-checkdoc-variables-form)))
             "--eval" (eval flycheck-emacs-lisp-checkdoc-form)
             "--" source)
   :error-patterns

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3285,6 +3285,11 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
    '(11 nil warning "All variables and subroutines might as well have a documentation string"
         :checker emacs-lisp-checkdoc)))
 
+(flycheck-ert-def-checker-test (emacs-lisp-checkdoc) emacs-lisp
+                               inherits-checkdoc-variables
+  (flycheck-ert-should-syntax-check
+   "language/emacs-lisp/local-checkdoc-variables.el" 'emacs-lisp-mode))
+
 (flycheck-ert-def-checker-test (emacs-lisp emacs-lisp-checkdoc) emacs-lisp
                                checks-compressed-file
   (flycheck-ert-should-syntax-check

--- a/test/resources/language/emacs-lisp/local-checkdoc-variables.el
+++ b/test/resources/language/emacs-lisp/local-checkdoc-variables.el
@@ -1,0 +1,23 @@
+;;; local-checkdoc-variables.el -- Silence checkdoc warnings with file-local variables -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Make sure that file-local checkdoc settings are properly propagated to
+;; checkdoc process.
+
+;;; Code:
+
+(defun imperative-mood ()
+  "Uses an imperative mood, which is wrong.")
+
+(defun arguments-in-wrong-order (a b)
+  "Sum B and A."
+  (+ a b))
+
+;; Local Variables:
+;; checkdoc-arguments-in-order-flag: nil
+;; checkdoc-verb-check-experimental-flag: nil
+;; End:
+
+(provide 'local-checkdoc-variables)
+;;; local-checkdoc-variables.el ends here

--- a/test/specs/languages/test-emacs-lisp.el
+++ b/test/specs/languages/test-emacs-lisp.el
@@ -1,0 +1,57 @@
+;;; test-emacs-lisp.el --- Flycheck Specs: Haskell      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
+
+;; Author: Clément Pit-Claudel <clement.pitclaudel@live.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for Emacs Lisp support.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(defconst flycheck/excluded-checkdoc-vars
+  '(checkdoc-autofix-flag checkdoc-bouncy-flag checkdoc-minor-mode-string)
+  "Checkdoc variables that should not be passed to the checker.")
+
+(defun flycheck/custom-var-p (var)
+  "Check if VAR is a customization pair describing a variable."
+  (eq (cadr var) 'custom-variable))
+
+(describe "Language Emacs Lisp"
+
+  (describe "Checkdoc"
+    (before-each
+      (assume (version<= "25" emacs-version)
+              "Checkdoc has additional variables in Emacs 25"))
+    (it "exports the right customizable variables"
+      (require 'checkdoc)
+      (let* ((checkdoc-custom-group
+              (get 'checkdoc 'custom-group))
+             (checkdoc-custom-pairs
+              (seq-filter #'flycheck/custom-var-p checkdoc-custom-group))
+             (checkdoc-custom-vars
+              (seq-map #'car checkdoc-custom-pairs))
+             (checkdoc-relevant-vars
+              (seq-difference checkdoc-custom-vars flycheck/excluded-checkdoc-vars)))
+        (expect (seq-sort #'string-lessp flycheck-emacs-lisp-checkdoc-variables)
+                :to-equal (seq-sort #'string-lessp checkdoc-relevant-vars))))))
+
+;;; test-emacs-lisp.el ends here


### PR DESCRIPTION
‘flycheck-emacs-lisp-checkdoc-variables’ contains all variables that are
passed to the inferior Emacs process running checkdoc (but only if they
are already bound in the parent process).

The main use of this is allowing for file- and directory-local checkdoc
settings.

Closes GH-741.

Edit: Connects to #741.