### PR TITLE
Add current working directory [:default-directory] property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 29-cvs (in development)
 =======================
 
+- New features:
+
+  - Add ``:default-directory`` option to ``flycheck-define-command-checker``
+    [GH-973]
+
 28 (Jun 05, 2016)
 =================
 

--- a/doc/community/people.rst
+++ b/doc/community/people.rst
@@ -177,6 +177,7 @@ to Flycheck:
 * Sean Salmon (:gh:`phatcabbage`)
 * Sebastian Beyer (:gh:`sebastianbeyer`)
 * Sebastian Wiesner (:gh:`lunaryorn`, founder, head maintainer)
+* Sergey Vinokurov (:gh:`sergv`)
 * Stephen Lewis (:gh:`stephenjlewis`)
 * Steve Purcell (:gh:`purcell`)
 * Sven Keidel (:gh:`svenkeidel`)

--- a/flycheck.el
+++ b/flycheck.el
@@ -93,7 +93,7 @@
 (eval-and-compile
   (unless (fboundp 'string-suffix-p)
     ;; TODO: Remove when dropping support for Emacs 24.3 and earlier
-    (defun string-suffix-p (suffix string  &optional ignore-case)
+    (defun string-suffix-p (suffix string &optional ignore-case)
       "Return non-nil if SUFFIX is a suffix of STRING.
 If IGNORE-CASE is non-nil, the comparison is done without paying
 attention to case differences."
@@ -2129,10 +2129,10 @@ will be used in buffers with MODE."
 Slots:
 
 `buffer'
-     The buffer being checked
+     The buffer being checked.
 
 `checker'
-     The syntax checker being used
+     The syntax checker being used.
 
 `context'
      The context object."
@@ -4280,7 +4280,8 @@ The :default-directory must be a function that will return an absolute path."
                               default-directory)))
     (unless (file-exists-p default-directory)
       (error "Syntax Checker %S has defined non existant :default-directory %s"
-             checker default-directory))
+             checker
+             default-directory))
     default-directory))
 
 ;;;###autoload
@@ -4394,7 +4395,7 @@ default `:verify' function of command checkers."
                     #'flycheck-parse-with-patterns))
         (predicate (plist-get properties :predicate))
         (standard-input (plist-get properties :standard-input))
-        (cwd       (plist-get properties :default-directory)))
+        (cwd (plist-get properties :default-directory)))
     (unless command
       (error "Missing :command in syntax checker %s" symbol))
     (unless (stringp (car command))
@@ -4720,7 +4721,7 @@ and rely on Emacs' own buffering and chunking."
                (args (flycheck-checker-substituted-arguments checker))
                (command (funcall flycheck-command-wrapper-function
                                  (cons program args)))
-               (default-directory  (flycheck-default-directory-wrapper checker))
+               (default-directory (flycheck-default-directory-wrapper checker))
                ;; Use pipes to receive output from the syntax checker.  They are
                ;; more efficient and more robust than PTYs, which Emacs uses by
                ;; default, and since we don't need any job control features, we
@@ -4744,19 +4745,19 @@ and rely on Emacs' own buffering and chunking."
           (process-put process 'flycheck-checker checker)
           (process-put process 'flycheck-callback callback)
           (process-put process 'flycheck-buffer (current-buffer))
-          (process-put process 'flycheck-default-directory  default-directory)
+          (process-put process 'flycheck-default-directory default-directory)
           ;; Track the temporaries created by argument substitution in the
           ;; process itself, to get rid of the global state ASAP.
           (process-put process 'flycheck-temporaries flycheck-temporaries)
           (setq flycheck-temporaries nil)
-          ;; Send the buffer to the process on standard input, if enabled
+          ;; Send the buffer to the process on standard input, if enabled.
           (when (flycheck-checker-get checker 'standard-input)
             (flycheck-process-send-buffer process))
-          ;; Return the process
+          ;; Return the process.
           process)
       (error
        ;; In case of error, clean up our resources, and report the error back to
-       ;; Flycheck
+       ;; Flycheck.
        (flycheck-safe-delete-temporaries)
        (when process
          ;; No need to explicitly delete the temporary files of the process,
@@ -4859,7 +4860,9 @@ FILES is a list of files given as input to the checker.  OUTPUT
 is the output of the syntax checker.  CALLBACK is the status
 callback to use for reporting.
 
-Parse the OUTPUT and report an appropriate error status."
+Parse the OUTPUT and report an appropriate error status.
+
+Resolve all errors in OUTPUT using CWD as worknig directory."
   (let ((errors (flycheck-parse-output output checker (current-buffer))))
     (when (and (/= exit-status 0) (not errors))
       ;; Warn about a suspicious result from the syntax checker.  We do right
@@ -4871,7 +4874,7 @@ Parse the OUTPUT and report an appropriate error status."
 output: %s\nChecker definition probably flawed." checker exit-status output)))
     (funcall callback 'finished
              ;; Fix error file names, by substituting them backwards from the
-             ;; temporaries
+             ;; temporaries.
              (seq-map (lambda (e) (flycheck-fix-error-filename e files cwd))
                       errors))))
 
@@ -5233,6 +5236,8 @@ Return the errors parsed with the error patterns of CHECKER."
 
 (defun flycheck-fix-error-filename (err buffer-files cwd)
   "Fix the file name of ERR from BUFFER-FILES.
+
+Resolves error file names relative to CWD directory.
 
 Make the file name of ERR absolute.  If the absolute file name of
 ERR is in BUFFER-FILES, replace it with the return value of the
@@ -6534,7 +6539,7 @@ See URL `http://www.erlang.org/'."
 See URL `http://www.kuwata-lab.com/erubis/'."
   :command ("erubis" "-z" source)
   :error-patterns
-  ((error line-start  (file-name) ":" line ": " (message) line-end))
+  ((error line-start (file-name) ":" line ": " (message) line-end))
   :modes (html-erb-mode rhtml-mode))
 
 (flycheck-def-args-var flycheck-gfortran-args fortran-gfortran
@@ -6586,7 +6591,7 @@ In any other case, an error is signaled.")
     (`fixed "fixed-form")
     (_ (error "Invalid value for flycheck-gfortran-layout: %S" value))))
 
-(flycheck-def-option-var flycheck-gfortran-warnings  '("all" "extra")
+(flycheck-def-option-var flycheck-gfortran-warnings '("all" "extra")
                          fortran-gfortran
   "A list of warnings for GCC Fortran.
 
@@ -7569,7 +7574,7 @@ See URL `https://puppet.com/'."
           (minimal-match (zero-or-more not-newline))
           ": Could not parse for environment " (one-or-more word)
           ": " (message (minimal-match (zero-or-more anything)))
-          " at "  (file-name "/" (zero-or-more not-newline)) ":" line line-end))
+          " at " (file-name "/" (zero-or-more not-newline)) ":" line line-end))
   :modes puppet-mode
   :next-checkers ((warning . puppet-lint)))
 
@@ -8762,7 +8767,7 @@ See URL `http://www.ruby-doc.org/stdlib-2.0.0/libdoc/yaml/rdoc/YAML.html'."
   :standard-input t
   :error-patterns
   ((error line-start "stdin:" (zero-or-more not-newline) ":" (message)
-          "at line " line " column " column  line-end))
+          "at line " line " column " column line-end))
   :modes yaml-mode)
 
 (provide 'flycheck)

--- a/flycheck.el
+++ b/flycheck.el
@@ -66,6 +66,7 @@
   (require 'compile)        ; Compile Mode integration
   (require 'jka-compr)      ; For JKA workarounds in `flycheck-temp-file-system'
   (require 'pcase)          ; `pcase-dolist' (`pcase' itself is autoloaded)
+  (require 'cl)             ; `cl-member-if-not'
   )
 
 (require 'dash)
@@ -4361,11 +4362,12 @@ default `:verify' function of command checkers."
         (standard-input (plist-get properties :standard-input))
         (environment (plist-get properties :environment))
         (cwd       (when (plist-get properties :cwd) (file-truename (car (plist-get properties :cwd))))))
-    ;; FIXME add more to the environment checker and to the cwd checker
+    ;; FIXME add more to the cwd checker
     ;; (unless (stringp (car cwd)) 
     ;;   (error "Current working directory must be a string"))
-    ;; (unless (listp environment)
-    ;;   (error "Environment needs to be a list of strings (\"var=value\")"))
+    ;; the environement variables need to be either emtpy or a list of strings
+    (unless (or (not environment) (and (listp environment) (not (member-if-not #'stringp environment))))
+       (error "Environment variables in syntax checker %s needs to be a list of strings (\"var=value\")" symbol))
     (unless command
       (error "Missing :command in syntax checker %s" symbol))
     (unless (stringp (car command))

--- a/flycheck.el
+++ b/flycheck.el
@@ -66,7 +66,6 @@
   (require 'compile)        ; Compile Mode integration
   (require 'jka-compr)      ; For JKA workarounds in `flycheck-temp-file-system'
   (require 'pcase)          ; `pcase-dolist' (`pcase' itself is autoloaded)
-  (require 'cl)             ; `cl-member-if-not'
   )
 
 (require 'dash)
@@ -4366,7 +4365,7 @@ default `:verify' function of command checkers."
     ;; (unless (stringp (car cwd)) 
     ;;   (error "Current working directory must be a string"))
     ;; the environement variables need to be either emtpy or a list of strings
-    (unless (or (not environment) (and (listp environment) (not (member-if-not #'stringp environment))))
+    (unless (or (not environment) (and (listp environment) (not (cl-member-if-not #'stringp environment))))
        (error "Environment variables in syntax checker %s needs to be a list of strings (\"var=value\")" symbol))
     (unless command
       (error "Missing :command in syntax checker %s" symbol))

--- a/flycheck.el
+++ b/flycheck.el
@@ -5520,7 +5520,7 @@ SYMBOL with `flycheck-def-executable-var'."
              `(:verify #',verify-fn))
          :standard-input ',(plist-get properties :standard-input)
          ,@(when cwd
-             `(:default-directory #',cwd))))))
+             `(:default-directory ,cwd))))))
 
 
 ;;; Built-in checkers

--- a/flycheck.el
+++ b/flycheck.el
@@ -4257,19 +4257,24 @@ universal prefix arg, and only the id with normal prefix arg."
     (`(eval ,_) t)
     (_ nil)))
 
-(defun flycheck-cwd-wrapper (checker)
+(defun flycheck-default-directory-wrapper (checker)
   "Function returning apropriate current working directory.
 
 Work out the working directory from which the CHECKER command
 will be called.  The default is the `default-directory' of the source-buffer
 from which flycheck is calling the checker.
-:cwd can be a list that contains a fixed path string or a function that will
-return a path.  The function needs to return an absolut path not a relative path."
-  (let ((cwd (flycheck-checker-get checker 'cwd)))
-    (or (and (functionp cwd) (funcall cwd))
-        (and (listp cwd) (stringp (car cwd)) (file-truename (car cwd)))
-        default-directory)))
-
+:default-directory can be a string that contains a fixed directory path or a function
+that will return a path.  The function needs to return an absolut path not a
+relative path."
+  (let* ((cwd (flycheck-checker-get checker 'default-directory))
+         (default-directory (or (and (functionp cwd) (funcall cwd))
+                                (and (stringp cwd) (file-truename cwd))
+                                default-directory))
+         )
+    (unless (file-exists-p default-directory)
+      (error "Syntax Checker %S has defined non existant :default-directory %s"
+             checker default-directory))
+    default-directory))
 
 ;;;###autoload
 (defun flycheck-define-command-checker (symbol docstring &rest properties)
@@ -4344,6 +4349,15 @@ of command checkers is `flycheck-sanitize-errors'.
 
      Defaults to nil.
 
+`:default-directory PATH-or-FUNCTION'
+     The value of `default-directory' from where the checker is called.
+
+     Either a directory path or a function that returns a directory
+     path.
+
+     This property is optional.  If omitted, it defaults to
+     `default-directory' of the buffer that calls the syntax checker.
+
 Note that you may not give `:start', `:interrupt', and
 `:print-doc' for a command checker.  You can give a custom
 `:verify' function, though, whose results will be appended to the
@@ -4373,10 +4387,7 @@ default `:verify' function of command checkers."
                     #'flycheck-parse-with-patterns))
         (predicate (plist-get properties :predicate))
         (standard-input (plist-get properties :standard-input))
-        (cwd       (plist-get properties :cwd)))
-    ;; FIXME add more to the cwd checker
-    ;; (unless (stringp (car cwd))
-    ;;   (error "Current working directory must be a string"))
+        (cwd       (plist-get properties :default-directory)))
     (unless command
       (error "Missing :command in syntax checker %s" symbol))
     (unless (stringp (car command))
@@ -4415,7 +4426,7 @@ default `:verify' function of command checkers."
                        (error-parser . ,parser)
                        (error-patterns . ,patterns)
                        (standard-input . ,standard-input)
-                       (cwd         . ,cwd)))
+                       (default-directory . ,cwd)))
         (setf (flycheck-checker-get symbol prop) value)))))
 
 (eval-and-compile
@@ -4702,7 +4713,7 @@ and rely on Emacs' own buffering and chunking."
                (args (flycheck-checker-substituted-arguments checker))
                (command (funcall flycheck-command-wrapper-function
                                  (cons program args)))
-               (default-directory  (flycheck-cwd-wrapper checker))
+               (default-directory  (flycheck-default-directory-wrapper checker))
                ;; Use pipes to receive output from the syntax checker.  They are
                ;; more efficient and more robust than PTYs, which Emacs uses by
                ;; default, and since we don't need any job control features, we
@@ -4719,7 +4730,6 @@ and rely on Emacs' own buffering and chunking."
           ;; example for such a conflict.
           (setq process (apply 'start-process (format "flycheck-%s" checker)
                                nil command))
-          ;; why is this using setf and not set-process-sentinal ??
           (setf (process-sentinel process) #'flycheck-handle-signal)
           (setf (process-filter process) #'flycheck-receive-checker-output)
           (set-process-query-on-exit-flag process nil)
@@ -4727,7 +4737,7 @@ and rely on Emacs' own buffering and chunking."
           (process-put process 'flycheck-checker checker)
           (process-put process 'flycheck-callback callback)
           (process-put process 'flycheck-buffer (current-buffer))
-          (process-put process 'flycheck-cwd  default-directory)
+          (process-put process 'flycheck-default-directory  default-directory)
           ;; Track the temporaries created by argument substitution in the
           ;; process itself, to get rid of the global state ASAP.
           (process-put process 'flycheck-temporaries flycheck-temporaries)
@@ -4816,7 +4826,7 @@ _EVENT is ignored."
     (let ((files (process-get process 'flycheck-temporaries))
           (buffer (process-get process 'flycheck-buffer))
           (callback (process-get process 'flycheck-callback))
-          (cwd (process-get process 'flycheck-cwd)))
+          (cwd (process-get process 'flycheck-default-directory)))
       ;; Delete the temporary files
       (seq-do #'flycheck-safe-delete files)
       (when (buffer-live-p buffer)
@@ -5196,7 +5206,7 @@ tool, just like `compile' (\\[compile])."
     (user-error "Cannot use syntax checker %S in this buffer" checker))
   (unless (flycheck-checker-executable checker)
     (user-error "Cannot run checker %S as shell command" checker))
-  (let* ((default-directory (flycheck-cwd-wrapper checker))
+  (let* ((default-directory (flycheck-default-directory-wrapper checker))
          (command (flycheck-checker-shell-command checker))
          (buffer (compilation-start command nil #'flycheck-compile-name)))
     (with-current-buffer buffer
@@ -5205,7 +5215,7 @@ tool, just like `compile' (\\[compile])."
 
 
 ;;; General error parsing for command checkers
-(defun flycheck-parse-output (output checker buffer) 
+(defun flycheck-parse-output (output checker buffer)
   "Parse OUTPUT from CHECKER in BUFFER.
 
 OUTPUT is a string with the output from the checker symbol
@@ -5489,7 +5499,7 @@ SYMBOL with `flycheck-def-executable-var'."
         (filter (plist-get properties :error-filter))
         (predicate (plist-get properties :predicate))
         (verify-fn (plist-get properties :verify))
-        (cwd (plist-get properties :cwd)))
+        (cwd (plist-get properties :default-directory)))
 
     `(progn
        (flycheck-def-executable-var ,symbol ,(car command))
@@ -5510,7 +5520,7 @@ SYMBOL with `flycheck-def-executable-var'."
              `(:verify #',verify-fn))
          :standard-input ',(plist-get properties :standard-input)
          ,@(when cwd
-             `(:cwd #',cwd))))))
+             `(:default-directory #',cwd))))))
 
 
 ;;; Built-in checkers

--- a/flycheck.el
+++ b/flycheck.el
@@ -4276,14 +4276,15 @@ universal prefix arg, and only the id with normal prefix arg."
 Work out the working directory from which the CHECKER command
 will be called.  The default is the `default-directory' of the source-buffer
 from which flycheck is calling the checker.
-:default-directory can be a string that contains a fixed directory path or a function
-that will return a path.  The function needs to return an absolut path not a
-relative path."
+The :default-directory must be a function that will return an absolute path."
   (let* ((cwd (flycheck-checker-get checker 'default-directory))
-         (default-directory (or (and (functionp cwd) (funcall cwd))
-                                (and (stringp cwd) (file-truename cwd))
-                                default-directory))
-         )
+         (default-directory (if cwd
+                                (if (functionp cwd)
+                                    (funcall cwd)
+                                  (error "Syntax Checker %S has defined :default-directory which is not a function: %s"
+                                         checker
+                                         default-directory))
+                              default-directory)))
     (unless (file-exists-p default-directory)
       (error "Syntax Checker %S has defined non existant :default-directory %s"
              checker default-directory))

--- a/flycheck.el
+++ b/flycheck.el
@@ -5510,8 +5510,7 @@ SYMBOL with `flycheck-def-executable-var'."
         (parser (plist-get properties :error-parser))
         (filter (plist-get properties :error-filter))
         (predicate (plist-get properties :predicate))
-        (verify-fn (plist-get properties :verify))
-        (cwd (plist-get properties :default-directory)))
+        (verify-fn (plist-get properties :verify)))
 
     `(progn
        (flycheck-def-executable-var ,symbol ,(car command))
@@ -5530,9 +5529,7 @@ SYMBOL with `flycheck-def-executable-var'."
          :next-checkers ',(plist-get properties :next-checkers)
          ,@(when verify-fn
              `(:verify #',verify-fn))
-         :standard-input ',(plist-get properties :standard-input)
-         ,@(when cwd
-             `(:default-directory ,cwd))))))
+         :standard-input ',(plist-get properties :standard-input)))))
 
 
 ;;; Built-in checkers

--- a/flycheck.el
+++ b/flycheck.el
@@ -4258,16 +4258,18 @@ universal prefix arg, and only the id with normal prefix arg."
     (_ nil)))
 
 (defun flycheck-cwd-wrapper (checker)
-  "is trying to work out the working directory from which the checker command 
-will be called. The default is the `default-directory' of the buffer from 
-which flycheck is calling the checker.
+  "Function returning apropriate current working directory.
+
+Work out the working directory from which the CHECKER command
+will be called.  The default is the `default-directory' of the source-buffer
+from which flycheck is calling the checker.
 :cwd can be a list that contains a fixed path string or a function that will
-return a path. The function needs to return an absolut path not a relative path."   
+return a path.  The function needs to return an absolut path not a relative path."
   (let ((cwd (flycheck-checker-get checker 'cwd)))
-    (or (and (functionp cwd) (funcall cwd)) 
+    (or (and (functionp cwd) (funcall cwd))
         (and (listp cwd) (stringp (car cwd)) (file-truename (car cwd)))
         default-directory)))
-  
+
 
 ;;;###autoload
 (defun flycheck-define-command-checker (symbol docstring &rest properties)
@@ -4371,14 +4373,10 @@ default `:verify' function of command checkers."
                     #'flycheck-parse-with-patterns))
         (predicate (plist-get properties :predicate))
         (standard-input (plist-get properties :standard-input))
-        (environment (plist-get properties :environment))
         (cwd       (plist-get properties :cwd)))
     ;; FIXME add more to the cwd checker
-    ;; (unless (stringp (car cwd)) 
+    ;; (unless (stringp (car cwd))
     ;;   (error "Current working directory must be a string"))
-    ;; the environement variables need to be either emtpy or a list of strings
-    (unless (or (not environment) (and (listp environment) (not (cl-member-if-not #'stringp environment))))
-       (error "Environment variables in syntax checker %s needs to be a list of strings (\"var=value\")" symbol))
     (unless command
       (error "Missing :command in syntax checker %s" symbol))
     (unless (stringp (car command))
@@ -4417,7 +4415,6 @@ default `:verify' function of command checkers."
                        (error-parser . ,parser)
                        (error-patterns . ,patterns)
                        (standard-input . ,standard-input)
-                       (environment . ,environment)
                        (cwd         . ,cwd)))
         (setf (flycheck-checker-get symbol prop) value)))))
 
@@ -4705,7 +4702,6 @@ and rely on Emacs' own buffering and chunking."
                (args (flycheck-checker-substituted-arguments checker))
                (command (funcall flycheck-command-wrapper-function
                                  (cons program args)))
-               (process-environment (append (flycheck-checker-get checker 'environment) process-environment))
                (default-directory  (flycheck-cwd-wrapper checker))
                ;; Use pipes to receive output from the syntax checker.  They are
                ;; more efficient and more robust than PTYs, which Emacs uses by
@@ -5197,8 +5193,7 @@ tool, just like `compile' (\\[compile])."
     (user-error "Cannot use syntax checker %S in this buffer" checker))
   (unless (flycheck-checker-executable checker)
     (user-error "Cannot run checker %S as shell command" checker))
-  (let* ((compilation-environment (flycheck-checker-get checker 'environment))
-         (default-directory (flycheck-cwd-wrapper checker))
+  (let* ((default-directory (flycheck-cwd-wrapper checker))
          (command (flycheck-checker-shell-command checker))
          (buffer (compilation-start command nil #'flycheck-compile-name)))
     (with-current-buffer buffer
@@ -5491,7 +5486,6 @@ SYMBOL with `flycheck-def-executable-var'."
         (filter (plist-get properties :error-filter))
         (predicate (plist-get properties :predicate))
         (verify-fn (plist-get properties :verify))
-        (environment (plist-get properties :environment))
         (cwd (plist-get properties :cwd)))
 
     `(progn
@@ -5512,8 +5506,6 @@ SYMBOL with `flycheck-def-executable-var'."
          ,@(when verify-fn
              `(:verify #',verify-fn))
          :standard-input ',(plist-get properties :standard-input)
-         ,@(when environment
-             `(:environment #',environment))
          ,@(when cwd
              `(:cwd #',cwd))))))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1522,12 +1522,17 @@
   :tags '(errors)
   (flycheck-ert-with-resource-buffer "global-mode-dummy.el"
     (let* ((absolute-fn (flycheck-ert-resource-filename "substitute-dummy"))
+           (cwd (file-name-directory absolute-fn))
+           (relative-fn (file-name-nondirectory absolute-fn))
            (errors (list (flycheck-error-new :filename "foo")
                          (flycheck-error-new :filename absolute-fn)
+                         (flycheck-error-new :filename relative-fn)
                          (flycheck-error-new :filename nil))))
       (should (equal (mapcar #'flycheck-error-filename
-                             (flycheck-fill-and-expand-error-file-names errors))
+                             (flycheck-fill-and-expand-error-file-names errors
+                                                                        cwd))
                      (list (flycheck-ert-resource-filename "foo")
+                           absolute-fn
                            absolute-fn
                            (flycheck-ert-resource-filename
                             "global-mode-dummy.el")))))))


### PR DESCRIPTION
Hi, this is a followup to #813. I cannot add new commits to that pull request so I'm creating a new one.

Since original pull request was stalled for quite some time with several unresolved review comments I decided to jump in and resolve any mentioned issues. This feature is pretty essential for Haskell checking, in my opinion.

Stylistic issues were resolved and, I hope, no new were introduced.

The problem with `flycheck-fill-and-expand-error-file-names` not having access to current working directory was fixed as well. The issue was critical for checkers that can report relative file names in their errors, but it didn't affect checkers that report absolute file names. So it was not as critical as last comment of #813 suggests, but it's fixed now anyway.

To fix it, I added `default-directory` field to `flycheck-syntax-check` structure  and moved binding of `default-directory` variable out of `flycheck-start-command-checker` function into the `flycheck-syntax-check-start` function. This indirection obscures things a bit but allows to calculate default directory only once per cherker run. Since computing default directory may involve costly traversals of filesystem, it seems worth some additional obscurity.

I regret not adding any new test cases, but it seems to require some non-trivial effort - the core repository seems to contain only, well, core tests and no tests for specific checkers.

Edit (@lunaryorn): Dear Waffle, this connects to #312.