### PR TITLE
immediately show errors after explicit jumps

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3706,7 +3706,8 @@ position."
   (when (consp n)
     ;; Universal prefix argument means reset
     (setq reset t n nil))
-  (flycheck-next-error-function n reset))
+  (flycheck-next-error-function n reset)
+  (flycheck-display-error-at-point))
 
 (defun flycheck-previous-error (&optional n)
   "Visit the N-th previous error.


### PR DESCRIPTION
immediately show any errors at point after using
flycheck-{first,next,previous}-error. fixes #1034.