### PR TITLE
Define default directory for haskell-stack-ghc checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@
   - Add ``:default-directory`` option to ``flycheck-define-command-checker``
     [GH-973]
 
+- Improvements:
+
+  - Add default directory for ``haskell-stack-ghc`` and ``haskell-ghc`` checkers [GH-1007]
+
+
 28 (Jun 05, 2016)
 =================
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -6977,16 +6977,15 @@ Otherwise return the previously used cache directory."
             (make-temp-file "flycheck-haskell-ghc-cache" 'directory))))
 
 (defun flycheck-haskell--find-default-directory (checker)
-  "Come up with a sutable default directory for Haskell to run
-checker in.
+  "Come up with a suitable default directory for Haskell to run CHECKER in.
 
 In case of `haskell-stack-ghc' checker it is directory with
-stack.yaml file. If there's no stack.yaml file in any parent
+stack.yaml file.  If there's no stack.yaml file in any parent
 directory, it will be the directory that \"stack path --project-root\"
-command returs.
+command returns.
 
 For all other checkers, it is the closest parent directory that
-contains cabal file."
+contains a cabal file."
   (pcase checker
     (`haskell-stack-ghc
      (or
@@ -7001,19 +7000,14 @@ contains cabal file."
                      (file-directory-p stack-dir))
             stack-dir)))))
     (_
-     (if (fboundp 'haskell-cabal-find-file)
-         (let ((cabal-file (haskell-cabal-find-file)))
-           (when cabal-file
-             (file-name-directory cabal-file)))
-       (locate-dominating-file (file-name-directory (buffer-file-name))
-                               (lambda (dir)
-                                 (not
-                                  (null
-                                   (directory-files dir
-                                                    nil ;; full
-                                                    ".+\\.cabal\\'"
-                                                    t ;; nosort
-                                                    )))))))))
+     (locate-dominating-file
+      (file-name-directory (buffer-file-name))
+      (lambda (dir)
+        (directory-files dir
+                         nil ;; use full paths
+                         ".+\\.cabal\\'"
+                         t ;; do not sort result
+                         ))))))
 
 (flycheck-define-checker haskell-stack-ghc
   "A Haskell syntax and type checker using `stack ghc'.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6993,9 +6993,7 @@ contains a cabal file."
       (when (executable-find "stack")
         (let* ((stack-output
                 (process-lines "stack" "path" "--project-root"))
-               (stack-dir
-                (when stack-output
-                  (car stack-output))))
+               (stack-dir (car stack-output)))
           (when (and stack-dir
                      (file-directory-p stack-dir))
             stack-dir)))))


### PR DESCRIPTION
Default directory is detected either by looking for `stack.yaml` or asking `stack path --project-root` for `haskel-stack-ghc` checker or by looking for cabal file in case of `haskell-ghc` checker.

@mrkkrp Please comment, if you think something should be done differently.