### PR TITLE
Display errors from other files (#966)

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3853,7 +3853,9 @@ Return a list with the contents of the table cell."
          (checker (flycheck-error-checker error)))
     (list error
           (vector (flycheck-error-list-make-cell
-                   (file-name-nondirectory filename)
+                   (if filename
+                       (file-name-nondirectory filename)
+                     "-")
                    'flycheck-error-list-filename)
                   (flycheck-error-list-make-number-cell
                    line 'flycheck-error-list-line-number)

--- a/flycheck.el
+++ b/flycheck.el
@@ -3855,7 +3855,7 @@ Return a list with the contents of the table cell."
           (vector (flycheck-error-list-make-cell
                    (if filename
                        (file-name-nondirectory filename)
-                     "-")
+                     "")
                    'flycheck-error-list-filename)
                   (flycheck-error-list-make-number-cell
                    line 'flycheck-error-list-line-number)

--- a/flycheck.el
+++ b/flycheck.el
@@ -4033,7 +4033,7 @@ POS defaults to `point'."
     (flycheck-jump-to-error error)))
 
 (defun flycheck-jump-to-error (error)
-  "Go to the location of the error."
+  "Go to the location of ERROR."
   (let ((buffer (flycheck-error-buffer error))
         (filename (flycheck-error-filename error)))
     (cond

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -67,34 +67,40 @@
     (it "has a local header line"
       (flycheck/with-error-list-buffer
         (expect header-line-format
-                :to-equal "  Line Col Level ID Message (Checker) ")
+                :to-equal " File  Line Col Level ID Message (Checker) ")
         (expect 'header-line-format :to-be-local))))
 
   (describe "Columns"
-    (it "has the line number in the 1st column"
+    (it "has the file name in the 1st column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 0)
                 :to-equal
-                '("Line" 5 flycheck-error-list-entry-< :right-align t))))
+                '("File" 6))))
 
-    (it "has the column number in the 2nd column"
+    (it "has the line number in the 2nd column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 1)
-                :to-equal '("Col" 3 nil :right-align t))))
+                :to-equal
+                '("Line" 5 flycheck-error-list-entry-< :right-align t))))
 
-    (it "has the error level in the 3rd column"
+    (it "has the column number in the 3rd column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 2)
-                :to-equal '("Level" 8 flycheck-error-list-entry-level-<))))
+                :to-equal '("Col" 3 nil :right-align t))))
 
-    (it "has the error ID in the 4th column"
+    (it "has the error level in the 4th column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 3)
-                :to-equal '("ID" 6 t))))
+                :to-equal '("Level" 8 flycheck-error-list-entry-level-<))))
 
-    (it "has the error message in the 5th column"
+    (it "has the error ID in the 5th column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 4)
+                :to-equal '("ID" 6 t))))
+
+    (it "has the error message in the 6th column"
+      (flycheck/with-error-list-buffer
+        (expect (aref tabulated-list-format 5)
                 :to-equal '("Message (Checker)" 0 t)))))
 
   (describe "Entry"
@@ -107,56 +113,56 @@
       (it "has the error object as ID"
         (expect (car entry) :to-be warning))
 
-      (it "has the line number in the 1st cell"
-        (expect (aref cells 0) :to-equal
+      (it "has the line number in the 2nd cell"
+        (expect (aref cells 1) :to-equal
                 (list "10"
                       'type 'flycheck-error-list
                       'face 'flycheck-error-list-line-number)))
 
-      (it "has the column number in the 2nd cell"
-        (expect (aref cells 1) :to-equal
+      (it "has the column number in the 3rd cell"
+        (expect (aref cells 2) :to-equal
                 (list "12"
                       'type 'flycheck-error-list
                       'face 'flycheck-error-list-column-number)))
 
-      (it "has an empty 2nd cell if there is no column number"
+      (it "has an empty 3rd cell if there is no column number"
         (cl-letf* (((flycheck-error-column warning) nil)
                    (entry (flycheck-error-list-make-entry warning))
                    (cells (cadr entry)))
-          (expect (aref cells 1) :to-equal
+          (expect (aref cells 2) :to-equal
                   (list ""
                         'type 'flycheck-error-list
                         'face 'flycheck-error-list-column-number))))
 
-      (it "has the error level in the 3rd cell"
-        (expect (aref cells 2) :to-equal
+      (it "has the error level in the 4th cell"
+        (expect (aref cells 3) :to-equal
                 (list "warning"
                       'type 'flycheck-error-list
                       'face (flycheck-error-level-error-list-face 'warning))))
 
-      (it "has the error ID in the 4th cell"
-        (expect (aref cells 3) :to-equal
+      (it "has the error ID in the 5th cell"
+        (expect (aref cells 4) :to-equal
                 (list "W1"
                       'type 'flycheck-error-list
                       'face 'flycheck-error-list-id)))
 
       (let ((checker-name (propertize "emacs-lisp-checkdoc"
                                       'face 'flycheck-error-list-checker-name)))
-        (it "has the error message in the 5th cell"
+        (it "has the error message in the 6th cell"
           (let* ((message (format (propertize "A foo warning (%s)"
                                               'face 'default)
                                   checker-name)))
-            (expect (aref cells 4) :to-equal
+            (expect (aref cells 5) :to-equal
                     (list message 'type 'flycheck-error-list))))
 
-        (it "has a default message in the 5th cell if there is no message"
+        (it "has a default message in the 6th cell if there is no message"
           (cl-letf* (((flycheck-error-message warning) nil)
                      (entry (flycheck-error-list-make-entry warning))
                      (cells (cadr entry))
                      (message (format (propertize "Unknown warning (%s)"
                                                   'face 'default)
                                       checker-name)))
-            (expect (aref cells 4) :to-equal
+            (expect (aref cells 5) :to-equal
                     (list message 'type 'flycheck-error-list)))))))
 
   (describe "Filter"


### PR DESCRIPTION
This implements the feature requested in #966 and laid out in https://github.com/flycheck/flycheck/pull/970#issuecomment-219734788.

Now:

* There's a new column in the error list, called `File`.

  ``` diff
  +  [("File" 6)
  ```
* We don't discard errors that don't match the current filename (in `flycheck-relevant-error-p`):

   ``` diff
   -       (or (not file-name) (flycheck-same-files-p file-name (buffer-file-name)))
   ```

* We only add overlays for the current buffer in `flycheck-add-overlay`:

   ``` diff
   +  (when (eq (flycheck-error-buffer err) (current-buffer))
   ```
* In `flycheck-next-error-function`, when there are no more errors in the current buffer, we jump to the first error from another file.
* The `flycheck-error-list-goto-error` function uses the same function as the previous item, both use a new function `flycheck-jump-to-error`.
* We add a new face for filenames, `flycheck-error-list-filename`, derived from `buffer-menu-buffer`.

I don't think this is an automatic merge, but it's a straight-forward one. I tried rebasing against master and it worked, but I was unable to get master to load in my Emacs due to a variety of new dependencies which have been added since I last updated flycheck. 😱  So I don't know if it actually runs on your version. Sorry!

Anyway, against `778493e` from 9 months ago it works fine. 🙊 I have to work on other things related to Intero now, but I hope this makes it upstream.

Edit (@lunaryorn): Connects to #966 