### PR TITLE
optionally install golang test dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
   - Add ``:working-directory`` option to ``flycheck-define-command-checker``
     [GH-973] [GH-1012]
+  - ``flycheck-go-build-install-deps`` turns on dependency installation for ``go test``
+    as well as ``go build`` [GH-1003]
 
 - Improvements:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -379,7 +379,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. option:: flycheck-go-build-install-deps
 
-         Whether to install dependencies while checking.
+         Whether to install dependencies while checking with `go-build` or
+         `go-test`
 
       .. option:: flycheck-go-build-tags
 
@@ -388,6 +389,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
    .. syntax-checker:: go-test
 
       Check syntax and types of Go tests with the `Go compiler`_.
+
+      .. option:: flycheck-go-build-install-deps
+         :noindex:
+
+         See `flycheck-go-build-install-deps`.
 
    .. syntax-checker:: go-errcheck
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -6732,8 +6732,8 @@ See URL `https://golang.org/cmd/go/' and URL
                 :message (if have-vet "present" "missing")
                 :face (if have-vet 'success '(bold error)))))))
 
-(flycheck-def-option-var flycheck-go-build-install-deps nil go-build
-  "Whether to install dependencies in `go build'.
+(flycheck-def-option-var flycheck-go-build-install-deps nil (go-build go-test)
+  "Whether to install dependencies in `go build' and `go test'.
 
 If non-nil automatically install dependencies with `go build'
 while syntax checking."
@@ -6802,7 +6802,9 @@ See URL `http://golang.org/cmd/go'."
   ;; `temporary-file-name'.
   ;; TODO: Switch to `null-device'` when < Go 1.6 support is removed.
   ;; See: https://github.com/flycheck/flycheck/issues/838
-  :command ("go" "test" "-c" "-o" temporary-file-name)
+  :command ("go" "test"
+            (option-flag "-i" flycheck-go-build-install-deps)
+            "-c" "-o" temporary-file-name)
   :error-patterns
   ((error line-start (file-name) ":" line ": "
           (message (one-or-more not-newline)


### PR DESCRIPTION
use the `flycheck-go-build-install-deps` flag to optionally install test dependencies. this will improve the time it takes to run flycheck