### PR TITLE
[lua-luacheck] specify filename when reading from stdin

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7446,7 +7446,7 @@ See URL `https://github.com/mpeterv/luacheck'."
             "-")
   :standard-input t
   :error-patterns
-  ((warning line-start 
+  ((warning line-start
             (optional (file-name))
             ":" line ":" column
             ": (" (id "W" (one-or-more digit)) ") "

--- a/flycheck.el
+++ b/flycheck.el
@@ -7447,12 +7447,12 @@ See URL `https://github.com/mpeterv/luacheck'."
   :standard-input t
   :error-patterns
   ((warning line-start 
-            (minimal-match (zero-or-more not-newline))
+            (optional (file-name))
             ":" line ":" column
             ": (" (id "W" (one-or-more digit)) ") "
             (message) line-end)
-   (error line-start 
-          (minimal-match (zero-or-more not-newline))
+   (error line-start
+          (optional (file-name))
           ":" line ":" column ":"
           ;; `luacheck' before 0.11.0 did not output codes for errors, hence
           ;; the ID is optional here

--- a/flycheck.el
+++ b/flycheck.el
@@ -7441,14 +7441,19 @@ See URL `https://github.com/mpeterv/luacheck'."
             "--formatter" "plain"
             "--codes"                   ; Show warning codes
             "--no-color"
+            "--filename" source-original
             ;; Read from standard input
             "-")
   :standard-input t
   :error-patterns
-  ((warning line-start "stdin:" line ":" column
+  ((warning line-start 
+            (minimal-match (zero-or-more not-newline))
+            ":" line ":" column
             ": (" (id "W" (one-or-more digit)) ") "
             (message) line-end)
-   (error line-start "stdin:" line ":" column ":"
+   (error line-start 
+          (minimal-match (zero-or-more not-newline))
+          ":" line ":" column ":"
           ;; `luacheck' before 0.11.0 did not output codes for errors, hence
           ;; the ID is optional here
           (optional " (" (id "E" (one-or-more digit)) ") ")


### PR DESCRIPTION
Close #1046 

@lunaryorn Though I haven't written any Lisp before, I thought this gonna be a simple fix. But apparently it is not. Would you please help with the following issues?

In `:error_patterns`, after `line-start` I used `(minimal-match (zero-or-more not-newline))` instead of `(file-name)` because the latter failed to match empty file name (e.g. when buffer is not saved yet, and `source-original` return empty string.

It worked for me for my current use case, but I don't think it is a good solution (e.g. what will happen on Windows, when the file name already include `:`?)

And also, in luacheckrc, it used globbing instead of regex for matching in `files[<glob>]`
https://github.com/mpeterv/luacheck/blob/master/src/luacheck/globbing.lua#L4
http://luacheck.readthedocs.io/en/stable/config.html#per-file-and-per-path-overrides

So ideally here we should do something like:

### If `.luacheckrc` is found, 
for `--filename` we passed in the pathname **relative** to the folder which has `.luacheckrc`.

 e.g.
```
$ tree -a code
code
├── .luacheckrc
└── spec
    └── test_app_spec.lua

$ cat /Users/abc/code/spec/test_app_spec.lua | luacheck --config /Users/abc/code/.luacheckrc -filename spec/test_app_spec.lua -
```
And expect `<filename>:` at the beginning of every output line

### If `.luacheckrc` is not found or buffer-file-name is nil
do not specify `--filename`

And expect `stdin:` at the beginning of every output line


Not sure how to achieve this, can you give me some hint so that I know what the next step could be?