### PR TITLE
Add variable to fix rust-cargo error for multiple targets

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -850,9 +850,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          The name of the binary to pass to ``cargo rustc --bin``, as a string.
 
-         `rust-cargo` needs this option to correctly invoke cargo when
-         `flycheck-rust-crate-type` is ``bin`` in the presence of multiple
-         binary targets.
+         Only required when `flycheck-rust-crate-type` is ``bin`` and the crate
+         has multiple targets.
 
       .. option:: flycheck-rust-library-path
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -846,6 +846,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
          The type of the crate to check, as string for the ``--crate-type``
          option.
 
+      .. option:: flycheck-rust-binary-name
+
+         The name of the binary to pass to ``cargo rustc --bin``, as a string.
+
+         `rust-cargo` needs this option to correctly invoke cargo when
+         `flycheck-rust-crate-type` is ``bin`` in the presence of multiple
+         binary targets.
+
       .. option:: flycheck-rust-library-path
 
          A list of additional library directories. Relative paths are relative

--- a/flycheck.el
+++ b/flycheck.el
@@ -8116,14 +8116,14 @@ for the `--crate-type' flag."
   "The name of the binary to pass to `cargo rustc --bin'.
 
 The value of this variable is a string denoting the name of the
-binary to build: either the name of the crate, or the name of one
+binary to build: Either the name of the crate, or the name of one
 of the files under `src/bin'.
 
-This variable is needed only when `flycheck-rust-crate-type' is
-`bin' and there are multiple binary targets."
+This variable is used only when `flycheck-rust-crate-type' is
+`bin', and is only useful for crates with multiple targets."
   :type 'string
   :safe #'stringp
-  :package-version '("flycheck" . "0.28"))
+  :package-version '("flycheck" . "0.27"))
 
 (flycheck-def-option-var flycheck-rust-library-path nil (rust-cargo rust)
   "A list of library directories for Rust.
@@ -8140,11 +8140,10 @@ Relative paths are relative to the file being checked."
 
 This syntax checker needs Cargo with rustc subcommand."
   :command ("cargo" "rustc"
-            (eval (if (string= flycheck-rust-crate-type "lib")
-                      "--lib"
-                    (if flycheck-rust-binary-name
-                        (list "--bin" flycheck-rust-binary-name)
-                      nil)))
+            (eval (cond
+                   ((string= flycheck-rust-crate-type "lib") "--lib")
+                   (flycheck-rust-binary-name
+                    (list "--bin" flycheck-rust-binary-name))))
             "--" "-Z" "no-trans"
             (option-flag "--test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path concat)

--- a/flycheck.el
+++ b/flycheck.el
@@ -8112,6 +8112,19 @@ for the `--crate-type' flag."
   :package-version '("flycheck" . "0.20"))
 (make-variable-buffer-local 'flycheck-rust-crate-type)
 
+(flycheck-def-option-var flycheck-rust-binary-name nil rust-cargo
+  "The name of the binary to pass to `cargo rustc --bin'.
+
+The value of this variable is a string denoting the name of the
+binary to build: either the name of the crate, or the name of one
+of the files under `src/bin'.
+
+This variable is needed only when `flycheck-rust-crate-type' is
+`bin' and there are multiple binary targets."
+  :type 'string
+  :safe #'stringp
+  :package-version '("flycheck" . "0.28"))
+
 (flycheck-def-option-var flycheck-rust-library-path nil (rust-cargo rust)
   "A list of library directories for Rust.
 
@@ -8127,7 +8140,11 @@ Relative paths are relative to the file being checked."
 
 This syntax checker needs Cargo with rustc subcommand."
   :command ("cargo" "rustc"
-            (eval (if (string= flycheck-rust-crate-type "lib") "--lib" nil))
+            (eval (if (string= flycheck-rust-crate-type "lib")
+                      "--lib"
+                    (if flycheck-rust-binary-name
+                        (list "--bin" flycheck-rust-binary-name)
+                      nil)))
             "--" "-Z" "no-trans"
             (option-flag "--test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path concat)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4145,8 +4145,7 @@ Why not:
     (flycheck-ert-should-syntax-check
      "language/rust/src/multiline-error.rs" 'rust-mode
      '(7 9 error "mismatched types:
- expected `u8`,\n    found `i8`
-(expected u8,\n    found i8)" :checker rust :id "E0308")
+ expected `u8`,\n    found `i8`" :checker rust :id "E0308")
      '(7 9 info "run `rustc --explain E0308` to see a detailed explanation"
         :checker rust))))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4124,7 +4124,8 @@ Why not:
           :checker ruby-jruby))))
 
 (flycheck-ert-def-checker-test rust-cargo rust warning
-  (let ((flycheck-rust-crate-type "bin"))
+  (let ((flycheck-rust-crate-type "bin")
+        (flycheck-rust-binary-name "flycheck"))
     (flycheck-ert-should-syntax-check
      "language/rust/src/warnings.rs" 'rust-mode
      '(3 1 warning "function is never used: `main`, #[warn(dead_code)] on by default"

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4124,8 +4124,7 @@ Why not:
           :checker ruby-jruby))))
 
 (flycheck-ert-def-checker-test rust-cargo rust warning
-  (let ((flycheck-rust-crate-type "bin")
-        (flycheck-rust-binary-name "flycheck"))
+  (let ((flycheck-rust-crate-type "bin"))
     (flycheck-ert-should-syntax-check
      "language/rust/src/warnings.rs" 'rust-mode
      '(3 1 warning "function is never used: `main`, #[warn(dead_code)] on by default"


### PR DESCRIPTION
When multiple binary targets are present, `cargo rustc` requires the `--bin NAME` option to filter the target to build, otherwise it errs.

This variable allows one to specify the binary to build for projects that have multiple targets.  If it is unset, we fallback to the previous behavior of not passing `--bin`, so it shouldn't break anything.

And I've also updated the 'multiline-error' test, which failed because rustc updated its syntax.