### PR TITLE
Puppet-lint: format output with `line`

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7679,7 +7679,7 @@ See URL `http://puppet-lint.com/'."
   :command ("puppet-lint"
             (config-file "--config" flycheck-puppet-lint-rc)
             "--log-format"
-            "%{path}:%{linenumber}:%{kind}: %{message} (%{check})"
+            "%{path}:%{line}:%{kind}: %{message} (%{check})"
             (option-list "" flycheck-puppet-lint-disabled-checks concat
                          flycheck-puppet-lint-disabled-arg-name)
             source-original)


### PR DESCRIPTION
Puppet-lint has deprecated formatting with `linenumber` in favour of
`line`. It has been deprecated since v1.0.0 in 2014 and will be removed
in v3.0.0. See https://github.com/rodjek/puppet-lint/issues/539

Closes GH-1050