### PR TITLE
Fix "End of file during parsing" when no errors with tslint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5361,7 +5361,7 @@ the BUFFER that was checked respectively.
 See URL `https://palantir.github.io/tslint/' for more information
 about TSLint."
   (let* ((json-array-type 'list)
-         (tslint-json-output (json-read-from-string output))
+         (tslint-json-output (and (not (string-empty-p output)) (json-read-from-string output)))
          errors)
     (dolist (emessage tslint-json-output)
       (let-alist emessage


### PR DESCRIPTION
Ping @Simplify since you seem to be responsible for the tslint integration. Thanks, by the way! 😄 

When outputting to JSON format, tslint returns nothing 
(empty string) if there are no errors. Passing empty string to 
`json-read-from-string` throws an "End of file during parsing" error.

This patch replaces empty string with a valid empty JSON object,
which allows the Flycheck pass to complete normally.