### PR TITLE
Add make check and make format to Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,9 @@ before_install:
 install:
   - if [[ -n $EMACS_VERSION ]]; then make init; fi
 script:
-  # Lint, compile, test
+  # Check formatting on Emacs 25 (our formatting rules dont’ work on Emacs 24).
+  - if [[ $EMACS_VERSION == "25.1-rc2" ]]; then make check; fi
+  # Compile and test
   - if [[ -n $EMACS_VERSION ]]; then make compile; fi
   - if [[ -n $EMACS_VERSION ]]; then make unit; fi
   - if [[ -n $EMACS_VERSION ]]; then make specs; fi

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,17 @@ clean:
 purge:
 	$(GIT) clean -xfd
 
+.PHONY: format
+format:
+	$(RUNEMACS) -l maint/flycheck-format.el -f flycheck/batch-format
+
+.PHONY: check-format
+check-format:
+	$(RUNEMACS) -l maint/flycheck-format.el -f flycheck/batch-check-format
+
+.PHONY: check
+check: check-format
+
 .PHONY: compile
 compile: $(OBJS)
 
@@ -122,7 +133,9 @@ help:
 	@echo ''
 	@echo 'Available targets:'
 	@echo '  init:    Initialise the project.  RUN FIRST!'
+	@echo '  check:   Check all Emacs Lisp sources'
 	@echo '  compile: Byte-compile Emacs Lisp sources'
+	@echo '  format:  Format all Emacs Lisp sources'
 	@echo '  specs:   Run all buttercup specs for Flycheck'
 	@echo '  unit:    Run all ERT unit tests for Flycheck (legacy)'
 	@echo '  integ:   Run all integration tests for Flycheck'

--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -84,7 +84,9 @@ Run ``make help`` to see a list of all available targets.  Some common ones are:
 
 - ``make init`` initialises the project by installing local Emacs Lisp
   dependencies.
+- ``make check`` checks all Emacs Lisp sources.
 - ``make compile`` compiles Flycheck and its libraries to byte code.
+- ``make format`` formats all Emacs Lisp sources.
 - ``make specs`` runs all Buttercup_ specs for Flycheck.  Set :makevar:`PATTERN`
   to run only specs matching a specific regular expression, e.g. ``make
   PATTERN='^Mode Line' specs`` to run only tests for the mode line.

