### PR TITLE
go-errcheck improvements

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6738,7 +6738,7 @@ See URL `https://github.com/kisielk/errcheck'."
           (message)
           line-end)
    (warning line-start
-            (file-name) ":" line ":" column (one-or-more "\t")
+            (file-name) ":" line ":" column "\t"
             (message)
             line-end))
   :error-filter

--- a/flycheck.el
+++ b/flycheck.el
@@ -6733,18 +6733,23 @@ or newer.
 See URL `https://github.com/kisielk/errcheck'."
   :command ("errcheck" "-abspath" ".")
   :error-patterns
-  ((warning line-start
-            (file-name) ":" line ":" column (or (one-or-more "\t") ": ")
+  ((error line-start
+          (file-name) ":" line ":" column ": "
+          (message)
+          line-end)
+   (warning line-start
+            (file-name) ":" line ":" column (one-or-more "\t")
             (message)
             line-end))
   :error-filter
   (lambda (errors)
     (let ((errors (flycheck-sanitize-errors errors)))
       (dolist (err errors)
-        (-when-let (message (flycheck-error-message err))
-          ;; Improve the messages reported by errcheck to make them more clear.
-          (setf (flycheck-error-message err)
-                (format "Ignored `error` returned from `%s`" message)))))
+        (when (eq (flycheck-error-level err) 'warning)
+          (-when-let (message (flycheck-error-message err))
+            ;; Improve the messages reported by errcheck to make them more clear.
+            (setf (flycheck-error-message err)
+                  (format "Ignored `error` returned from `%s`" message))))))
     errors)
   :modes go-mode
   :predicate (lambda () (flycheck-buffer-saved-p))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3473,6 +3473,14 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
      '(9 9 warning "Ignored `error` returned from `os.Stat(\"enoent\")`"
          :checker go-errcheck))))
 
+(flycheck-ert-def-checker-test go-errcheck go nil
+  (flycheck-ert-with-env
+      `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
+    (flycheck-ert-should-syntax-check
+     "language/go/src/errcheck/errcheck2.go" 'go-mode
+     '(4 6 error "undeclared name: x"
+         :checker go-errcheck))))
+
 (flycheck-ert-def-checker-test go-unconvert go nil
   :tags '(language-go external-tool)
   (flycheck-ert-with-env

--- a/test/resources/language/go/src/errcheck/errcheck2.go
+++ b/test/resources/language/go/src/errcheck/errcheck2.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	_ = x
+}


### PR DESCRIPTION
Don't treat errors as warnings and simplify a pattern.

I'm not sure if the new test is correct. I can't get tests to run locally at the moment.