### PR TITLE
Use JSON output for rust and rust-cargo checkers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 
   - Change ``flycheck-eslint-rulesdir`` (string) to
     ``flycheck-eslint-rules-directories`` (list of strings) [GH-1016]
+  - Require rust 1.7 or newer for ``rust`` and ``rust-cargo`` [GH-1036]
 
 - New syntax checkers:
 
@@ -22,7 +23,8 @@
 
   - Add default directory for ``haskell-stack-ghc`` and ``haskell-ghc`` checkers
     [GH-1007]
-
+  - ``rust`` and ``rust-cargo`` checkers now support the new error format of
+    rust 1.12 [GH-1016]
 
 28 (Jun 05, 2016)
 =================

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -887,7 +887,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. note::
 
-         These syntax checkers require Rust 1.0 or newer.
+         These syntax checkers require Rust 1.7 or newer.
 
       .. _Cargo: http://doc.crates.io/index.html
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3835,19 +3835,15 @@ Why not:
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/src/syntax-error.rs" 'rust-mode
-     '(4 5 error "unresolved name `bla`" :checker rust :id "E0425")
-     '(4 5 info "run `rustc --explain E0425` to see a detailed explanation"
-         :checker rust))))
+     '(4 5 error "unresolved name `bla`" :checker rust :id "E0425"))))
 
 (flycheck-ert-def-checker-test rust rust multiline-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/src/multiline-error.rs" 'rust-mode
-     '(7 9 error "mismatched types" :checker rust :id "E0308")
-     '(7 9 info "run `rustc --explain E0308` to see a detailed explanation"
-         :checker rust)
-     '(7 9 info "expected type `u8`" :checker rust)
-     '(7 9 info "found type `i8`" :checker rust))))
+     '(7 9 error "mismatched types (expected u8, found i8)" :checker rust :id "E0308")
+     '(7 9 info "expected type `u8`" :checker rust :id "E0308")
+     '(7 9 info "found type `i8`" :checker rust :id "E0308"))))
 
 (flycheck-ert-def-checker-test rust rust warning
   (let ((flycheck-disabled-checkers '(rust-cargo)))
@@ -3860,20 +3856,15 @@ Why not:
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/src/note-and-help.rs" 'rust-mode
-     '(11 9 info "value moved here" :checker rust)
-     '(12 9 error "use of moved value: `x`" :checker rust :id "E0382")
-     '(12 9 info "run `rustc --explain E0382` to see a detailed explanation"
-          :checker rust)
-     '(12 9 info "move occurs because `x` has type `NonPOD`, which does not implement the `Copy` trait"
-          :checker rust))))
+     '(11 9 info "value moved here" :checker rust :id "E0382")
+     '(12 9 error "use of moved value: `x` (value used here after move)" :checker rust :id "E0382")
+     '(12 9 info "move occurs because `x` has type `NonPOD`, which does not implement the `Copy` trait" :checker rust :id "E0382"))))
 
 (flycheck-ert-def-checker-test rust rust crate-root-not-set
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/src/importing.rs" 'rust-mode
-     '(1 5 error "unresolved import `super::imported`. There are too many initial `super`s." :checker rust :id "E0432")
-     '(1 5 info "run `rustc --explain E0432` to see a detailed explanation"
-         :checker rust))))
+     '(1 5 error "unresolved import `super::imported`. There are too many initial `super`s." :checker rust :id "E0432"))))
 
 (flycheck-ert-def-checker-test sass sass nil
   (flycheck-ert-should-syntax-check


### PR DESCRIPTION
See #1035 for the background discussion.

Essentially: this pull request restores flycheck for users of rust nightly, while (almost) preserving the functionality for rust stable users.

Almost, because some messages may have been slightly altered (see the tests update). 

I've switched the error parsers of rust and rust-cargo to parse the JSON output directly.  I've based the code on the tslint JSON parser, but the situation was alas not as simple.  

Things to watch out for: the `-Z unstable-options` might trigger an error in the future.  We can revisit it when it does.

Also, I _think_ the JSON output requires at least rust 1.7, meaning we might break some setups.  Is there a place where we should state that flycheck now requires a more recent rust version?
