### PR TITLE
Detect DMD continuation lines

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6187,7 +6187,9 @@ Requires DMD 2.066 or newer.  See URL `http://dlang.org/'."
           (file-name) "(" line "," column "): Error: " (message)
           line-end)
    (warning line-start (file-name) "(" line "," column "): "
-            (or "Warning" "Deprecation") ": " (message) line-end))
+            (or "Warning" "Deprecation") ": " (message) line-end)
+   (info line-start (file-name) "(" line "," column "): "
+            (one-or-more " ") (message) line-end))
   :modes d-mode)
 
 (defconst flycheck-this-emacs-executable

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2950,6 +2950,19 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
    '(4 8 error "module external_library is in file 'external_library.d' which cannot be read"
        :checker d-dmd)))
 
+(flycheck-ert-def-checker-test d-dmd d continuation-line
+  (unless (version<= "24.4" emacs-version)
+    (ert-skip "Skipped because CC Mode is broken on 24.3.
+See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
+  (flycheck-ert-should-syntax-check
+   "language/d/src/dmd/continuation.d" 'd-mode
+   '(5 12 error "undefined identifier 'invalid'"
+       :checker d-dmd)
+   '(10 12 error "template instance continuation.T!() error instantiating"
+       :checker d-dmd)
+   '(13 1 info "instantiated from here: U!()"
+       :checker d-dmd)))
+
 (flycheck-ert-def-checker-test (emacs-lisp emacs-lisp-checkdoc) emacs-lisp nil
   (flycheck-ert-should-syntax-check
    "language/emacs-lisp/warnings.el" 'emacs-lisp-mode

--- a/test/resources/language/d/src/dmd/continuation.d
+++ b/test/resources/language/d/src/dmd/continuation.d
@@ -1,0 +1,13 @@
+// Test continuation lines for template instantiations
+
+template T()
+{
+	alias T = invalid;
+}
+
+template U()
+{
+	alias U = T!();
+}
+
+U!() u;


### PR DESCRIPTION
When a template declared in another module fails to instantiate, DMD produces errors such as:

```
lib.d(3,12): Error: undefined identifier 'invalid'
lib.d(8,12): Error: template instance lib.T!() error instantiating
src.d(3,1):        instantiated from here: U!()
```

Previously, Flycheck would only detect the first two lines as error messages. However, since they both occur outside of the edited file, this gives the impression that the edited file has no issues.

This patch detects continuation lines (such as the third line above) as Flycheck errors with the "info" severity.

----

I hope I got the tests right, because I haven't been able to run them locally. Running `make SELECTOR='(language d)' integ` tries to run three tests and fails them all, with the message `(file-error "Cannot open load file" "no such file or directory" "cask-cli")`. I found https://github.com/flycheck/flycheck/issues/531, however from that I gather that this is a problem specific to Emacs 24.3 and below, and I'm running Emacs 24.5.1.

Also, I guess this isn't relevant to the changes here, but when running `make specs`, the "Utilities" / "flycheck-encrypted-buffer-p" / "recognizes an encrypted buffer" test seems to still pop up a dialog box prompting me for a password. Entering "spam with eggs" (from looking at the code) does get it to continue.