### PR TITLE
Fix temporary filename in error body in addition to error header

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5264,16 +5264,14 @@ function `buffer-file-name'."
       (when (seq-some (apply-partially #'flycheck-same-files-p
                                        (expand-file-name filename cwd))
                       buffer-files)
-        (let ((new-filename (buffer-file-name)))
+        (-when-let (new-filename (buffer-file-name))
           (setf (flycheck-error-filename err) new-filename
-                (flycheck-error-message err)
-                (replace-regexp-in-string
-                 (regexp-quote filename)
-                 new-filename
-                 (flycheck-error-message err)
-                 nil
-                 t ;; do literal substitution
-                 ))))))
+                (flycheck-error-message err) (replace-regexp-in-string
+                                              (regexp-quote filename)
+                                              new-filename
+                                              (flycheck-error-message err)
+                                              'fixed-case
+                                              'literal))))))
   err)
 
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -5264,14 +5264,16 @@ function `buffer-file-name'."
       (when (seq-some (apply-partially #'flycheck-same-files-p
                                        (expand-file-name filename cwd))
                       buffer-files)
-        (-when-let (new-filename (buffer-file-name))
-          (setf (flycheck-error-filename err) new-filename
-                (flycheck-error-message err) (replace-regexp-in-string
-                                              (regexp-quote filename)
-                                              new-filename
-                                              (flycheck-error-message err)
-                                              'fixed-case
-                                              'literal))))))
+        (let ((new-filename (buffer-file-name)))
+          (setf (flycheck-error-filename err) new-filename)
+          (when new-filename
+            (setf (flycheck-error-message err)
+                  (replace-regexp-in-string
+                   (regexp-quote filename)
+                   new-filename
+                   (flycheck-error-message err)
+                   'fixed-case
+                   'literal)))))))
   err)
 
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -5264,7 +5264,16 @@ function `buffer-file-name'."
       (when (seq-some (apply-partially #'flycheck-same-files-p
                                        (expand-file-name filename cwd))
                       buffer-files)
-        (setf (flycheck-error-filename err) (buffer-file-name)))))
+        (let ((new-filename (buffer-file-name)))
+          (setf (flycheck-error-filename err) new-filename
+                (flycheck-error-message err)
+                (replace-regexp-in-string
+                 (regexp-quote filename)
+                 new-filename
+                 (flycheck-error-message err)
+                 nil
+                 t ;; do literal substitution
+                 ))))))
   err)
 
 


### PR DESCRIPTION
Some checkers report filename in multiple places in the error message, therefore it's not enough to fix only flycheck-error-filename field. If message is not fixed, the user may observe temporary filenames.

This is a proposed fix for #978.