### PR TITLE
maint: rename compile.el -> flycheck-compile.el

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ flycheck-ert.elc: flycheck.elc
 flycheck-buttercup.elc: flycheck.elc
 
 $(OBJS): %.elc: %.el
-	$(EMACSBATCH) -l maint/compile.el -f flycheck/batch-byte-compile $<
+	$(EMACSBATCH) -l maint/flycheck-compile.el -f flycheck/batch-byte-compile $<
 
 doc/_static/logo.png: flycheck.svg
 ifndef HAVE_CONVERT

--- a/maint/flycheck-compile.el
+++ b/maint/flycheck-compile.el
@@ -1,4 +1,4 @@
-;;; compile.el --- Flycheck byte compiler            -*- lexical-binding: t; -*-
+;;; flycheck-compile.el --- Flycheck byte compiler            -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2016  Sebastian Wiesner and Flycheck contributors
 
@@ -73,4 +73,4 @@ Specifically set `byte-compile-error-on-warn' to t on Emacs 25."
           (kill-emacs 1)))))
   (kill-emacs 0))
 
-;;; compile.el ends here
+;;; flycheck-compile.el ends here


### PR DESCRIPTION
When byte-compiling flycheck.el manually, if you use `-L maint` instead
of `-l maint/compile.el`, maint/ will be placed at the front of the
load-path, overriding Emacs' build-in compile.el and causing the
following error:

```
Eager macro-expansion failure: (error "Required feature ‘compile’ was not provided")
Eager macro-expansion failure: (error "Required feature ‘compile’ was not provided")

In toplevel form:
flycheck-package.el:41:1:Error: Required feature ‘compile’ was not provided
```