### PR TITLE
Support latest output format of errcheck

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6839,7 +6839,7 @@ See URL `https://github.com/kisielk/errcheck'."
   :command ("errcheck" "-abspath" ".")
   :error-patterns
   ((warning line-start
-            (file-name) ":" line ":" column (or (one-or-more "\t") ": ")
+            (file-name) ":" line ":" column (or (one-or-more "\t") ": " ":\t")
             (message)
             line-end))
   :error-filter


### PR DESCRIPTION
errcheck now prints a colon, to more closely match the quickfix format.

We now support 3 different revisions of errcheck:

- the one that prints all indentation of the actual code line (multiple
  tabs)

- the one that separates position and code with a single tab

- the one that separates position and code with a colon and a single
  tab.