--- a/maint/flycheck-format.el
+++ b/maint/flycheck-format.el
@@ -1,0 +1,135 @@
+;;; flycheck-format.el --- Flycheck: Source code formatter  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016  Sebastian Wiesner and Flycheck contributors
+
+;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides source code formatting for Flycheck.  It's mainly intended
+;; for non-interactive use, see "make format".
+
+;;; Code:
+
+(require 'seq)
+(require 'rx)
+(require 'whitespace)
+(require 'elisp-mode)
+
+(unless noninteractive
+  (error "This file must not be used interactively"))
+
+(unless (version<= "25" emacs-version)
+  (user-error "Emacs 25 required for formatting"))
+
+(defconst flycheck/source-dir (locate-dominating-file load-file-name "Cask")
+  "The source directory of Flycheck.")
+
+(defun flycheck/collect-el-files (directory &optional recursive)
+  "Collect all Emacs Lisp files in DIRECTORY.
+
+If RECURSIVE is given and non-nil collect files recursively."
+  (let ((fn-re (rx ".el" eos)))
+    (if recursive
+        (directory-files-recursively directory fn-re)
+      (directory-files directory 'full fn-re))))
+
+(defun flycheck/all-source-files ()
+  "Find all source files of Flycheck."
+  (append
+   (seq-mapcat (lambda (rel-name)
+                 (flycheck/collect-el-files
+                  (expand-file-name rel-name flycheck/source-dir)))
+               '("." "maint/" "doc/" "test/"))
+   (flycheck/collect-el-files
+    (expand-file-name "test/specs/" flycheck/source-dir) 'recursive)))
+
+(defun flycheck/already-loaded-p (filename)
+  "Whether FILENAME is already loaded."
+  (not (null (assoc filename load-history))))
+
+(defun flycheck/eval-and-format-buffer (filename)
+  "Format the current buffer for FILENAME.
+
+THIS FUNCTION HAS GLOBAL AND LOCAL SIDE EFFECTS.
+
+Evaluate the buffer to make all special indentation rules of
+local definitions available before formatting.
+
+Switch the buffer to Emacs Lisp mode."
+  (let (delayed-mode-hooks)
+    (delay-mode-hooks (emacs-lisp-mode)))
+  ;; Load the file to make indentation rules from local definitions available.
+  ;; We load files instead of evaluating them because some files in our code
+  ;; rely on `load-file-name' and similar stuff.  Don't load files which are
+  ;; already loaded, though, to prevent a recursive load of this file.
+  (unless (flycheck/already-loaded-p filename)
+    (let ((load-prefer-newer t))          ; Silence "newer" messages
+      (load filename 'noerror 'nomessage 'nosuffix)))
+  (widen)
+  (let ((indent-tabs-mode nil)
+        (whitespace-style
+         '(empty                        ; Cleanup empty lines at end
+           indentation::space           ; Replace tabs with spaces
+           space-before-tab::space      ; Replace tabs with spaces
+           trailing                     ; Remove trailing spaces
+           )))
+    (cl-letf (((symbol-function 'message) #'ignore))
+      ;; Silence "Indenting region..." progress reporter
+      (indent-region (point-min) (point-max)))
+    (whitespace-cleanup-region (point-min) (point-max))))
+
+(defun flycheck/file-formatted-p (filename)
+  "Check whether FILENAME is properly formatted.
+
+Return a non-nil value in this case, otherwise return nil."
+  (with-temp-buffer
+    (insert-file-contents filename)
+    (set-buffer-modified-p nil)
+    (flycheck/eval-and-format-buffer filename)
+    (not (buffer-modified-p))))
+
+(defun flycheck/batch-check-format ()
+  "Check formatting of all sources."
+  (let ((bad-files (seq-remove #'flycheck/file-formatted-p
+                               (flycheck/all-source-files))))
+    (if (null bad-files)
+        (kill-emacs 0)
+      (seq-do (lambda (filename) (message "%s: misformatted!" filename))
+              bad-files)
+      (kill-emacs 1))))
+
+(defun flycheck/format-file (filename)
+  "Format FILENAME.
+
+Return a non-nil value if the file was formatted, and nil
+otherwise."
+  (with-temp-file filename
+    (insert-file-contents filename)
+    (set-buffer-modified-p nil)
+    (flycheck/eval-and-format-buffer filename)
+    (buffer-modified-p)))
+
+(defun flycheck/batch-format ()
+  "Format all Flycheck source files."
+  (let ((formatted-files (seq-filter #'flycheck/format-file
+                                     (flycheck/all-source-files))))
+    (seq-do (lambda (filename) (message "Formatted %s" filename))
+            formatted-files)
+    (kill-emacs 0)))
+
+;;; flycheck-format.el ends here

--- a/test/init.el
+++ b/test/init.el
@@ -23,8 +23,8 @@
 
 ;;; Commentary:
 
-;; Use with `emacs -Q -l test/init.el' to start a clean session with only
-;; Flycheck present.
+;; Use with `emacs -Q -l test/init.el -f flycheck/init' to start a clean session
+;; with only Flycheck present.
 ;;
 ;; Installs all dependencies of Flycheck to a temporary package directory, and
 ;; loads Flycheck.
@@ -33,76 +33,91 @@
 
 (require 'package)
 
-(setq load-prefer-newer t)              ; Don't load outdated bytecode
+(defun flycheck/init ()
+  "Initialize a minimal Flycheck session.
 
-(setq package-user-dir (expand-file-name "init-elpa"
-                                         (file-name-directory load-file-name))
-      package-check-signature nil)
-(add-to-list 'package-archives '("MELPA" . "https://stable.melpa.org/packages/"))
+Install Flycheck and its dependencies into a separate package
+directory (init-elpa in the current directory) and enable
+Flycheck globally.
 
-(package-initialize)
+Set some global customization options to get rid of some of the
+worst defaults of Emacs and create a half-way bearable Emacs
+session.
 
-(let* ((source-dir (locate-dominating-file load-file-name "flycheck.el"))
-       (flycheck-el (expand-file-name "flycheck.el" source-dir)))
-  ;; Install Flycheck to bring its dependencies in
-  (unless (package-installed-p 'flycheck)
-    (package-refresh-contents)
-    (package-install-file flycheck-el))
-  (load flycheck-el))
+Define a `demo' checker which can be used to demonstrate Flycheck
+in this file."
+  (setq load-prefer-newer t)              ; Don't load outdated bytecode
 
-(require 'flycheck)
-(global-flycheck-mode)
+  (setq package-user-dir (expand-file-name "init-elpa"
+                                           (file-name-directory load-file-name))
+        package-check-signature nil)
+  (add-to-list 'package-archives '("MELPA" . "https://stable.melpa.org/packages/"))
 
-(list 'an-info-here
-      'a-warning-here
-      'an-error-here)
+  (package-initialize)
 
-;; Some little convenience, to this Emacs session at least half way bearable
-(require 'ido)
-(ido-mode t)
-(setq ido-enable-flex-matching t)
+  (let* ((source-dir (locate-dominating-file load-file-name "flycheck.el"))
+         (flycheck-el (expand-file-name "flycheck.el" source-dir)))
+    ;; Install Flycheck to bring its dependencies in
+    (unless (package-installed-p 'flycheck)
+      (package-refresh-contents)
+      (package-install-file flycheck-el))
+    (load flycheck-el))
 
-;; Get rid of all the silly UI clutter of a default Emacs session and opt out of
-;; all the stupid startup and license messages
-(tool-bar-mode -1)
-(blink-cursor-mode -1)
-(setq ring-bell-function #'ignore
-      inhibit-startup-screen t
-      initial-scratch-message "")
-(fset 'yes-or-no-p #'y-or-n-p)
-(fset 'display-startup-echo-area-message #'ignore)
+  (require 'flycheck)
+  (global-flycheck-mode)
 
-;; Improve OS X key behaviour
-(when (eq system-type 'darwin)
-  (setq mac-option-modifier 'meta       ; Option is simply the natural Meta
-        mac-command-modifier 'meta      ; But command is a lot easier to hit
-        mac-right-command-modifier 'left
-        mac-right-option-modifier 'none ; Keep right option for accented input
-        mac-function-modifier 'hyper))
+  ;; Some dummy code for warnings which we use to demonstrate Flycheck, see
+  ;; `demo' checker below.
+  (list 'an-info-here
+        'a-warning-here
+        'an-error-here)
 
-(flycheck-define-generic-checker 'demo
-  "A demo syntax checker."
-  :start (lambda (checker callback)
-           (funcall callback 'finished
-                    (save-excursion
-                      (goto-char (point-min))
-                      (search-forward "an-info-here")
-                      (list (flycheck-error-new-at (line-number-at-pos)
-                                                   10 'info "An info here"
-                                                   :checker checker)
-                            (flycheck-error-new-at (+ 1 (line-number-at-pos))
-                                                   10 'warning "A warning here"
-                                                   :checker checker)
-                            (flycheck-error-new-at (+ 2 (line-number-at-pos))
-                                                   10 'error "A error here"
-                                                   :checker checker)))))
-  :modes 'emacs-lisp-mode)
+  ;; Some little convenience, to this Emacs session at least half way bearable
+  (require 'ido)
+  (ido-mode t)
+  (setq ido-enable-flex-matching t)
+
+  ;; Get rid of all the silly UI clutter of a default Emacs session and opt out of
+  ;; all the stupid startup and license messages
+  (tool-bar-mode -1)
+  (blink-cursor-mode -1)
+  (setq ring-bell-function #'ignore
+        inhibit-startup-screen t
+        initial-scratch-message "")
+  (fset 'yes-or-no-p #'y-or-n-p)
+  (fset 'display-startup-echo-area-message #'ignore)
+
+  ;; Improve OS X key behaviour
+  (when (eq system-type 'darwin)
+    (setq mac-option-modifier 'meta       ; Option is simply the natural Meta
+          mac-command-modifier 'meta      ; But command is a lot easier to hit
+          mac-right-command-modifier 'left
+          mac-right-option-modifier 'none ; Keep right option for accented input
+          mac-function-modifier 'hyper))
+
+  (flycheck-define-generic-checker 'demo
+    "A demo syntax checker."
+    :start (lambda (checker callback)
+             (funcall callback 'finished
+                      (save-excursion
+                        (goto-char (point-min))
+                        (search-forward "an-info-here")
+                        (list (flycheck-error-new-at (line-number-at-pos)
+                                                     10 'info "An info here"
+                                                     :checker checker)
+                              (flycheck-error-new-at (+ 1 (line-number-at-pos))
+                                                     10 'warning "A warning here"
+                                                     :checker checker)
+                              (flycheck-error-new-at (+ 2 (line-number-at-pos))
+                                                     10 'error "A error here"
+                                                     :checker checker)))))
+    :modes 'emacs-lisp-mode))
 
 (defun flycheck-prepare-screenshot (&optional hide-cursor)
   "Prepare this Emacs session for a screenshot.
 
-If HIDE-CURSOR is non-nil, or with prefix arg, hide the cursor,
-otherwise keep it."
+If HIDE-CURSOR is non-nil or if a prefix arg is given hide the
+cursor, otherwise keep it."
   (interactive "P")
   ;; Reduce UI and disable cursor
   (menu-bar-mode -1)
@@ -121,5 +136,9 @@ otherwise keep it."
                  (side            . bottom)
                  (reusable-frames . visible)
                  (window-height   . 0.33))))
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
 
 ;;; init.el ends here

--- a/test/specs/test-code-style.el
+++ b/test/specs/test-code-style.el
@@ -65,26 +65,6 @@
 
       (it "has proper documentation format"
         (expect (flycheck/checkstyle source)
-                :to-equal ""))
-
-      ;; Don't test the test init file because loading it has it has
-      ;; side-effects, and we need to load files in order to figure out their
-      ;; indentation rules.
-      (unless (equal (file-relative-name source) "test/init.el")
-        (it "is properly indented"
-          (with-temp-buffer
-            (insert-file-contents source)
-            (set-buffer-modified-p nil)
-            ;; Enable `emacs-lisp-mode' to bring indentation rules and syntax
-            ;; table in, but ignore all mode hooks
-            (delay-mode-hooks (emacs-lisp-mode))
-            (setq delayed-mode-hooks nil)
-            ;; Load the library to make local definitions available
-            (load source 'noerror 'nomessage 'nosuffix)
-            ;; Now re-indent.  If it's modified afterwards indentation wasn't
-            ;; right.
-            (let ((inhibit-message t))  ; `indent-region' is chatty, silence it
-              (indent-region (point-min) (point-max)))
-            (expect (buffer-modified-p) :not :to-be-truthy)))))))
+                :to-equal "")))))
 
 ;;; test-code-style.el ends here


### PR DESCRIPTION
`make format` automatically formats all Flycheck sources, `make check` checks formatting (and could later be extended to run checkdoc and other linting as well).

`make check` runs on Travis CI, and replaces the buttercup specs for indentation which are consequently gone now.