### PR TITLE
Enable ms-compatibility-version for clang

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -109,6 +109,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          Whether to enable Microsoft extensions to C/C++ in `c/c++-clang`.
 
+      .. option:: flycheck-clang-ms-compatibility-version
+
+         The Microsoft compatibility version to use with Clang.
+
       .. option:: flycheck-clang-no-exceptions
                   flycheck-gcc-no-exceptions
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -5639,14 +5639,14 @@ When non-nil, enable Microsoft extensions to C/C++ via
   :package-version '(flycheck . "0.16"))
 
 (flycheck-def-option-var flycheck-clang-ms-compatibility-version nil c/c++-clang
-  "The Microsoft compatibility version to use with clang
+  "The Microsoft compatibility version to use with Clang.
 
 When non-nil, enable Microsoft compatibility to C/C++ via
 `-fms-compatibility-version'."
   :type '(choice (const :tag "No compatibility version" nil)
                  (string :tag "Compatibility version"))
   :safe #'stringp
-  :package-version '(flycheck . "0.29"))
+  :package-version '(flycheck . "29"))
 
 (flycheck-def-option-var flycheck-clang-no-exceptions nil c/c++-clang
   "Whether to disable exceptions in Clang.

--- a/flycheck.el
+++ b/flycheck.el
@@ -5638,6 +5638,16 @@ When non-nil, enable Microsoft extensions to C/C++ via
   :safe #'booleanp
   :package-version '(flycheck . "0.16"))
 
+(flycheck-def-option-var flycheck-clang-ms-compatibility-version nil c/c++-clang
+  "The Microsoft compatibility version to use with clang
+
+When non-nil, enable Microsoft compatibility to C/C++ via
+`-fms-compatibility-version'."
+  :type '(choice (const :tag "No compatibility version" nil)
+                 (string :tag "Compatibility version"))
+  :safe #'stringp
+  :package-version '(flycheck . "0.29"))
+
 (flycheck-def-option-var flycheck-clang-no-exceptions nil c/c++-clang
   "Whether to disable exceptions in Clang.
 
@@ -5739,6 +5749,7 @@ See URL `http://clang.llvm.org/'."
             (option-flag "-pedantic-errors" flycheck-clang-pedantic-errors)
             (option "-stdlib=" flycheck-clang-standard-library concat)
             (option-flag "-fms-extensions" flycheck-clang-ms-extensions)
+            (option "-fms-compatibility-version=" flycheck-clang-ms-compatibility-version concat)
             (option-flag "-fno-exceptions" flycheck-clang-no-exceptions)
             (option-flag "-fno-rtti" flycheck-clang-no-rtti)
             (option-flag "-fblocks" flycheck-clang-blocks)


### PR DESCRIPTION
Hi,

I started today to configure flycheck for myself on windows and I tried to make it work with windows. Unfortunately clang reports errors for Microsoft Visual C++ headers. There is option to avoid it - ms-compatibility-version but unfortunately it was not available in flycheck.

Now you only need to call:
`(setq flycheck-clang-ms-compatibility-version "19")`
to fix this problem.

You may see how problem looks like in the following image (trying to include <string> header)
![error](https://cloud.githubusercontent.com/assets/5777649/16126343/f758ca9a-33f7-11e6-8894-500b273dfe66.png)

