### PR TITLE
install: add (package-refresh-contents)

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -40,7 +40,8 @@ run ``M-x eval-buffer``:
    (add-to-list 'package-archives
                 '("melpa" . "http://stable.melpa.org/packages/") t)
    (package-initialize)
-
+   (package-refresh-contents)
+   
    (package-install 'flycheck)
 
    (global-flycheck-mode)


### PR DESCRIPTION
At least on Emacs 24.4.1, the instructions didn't work and instead the
line (package-install 'flycheck) was raising the error:

    package-compute-transaction: Package `flycheck-' is unavailable

Indeed, the index of available packages wasn't refreshed after
'package-archives was updated. Add (package-refresh-contents) to make
sure it is.
