### PR TITLE
Pass epg-gpg-home-directory to gpg invocation

### DIFF
--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -39,6 +39,7 @@ This function is ABSOLUTELY INSECURE, use only and exclusively for testing."
   (let* ((process-connection-type nil)
          (gpg (start-process "flycheck-buttercup-gpg" nil
                              epg-gpg-program "--batch" "--no-tty"
+                             "--homedir" epg-gpg-home-directory
                              "-c" "--passphrase"
                              passphrase "-o" filename "-")))
     (process-send-string gpg string)


### PR DESCRIPTION
Otherwise, the temporary GPG home directory that the test suite sets up
doesn't actually get used when gpg is invoked to encrypt the file.