### PR TITLE
Add option to build offline HTML

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,7 +21,14 @@ SPHINXAUTOBUILD = sphinx-autobuild
 OPTIPNG = optipng
 BUILDDIR = _build
 
+# Whether to build offline HTML that loads no external resources, for use in 3rd
+# party packages, see https://github.com/flycheck/flycheck/issues/999
+OFFLINE =
+
 ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .
+ifdef OFFLINE
+ALLSPHINXOPTS += -Dflycheck_offline_html=1
+endif
 
 IMAGES = images/*.png
 
@@ -45,6 +52,9 @@ help:
 	@echo ''
 	@echo 'To build the documentation you need $(SPHINXBUILD).'
 	@echo 'For *-auto targets you also need $(SPHINXAUTOBUILD).'
+	@echo ''
+	@echo 'Available make variables:'
+	@echo '  OFFLINE:  If set build HTML that loads no external resources'
 	@echo ''
 	@echo 'Available programs:'
 	@echo '  $(SPHINXBUILD): $(if $(HAVE_SPHINXBUILD),yes,no)'

--- a/doc/_templates/about.html
+++ b/doc/_templates/about.html
@@ -19,7 +19,7 @@
 <p><a href="{{href}}"><img src="https://img.shields.io/{{badge}}"/></a></p>
 {%- endmacro %}
 
-{% if theme_github_user and theme_github_repo %}
+{% if theme_github_user and theme_github_repo and not flycheck_offline_html %}
 {% if theme_github_button|lower == 'true' %}
 <p>
     <iframe src="https://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type={{ theme_github_type }}&count={{ theme_github_count }}&v=2"
@@ -28,6 +28,7 @@
 {% endif %}
 {% endif %}
 
+{% if not flycheck_offline_html %}
 <p>
     <a href="https://twitter.com/emacs_flycheck" class="twitter-follow-button"
        data-show-count="false" data-dnt="true">Follow @emacs_flycheck</a>
@@ -45,3 +46,4 @@
 <p>
     <a href="https://melpa.org/#/flycheck"><img alt="MELPA" src="https://melpa.org/packages/flycheck-badge.svg"/></a>
 </p>
+{% endif %}

--- a/doc/_templates/about.html
+++ b/doc/_templates/about.html
@@ -22,7 +22,7 @@
 {% if theme_github_user and theme_github_repo and not flycheck_offline_html %}
 {% if theme_github_button|lower == 'true' %}
 <p>
-    <iframe src="https://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type={{ theme_github_type }}&count={{ theme_github_count }}&v=2"
+    <iframe src="https://ghbtns.com/github-btn.html?user={{ theme_github_user }}&amp;repo={{ theme_github_repo }}&amp;type={{ theme_github_type }}&amp;count={{ theme_github_count }}&amp;v=2"
             allowtransparency="true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
 </p>
 {% endif %}


### PR DESCRIPTION
With this PR `make -C doc OFFLINE=yes html` creates HTML that does not load any external resources.  See #999 for background.

/cc @spwhitton 

@cpitclaudel Please take a look.