### PR TITLE
New syntax checker chaining system

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1854,7 +1854,8 @@ Pop up a help buffer with the documentation of CHECKER."
             (modes (flycheck-checker-get checker 'modes))
             (predicate (flycheck-checker-get checker 'predicate))
             (print-doc (flycheck-checker-get checker 'print-doc))
-            (next-checkers (flycheck-checker-get checker 'next-checkers)))
+            (next-checkers (flycheck-checker-get checker 'next-checkers))
+            (conflicts-with (flycheck-checker-get checker 'conflicts-with)))
         (princ (format "%s is a Flycheck syntax checker" checker))
         (when filename
           (princ (format " in `%s'" (file-name-nondirectory filename)))
@@ -1867,13 +1868,20 @@ Pop up a help buffer with the documentation of CHECKER."
         (let ((modes-start (with-current-buffer standard-output (point-max))))
           ;; Track the start of the modes documentation, to properly re-fill
           ;; it later
-          (princ "  This syntax checker checks syntax in the major mode(s) ")
+          (princ (format "  This `%s' checker checks syntax in the major mode(s) "
+                         (flycheck-checker-get checker 'kind)))
           (princ (string-join
                   (seq-map (apply-partially #'format "`%s'") modes)
                   ", "))
           (when predicate
             (princ ", and uses a custom predicate"))
           (princ ".")
+          (when conflicts-with
+            (princ "  It conflicts with ")
+            (princ (string-join
+                    (seq-map (apply-partially #'format "`%s'") conflicts-with)
+                    ", "))
+            (princ "."))
           (when next-checkers
             (princ "  It runs the following checkers afterwards:"))
           (with-current-buffer standard-output

--- a/flycheck.el
+++ b/flycheck.el
@@ -2173,22 +2173,25 @@ Slots:
 `buffer'
      The buffer being checked
 
-`checker'
+`current-checker'
      The syntax checker being used
+
+`remaining-checkers'
+     Syntax checkers to run after the current one.
 
 `context'
      The context object."
-  buffer checker context)
+  buffer current-checker remaining-checkers context)
 
 (defun flycheck-syntax-check-start (syntax-check callback)
   "Start a SYNTAX-CHECK with CALLBACK."
-  (let ((checker (flycheck-syntax-check-checker syntax-check)))
+  (let ((checker (flycheck-syntax-check-current-checker syntax-check)))
     (setf (flycheck-syntax-check-context syntax-check)
           (funcall (flycheck-checker-get checker 'start) checker callback))))
 
 (defun flycheck-syntax-check-interrupt (syntax-check)
   "Interrupt a SYNTAX-CHECK."
-  (let* ((checker (flycheck-syntax-check-checker syntax-check))
+  (let* ((checker (flycheck-syntax-check-current-checker syntax-check))
          (interrupt-fn (flycheck-checker-get checker 'interrupt))
          (context (flycheck-syntax-check-context syntax-check)))
     (when interrupt-fn
@@ -2434,15 +2437,19 @@ checker in order."
   "The current syntax check in the this buffer.")
 (put 'flycheck-current-syntax-check 'permanent-local t)
 
-(defun flycheck-start-current-syntax-check (checker)
-  "Start a syntax check in the current buffer with CHECKER.
+(defun flycheck-start-current-syntax-check (checkers)
+  "Start a syntax check in the current buffer with CHECKERS.
+
+CHECKERS is a list of syntax checkers.  Start the `car' of
+CHECKERS and save the `cdr' of CHECKERS to run later.
 
 Set `flycheck-current-syntax-check' accordingly."
   ;; Allocate the current syntax check *before* starting it.  This allows for
   ;; synchronous checks, which call the status callback immediately in there
   ;; start function.
   (let* ((check (flycheck-syntax-check-new :buffer (current-buffer)
-                                           :checker checker
+                                           :current-checker (car checkers)
+                                           :remaining-checkers (cdr checkers)
                                            :context nil))
          (callback (flycheck-buffer-status-callback check)))
     (setq flycheck-current-syntax-check check)
@@ -2486,9 +2493,9 @@ Get a syntax checker for the current buffer with
         (flycheck-clear-errors)
         (flycheck-mark-all-overlays-for-deletion)
         (condition-case err
-            (let* ((checker (flycheck-get-checker-for-buffer)))
-              (if checker
-                  (flycheck-start-current-syntax-check checker)
+            (let ((checkers (flycheck-get-syntax-checker-chain-for-buffer)))
+              (if checkers
+                  (flycheck-start-current-syntax-check checkers)
                 (flycheck-clear)
                 (flycheck-report-status 'no-checker)))
           (error
@@ -2545,7 +2552,7 @@ discarded."
                (eq syntax-check
                    (buffer-local-value 'flycheck-current-syntax-check buffer)))
       (with-current-buffer buffer
-        (let ((checker (flycheck-syntax-check-checker syntax-check)))
+        (let ((checker (flycheck-syntax-check-current-checker syntax-check)))
           (pcase status
             ((or `errored `interrupted)
              (flycheck-report-failed-syntax-check status)
@@ -2573,35 +2580,36 @@ discarded."
 ERRORS is a list of `flycheck-error' objects reported by the
 current syntax check in `flycheck-current-syntax-check'.
 
-Report all ERRORS and potentially start any next syntax checkers.
+Report all ERRORS and potentially start any remaining syntax
+checkers.
 
-If the current syntax checker reported excessive errors, it is disabled
-via `flycheck-disable-excessive-checker' for subsequent syntax
-checks."
+If the current syntax checker reported excessive errors, it is
+disabled via `flycheck-disable-excessive-checker' for subsequent
+syntax checks."
   (let* ((syntax-check flycheck-current-syntax-check)
-         (checker (flycheck-syntax-check-checker syntax-check))
+         (checker (flycheck-syntax-check-current-checker syntax-check))
+         (next-checkers (flycheck-syntax-check-remaining-checkers syntax-check))
          (errors (flycheck-relevant-errors
                   (flycheck-fill-and-expand-error-file-names
                    (flycheck-filter-errors
                     (flycheck-assert-error-list-p errors) checker)))))
     (unless (flycheck-disable-excessive-checker checker errors)
       (flycheck-report-current-errors errors))
-    (let ((next-checker (flycheck-get-next-checker-for-buffer checker)))
-      (if next-checker
-          (flycheck-start-current-syntax-check next-checker)
-        (setq flycheck-current-syntax-check nil)
-        (flycheck-report-status 'finished)
-        ;; Delete overlays only after the very last checker has run, to avoid
-        ;; flickering on intermediate re-displays
-        (flycheck-delete-marked-overlays)
-        (flycheck-error-list-refresh)
-        (run-hooks 'flycheck-after-syntax-check-hook)
-        (when (eq (current-buffer) (window-buffer))
-          (flycheck-display-error-at-point))
-        ;; Immediately try to run any pending deferred syntax check, which
-        ;; were triggered by intermediate automatic check event, to make sure
-        ;; that we quickly refine outdated error information
-        (flycheck-perform-deferred-syntax-check)))))
+    (if next-checkers
+        (flycheck-start-current-syntax-check next-checkers)
+      (setq flycheck-current-syntax-check nil)
+      (flycheck-report-status 'finished)
+      ;; Delete overlays only after the very last checker has run, to avoid
+      ;; flickering on intermediate re-displays
+      (flycheck-delete-marked-overlays)
+      (flycheck-error-list-refresh)
+      (run-hooks 'flycheck-after-syntax-check-hook)
+      (when (eq (current-buffer) (window-buffer))
+        (flycheck-display-error-at-point))
+      ;; Immediately try to run any pending deferred syntax check, which
+      ;; were triggered by intermediate automatic check event, to make sure
+      ;; that we quickly refine outdated error information
+      (flycheck-perform-deferred-syntax-check))))
 
 (defun flycheck-disable-excessive-checker (checker errors)
   "Disable CHECKER if it reported excessive ERRORS.

--- a/test/specs/test-checker-chains.el
+++ b/test/specs/test-checker-chains.el
@@ -1,0 +1,95 @@
+;;; test-checker-chains.el --- Flycheck Specs: Syntax checker chains  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016  Sebastian Wiesner
+
+;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for syntax checker chains.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(describe "Syntax checker chains"
+
+  ;; Declare a couple of fake checkers
+  (setf (flycheck-checker-get 'chain-syntax-1 'kind) 'syntax)
+  (setf (flycheck-checker-get 'chain-syntax-2 'kind) 'syntax)
+  (setf (flycheck-checker-get 'chain-lint-1 'kind) 'lint)
+  (setf (flycheck-checker-get 'chain-style-1 'kind) 'style)
+  (setf (flycheck-checker-get 'chain-style-2 'kind) 'style)
+
+  (before-each
+    ;; Assume that we can use all syntax checkers
+    (spy-on 'flycheck-may-use-checker :and-return-value t))
+
+  (it "sorts stably by kind"
+    (let ((flycheck-checkers '(chain-lint-1
+                               chain-syntax-1
+                               chain-style-2
+                               chain-syntax-2
+                               chain-style-1)))
+      (expect (flycheck-get-syntax-checker-chain-for-buffer)
+              :to-equal
+              '(chain-syntax-1
+                chain-syntax-2
+                chain-lint-1
+                chain-style-2
+                chain-style-1))))
+
+  (it "evicts conflicting checkers"
+    (cl-letf (
+              ;; A forward conflict
+              ((flycheck-checker-get 'chain-syntax-1 'conflicts-with)
+               '(chain-syntax-2 chain-style-1))
+              ;; A backward conflict
+              ((flycheck-checker-get 'chain-style-2 'conflicts-with)
+               '(chain-syntax-1))
+              ;; This conflict should be ignore because `chain-style-1' is
+              ;; already evicted
+              ((flycheck-checker-get 'chain-style-1 'conflicts-with)
+               '(chain-lint-1)))
+      (expect (flycheck-evict-checkers  '(chain-syntax-1
+                                          chain-syntax-2
+                                          chain-lint-1
+                                          chain-style-1
+                                          chain-style-2))
+              :to-equal '(chain-syntax-1 chain-lint-1))))
+
+  (it "skips unusable syntax checkers"
+    (spy-on 'flycheck-may-use-checker
+            :and-call-fake (lambda (c) (eq c 'chain-syntax-1)))
+    (let ((flycheck-checkers '(chain-syntax-1 chain-lint-1 chain-style-1)))
+      (expect (flycheck-get-syntax-checker-chain-for-buffer)
+              :to-equal '(chain-syntax-1))))
+
+  (it "ignores conflicts from unusable syntax checkers"
+    (spy-on 'flycheck-may-use-checker
+            :and-call-fake (lambda (c) (not (eq c 'chain-syntax-1))))
+    (cl-letf (((flycheck-checker-get 'chain-syntax-1 'conflicts-with)
+               ;; Even though `chain-syntax-1' conflicts with `chain-lint-1' the
+               ;; latter must be included in the chain because the former is
+               ;; ruled out due to `flycheck-may-use-checker'
+               '(chain-lint-1))
+              (flycheck-checkers '(chain-syntax-1 chain-lint-1 chain-style-1)))
+      (expect (flycheck-get-syntax-checker-chain-for-buffer)
+              :to-equal '(chain-lint-1 chain-style-1)))))
+
+;;; test-checker-chains.el ends here

--- a/test/specs/test-checker-chains.el
+++ b/test/specs/test-checker-chains.el
@@ -35,6 +35,8 @@
   (setf (flycheck-checker-get 'chain-lint-1 'kind) 'lint)
   (setf (flycheck-checker-get 'chain-style-1 'kind) 'style)
   (setf (flycheck-checker-get 'chain-style-2 'kind) 'style)
+  (setf (flycheck-checker-get 'chain-style-1 'maximum-level) 'warning)
+  (setf (flycheck-checker-get 'chain-style-2 'maximum-level) 'info)
 
   (before-each
     ;; Assume that we can use all syntax checkers
@@ -90,6 +92,24 @@
                '(chain-lint-1))
               (flycheck-checkers '(chain-syntax-1 chain-lint-1 chain-style-1)))
       (expect (flycheck-get-syntax-checker-chain-for-buffer)
-              :to-equal '(chain-lint-1 chain-style-1)))))
+              :to-equal '(chain-lint-1 chain-style-1))))
+
+  (describe "Maximum level"
+    (let ((checkers '(chain-syntax-1 chain-style-1 chain-style-2)))
+      (it "ignores maximum-level if no level is given"
+        (expect (flycheck-filter-chain-by-error-level checkers nil)
+                :to-equal checkers))
+
+      (it "ignores syntax checkers whose :maximum-level is less severe"
+        (expect (flycheck-filter-chain-by-error-level checkers 'error)
+                :to-equal '(chain-syntax-1)))
+
+      (it "does not ignore syntax checkers whose :maximum-level is more severe"
+        (expect (flycheck-filter-chain-by-error-level checkers 'warning)
+                :to-equal '(chain-syntax-1 chain-style-1)))
+
+      (it "does not ignore any syntax checkers if the level is not severe"
+        (expect (flycheck-filter-chain-by-error-level checkers 'info)
+                :to-equal checkers)))))
 
 ;;; test-checker-chains.el ends here

--- a/test/specs/test-current-errors.el
+++ b/test/specs/test-current-errors.el
@@ -1,0 +1,38 @@
+;;; test-current-errors.el --- Flycheck Specs: Errors in current buffer  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016  Sebastian Wiesner
+
+;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for errors in the current buffer, e.g. `flycheck-current-errors'.
+
+;;; Code:
+
+(describe "Flycheck Current Errors"
+
+  (it "finds the most severe errors"
+    (let ((flycheck-current-errors (list (flycheck-error-new-at 20 10 'warning)
+                                         (flycheck-error-new-at 20 20 'error)
+                                         (flycheck-error-new-at 5 15 'error))))
+      (expect (flycheck-most-severe-current-error)
+              :to-equal
+              (flycheck-error-new-at 20 20 'error)))))
+
+;;; test-current-errors.el ends here

--- a/test/specs/test-generic-checkers.el
+++ b/test/specs/test-generic-checkers.el
@@ -1,0 +1,46 @@
+;;; test-generic-checkers.el --- Flycheck Specs: Generic checkers  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016  Sebastian Wiesner and Flycheck contributors
+
+;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for generic syntax checkers.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(describe "A Generic checker"
+  ;; Fake a checker for `spam-mode' and `eggs-mode'
+  (it "supports a mode it was declared for"
+    (cl-letf (((flycheck-checker-get 'dummy-checker 'modes)
+               '(spam-mode 'eggs-mode))
+              (major-mode 'spam-mode))
+      (expect (flycheck-checker-supports-major-mode-p 'dummy-checker)
+              :to-be-truthy)))
+
+  (it "does not support a mode it was not declared for"
+    (cl-letf (((flycheck-checker-get 'dummy-checker 'modes)
+               '(spam-mode 'eggs-mode))
+              (major-mode 'foo-mode))
+      (expect (flycheck-checker-supports-major-mode-p 'dummy-checker)
+              :not :to-be-truthy))))
+
+;;; test-generic-checkers.el ends here


### PR DESCRIPTION
See #836 for a motivation.  To summarize, the current system is cumbersome to maintain and hard to understand.  This in-progress PR intends to provide a new simpler system that addresses these shortcomings.

I'm opening it early to collect feedback on the approach and the implementation.  Inviting @flycheck/core-developers, @flycheck/maintainers, @mgudemann and @purcell.

Connects to #836.

# Design

Instead of `:next-checkers` we now have three properties to control when a checker is selected:

- `:stage`: The kind of syntax checker, e.g. `syntax`, `type`, `lint`, `style`, `test`, which serves to order checker execution.
- `:conflicts-with`: A list of syntax checkers this syntax checker conflicts with, i.e. may not be used together with.
- `:maximum-level`: The maximum error level in the current buffer this syntax checker should still run at.

I hope that the meaning of these properties is fairly obvious:  Flycheck runs all syntax checkers in order of their `:stage` (e.g. syntax checkers before type checkers, and so on).  To find all checkers it goes through `flycheck-checkers` and collects all checkers that support the current buffer, and then evicts conflicting checkers from first to last.

Finally, after it has assembled the chain, it runs all syntax checkers one by one, and skips over any checker if the highest error level in the current buffer is greater (by priority) than the `:maximum-level`.

# Pros

- The new system is easier to extend.  You just need to declare a proper `:stage` and the new checker seamlessly plugs into existing ones.  There's no need for `flycheck-add-next-checker` anymore.
- It's also easier to understand, because there's no ambiguity in the meaning anymore.  With `:next-checkers` it was never obvious whether Flycheck would try to run all or just the first.
- It scales a lot better:  For large chains, e.g. Go, it's much less maintenance work, because adding a new checker doesn't imply updating `:next-checkers` of all other Go checkers anymore.

# Cons

- With the new system selecting individual checkers doesn't make much sense anymore, so `flycheck-select-checker` and related functionality is gone.  We'll recommend buffer-local bindings of `flycheck-checkers` as alternative, which is actually simpler, too.  But there'll not be an interactive command anymore.
- **It's a breaking change.**  That'll bring some inconvenience to extension authors, but we'll update all official extensions.  Others are on their own anyway, and I'd rather break things once than try and maintain a stub for `:next-checkers` indefinitely.

# Status

- [x] Collect a syntax checker chain
- [x] Declare chains in all syntax checkers
- [x] Run a syntax checker chain
- [ ] Rename `:kind` to `:stage`
- [ ] Filter remaining checkers by maximum level
- [ ] Remove old next-checkers functionality
- [ ] Remove `flycheck-select-checker` and friends
- [ ] Add support for buffer local bindings of `flycheck-checkers`
- [ ] Document the new chaining

# Todo after merging

- [ ] Update official Flycheck extensions that use `:next-checkers`.