### PR TITLE
Add slim-lint checker definition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,16 @@
 29-cvs (in development)
 =======================
 
+- New syntax checkers:
+
+  - Slim with ``slim-lint`` [GH-1013]
+
 - New features:
 
   - Add ``:working-directory`` option to ``flycheck-define-command-checker``
     [GH-973] [GH-1012]
   - ``flycheck-go-build-install-deps`` turns on dependency installation for ``go test``
     as well as ``go build`` [GH-1003]
-
-- New syntax checkers:
-
-  - Slim with ``slim-lint`` [GH-1013]
 
 - Improvements:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
   - ``flycheck-go-build-install-deps`` turns on dependency installation for ``go test``
     as well as ``go build`` [GH-1003]
 
+- New syntax checkers:
+
+  - Slim with ``slim-lint`` [GH-1013]
+
 - Improvements:
 
   - Add default directory for ``haskell-stack-ghc`` and ``haskell-ghc`` checkers

--- a/doc/community/people.rst
+++ b/doc/community/people.rst
@@ -143,6 +143,7 @@ to Flycheck:
 * Gereon Frey (:gh:`gfrey`)
 * Gulshan Singh (:gh:`gsingh93`)
 * Iain Beeston (:gh:`iainbeeston`)
+* Ibrahim Awwal (:gh:`ibrahima`)
 * Jackson Ray Hamilton (:gh:`jacksonrayhamilton`)
 * Jim Hester (:gh:`jimhester`)
 * Jimmy Yuen Ho Wong (:gh:`wyuenho`)

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -972,6 +972,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check Slim using the `Slim <http://slim-lang.com/>`_ compiler.
 
+   .. syntax-checker:: slim-lint
+
+      Check Slim best practices using the `slim-lint <https://github.com/sds/slim-lint>`_ linter.
+
 .. supported-language:: SQL
 
    .. syntax-checker:: sql-sqlint

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -974,7 +974,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
    .. syntax-checker:: slim-lint
 
-      Check Slim best practices using the `slim-lint <https://github.com/sds/slim-lint>`_ linter.
+      Check Slim best practices using the `slim-lint
+      <https://github.com/sds/slim-lint>`_ linter.
 
 .. supported-language:: SQL
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -241,6 +241,7 @@ attention to case differences."
     sh-zsh
     sh-shellcheck
     slim
+    slim-lint
     sql-sqlint
     tex-chktex
     tex-lacheck
@@ -8628,6 +8629,15 @@ See URL `http://slim-lang.com'."
           "Slim::Parser::SyntaxError:" (message) (optional "\r") "\n  "
           "STDIN, Line " line (optional ", Column " column)
           line-end))
+  :modes slim-mode
+  :next-checkers ((warning . slim-lint)))
+
+(flycheck-define-checker slim-lint
+  "A Slim linter.
+
+See URL `https://github.com/sds/slim-lint'."
+  :command ("slim-lint" "--reporter=checkstyle" source)
+  :error-parser flycheck-parse-checkstyle
   :modes slim-mode)
 
 (flycheck-define-checker sql-sqlint


### PR DESCRIPTION
Slim-lint is a third-party linter for slim templates.

See https://github.com/sds/slim-lint

I hope this was formatted correctly, first time contributing to flycheck! Currently there's no option to read from stdin so I couldn't set that, which is kind of annoying. Also, not sure if I set :next-checkers correctly or if the order matters. I think slim-lint also includes the basic slim errors so not sure if having both enabled causes problems, or what happens if the executable is not found (I assume no errors are thrown if it's not installed, right?)

Thanks!