### PR TITLE
Fix php checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7538,7 +7538,7 @@ See URL `http://php.net/manual/en/features.commandline.php'."
             "-d" "log_errors=0" source)
   :error-patterns
   ((error line-start (or "Parse" "Fatal" "syntax") " error" (any ":" ",") " "
-          (message) " in - on line " line line-end))
+          (message) " in " (file-name) " on line " line line-end))
   :modes (php-mode php+-mode)
   :next-checkers ((warning . php-phpmd)
                   (warning . php-phpcs)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -7535,8 +7535,7 @@ See URL `https://metacpan.org/pod/Perl::Critic'."
 
 See URL `http://php.net/manual/en/features.commandline.php'."
   :command ("php" "-l" "-d" "error_reporting=E_ALL" "-d" "display_errors=1"
-            "-d" "log_errors=0")
-  :standard-input t
+            "-d" "log_errors=0" source)
   :error-patterns
   ((error line-start (or "Parse" "Fatal" "syntax") " error" (any ":" ",") " "
           (message) " in - on line " line line-end))


### PR DESCRIPTION
# Motivation

PHP script can include shebang. But `php -l` behave differ from when read using STDIN and when using file.

# Reproduce

```php
#!/usr/bin/env php
<?php

namespace Flycheck\Sample;

echo "Hello", PHP_EOL;
```

# Current

<img width="872" alt="2016-08-19 20 30 10" src="https://cloud.githubusercontent.com/assets/822086/17808594/e197d56c-664b-11e6-8f5b-22458d3779a0.png">
