### PR TITLE
C/C++-cppcheck: Add support for multiple --std= arguments and add support for --suppress= arguments

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -169,9 +169,9 @@ to view the docstring of the syntax checker.  Likewise, you may use
          A list of include directories.  Relative paths are relative to the file
          being checked.
 
-      .. option:: flycheck-cppcheck-language-standard
+      .. option:: flycheck-cppcheck-standards
 
-         The C or C++ language standard to use via ``--std=``.
+         The C, C++ and/or POSIX standards to use via one or more ``--std=``.
 
 .. supported-language:: CFEngine
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -173,6 +173,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          The C, C++ and/or POSIX standards to use via one or more ``--std=``.
 
+      .. option:: flycheck-cppcheck-suppressions
+
+         The cppcheck suppressions list to use via one or more ``--suppress=``.
+
 .. supported-language:: CFEngine
 
    .. syntax-checker:: cfengine

--- a/flycheck.el
+++ b/flycheck.el
@@ -5970,6 +5970,19 @@ non-nil, pass the standards via one or more `--std=' options."
   :package-version '(flycheck . "27"))
 (make-variable-buffer-local 'flycheck-cppcheck-standards)
 
+(flycheck-def-option-var flycheck-cppcheck-suppressions nil c/c++-cppcheck
+  "The suppressions to use in cppcheck.
+
+The value of  this variable is either a list  of strings denoting
+the suppressions  to use,  or nil, to  pass nothing  to cppcheck.
+When   non-nil,   pass  the   suppressions   via   one  or   more
+`--suppress=' options."
+  :type '(choice (const :tag "Default" nil)
+                 (repeat :tag "Additional suppressions"
+                         (string :tag "Suppression")))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "27"))
+
 (flycheck-def-option-var flycheck-cppcheck-inconclusive nil c/c++-cppcheck
   "Whether to enable Cppcheck inconclusive checks.
 
@@ -6001,6 +6014,7 @@ See URL `http://cppcheck.sourceforge.net/'."
             (option-flag "--inconclusive" flycheck-cppcheck-inconclusive)
             (option-list "-I" flycheck-cppcheck-include-path)
             (option-list "--std=" flycheck-cppcheck-standards concat)
+            (option-list "--suppress=" flycheck-cppcheck-suppressions concat)
             "-x" (eval
                   (pcase major-mode
                     (`c++-mode "c++")

--- a/flycheck.el
+++ b/flycheck.el
@@ -5957,17 +5957,18 @@ including a list of supported checks."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.14"))
 
-(flycheck-def-option-var flycheck-cppcheck-language-standard nil c/c++-cppcheck
-  "The language standard to use in cppcheck.
+(flycheck-def-option-var flycheck-cppcheck-standards nil c/c++-cppcheck
+  "The standards to use in cppcheck.
 
-The value of this variable is either a string denoting a language
-standard, or nil, to use the default standard.  When non-nil,
-pass the language standard via the `-std' option."
-  :type '(choice (const :tag "Default standard" nil)
-                 (string :tag "Language standard"))
-  :safe #'stringp
-  :package-version '(flycheck . "26"))
-(make-variable-buffer-local 'flycheck-cppcheck-language-standard)
+The value of  this variable is either a list  of strings denoting
+the standards to use, or nil,  to pass nothing to cppcheck.  When
+non-nil, pass the standards via one or more `--std=' options."
+  :type '(choice (const :tag "Default" nil)
+                 (repeat :tag "Custom standards"
+                         (string :tag "Standard name")))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "27"))
+(make-variable-buffer-local 'flycheck-cppcheck-standards)
 
 (flycheck-def-option-var flycheck-cppcheck-inconclusive nil c/c++-cppcheck
   "Whether to enable Cppcheck inconclusive checks.
@@ -5999,7 +6000,7 @@ See URL `http://cppcheck.sourceforge.net/'."
                     flycheck-option-comma-separated-list)
             (option-flag "--inconclusive" flycheck-cppcheck-inconclusive)
             (option-list "-I" flycheck-cppcheck-include-path)
-            (option "--std=" flycheck-cppcheck-language-standard concat)
+            (option-list "--std=" flycheck-cppcheck-standards concat)
             "-x" (eval
                   (pcase major-mode
                     (`c++-mode "c++")


### PR DESCRIPTION
The two commit messages contain descriptions. Let me know if I should clarify anything.

The first commit changes the -cppcheck-language-standard to -cppcheck-standards and to support multiple --std= arguments.

The second commit adds the -cppcheck-suppressions to support zero or more --suppression= arguments.