### PR TITLE
Parse puppet 3 errors, add puppet 3 tests

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7627,6 +7627,10 @@ See URL `https://puppet.com/'."
           (one-or-more (in "a-z" "0-9" "_")) ":"
           (message) " at line " line ":" column line-end)
    ;; Errors from Puppet < 4
+   (error line-start "Error: Could not parse for environment "
+          (one-or-more (in "a-z" "0-9" "_")) ":"
+          (message (minimal-match (one-or-more anything)))
+          " at line " line line-end)
    (error line-start
           ;; Skip over the path of the Puppet executable
           (minimal-match (zero-or-more not-newline))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3553,10 +3553,26 @@ Why not:
    '(4 2 error "Syntax error, maybe a missing semicolon?"
        :checker processing)))
 
-(flycheck-ert-def-checker-test puppet-parser puppet parser-error
+;; N.B. the puppet 4 and 3 tests are mutually exclusive
+;; due to one having column and the other not
+(flycheck-ert-def-checker-test puppet-parser puppet parser-error-puppet-4
+  (skip-unless (version<= "4" (shell-command-to-string
+                               "printf %s \"$(puppet --version)\"")))
   (flycheck-ert-should-syntax-check
    "language/puppet/parser-error.pp" 'puppet-mode
    '(3 9 error "Syntax error at '>'" :checker puppet-parser)))
+
+(flycheck-ert-def-checker-test puppet-parser puppet parser-error-puppet-3
+  (skip-unless (version<= (shell-command-to-string
+                           "printf %s \"$(puppet --version)\"") "4"))
+  (flycheck-ert-should-syntax-check
+   "language/puppet/puppet3-parser-error.pp" 'puppet-mode
+   '(4 nil error "Syntax error at 'helloagain'; expected '}'"
+       :checker puppet-parser))
+  (flycheck-ert-should-syntax-check
+   "language/puppet/puppet3-parser-multiline-error.pp" 'puppet-mode
+   '(4 nil error "Unclosed quote after '' in '\n}\n'"
+       :checker puppet-parser)))
 
 (flycheck-ert-def-checker-test puppet-lint puppet nil
   (flycheck-ert-should-syntax-check

--- a/test/resources/language/puppet/puppet3-parser-error.pp
+++ b/test/resources/language/puppet/puppet3-parser-error.pp
@@ -1,0 +1,5 @@
+# Test that the missing comma error is parsed
+class {'parser_error':
+  hello      => 'test'
+  helloagain => 'test'
+}

--- a/test/resources/language/puppet/puppet3-parser-multiline-error.pp
+++ b/test/resources/language/puppet/puppet3-parser-multiline-error.pp
@@ -1,0 +1,5 @@
+# Test that the multiline error output of puppet parser is parsed
+file { 'test':
+  ensure   => file,
+  contents => something'
+}


### PR DESCRIPTION
- Add an error pattern for puppet 3 parser, fixes GH-995.
- Split the puppet-parser tests into puppet 3 and puppet 4 tests.
 Since puppet 3 and 4 parser output is incompatible, name the
 puppet-parser tests explicitly after the puppet version they test.
 Only run the tests for the puppet version available on the system.
- Add two tests for puppet3. One test checks for single-line error
  output, the other tests checks for multiline error output.