### PR TITLE
Parse puppet 3 errors, add puppet 3 tests

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7521,6 +7521,9 @@ See URL `https://puppet.com/'."
           (one-or-more (in "a-z" "0-9" "_")) ":"
           (message) " at line " line ":" column line-end)
    ;; Errors from Puppet < 4
+   (error line-start "Error: Could not parse for environment "
+          (one-or-more (in "a-z" "0-9" "_")) ":"
+          (message) " at line " line line-end)
    (error line-start
           ;; Skip over the path of the Puppet executable
           (minimal-match (zero-or-more not-newline))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3563,10 +3563,18 @@ Why not:
    '(4 2 error "Syntax error, maybe a missing semicolon?"
        :checker processing)))
 
-(flycheck-ert-def-checker-test puppet-parser puppet parser-error
+; the puppet 4 and 3 tests are mutually exclusive due to one having column and the other not
+(flycheck-ert-def-checker-test puppet-parser puppet parser-error-puppet-4
+  (skip-unless (version<= "4" (shell-command-to-string "printf %s \"$(puppet --version)\"")))
   (flycheck-ert-should-syntax-check
    "language/puppet/parser-error.pp" 'puppet-mode
    '(3 9 error "Syntax error at '>'" :checker puppet-parser)))
+
+(flycheck-ert-def-checker-test puppet-parser puppet parser-error-puppet-3
+  (skip-unless (version<= (shell-command-to-string "printf %s \"$(puppet --version)\"") "4"))
+  (flycheck-ert-should-syntax-check
+   "language/puppet/parser-error2.pp" 'puppet-mode
+   '(4 nil error "Syntax error at 'helloagain'; expected '}'" :checker puppet-parser)))
 
 (flycheck-ert-def-checker-test puppet-lint puppet nil
   (flycheck-ert-should-syntax-check

--- a/test/resources/language/puppet/parser-error2.pp
+++ b/test/resources/language/puppet/parser-error2.pp
@@ -1,0 +1,5 @@
+# Test that the missing comma error is parsed
+class {'parser_error':
+  hello      => 'test'
+  helloagain => 'test'
+}


### PR DESCRIPTION
This adds an error pattern for puppet 3 parser, so that it can parse some
errors which weren't parsed before. It also adds a test for this case.
Since puppet 3 and 4 parser output is incompatible, the puppet-parser
tests are now explicitly named after the puppet version they test.