### PR TITLE
let luacheck find luacheck itself

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 - **Breaking changes**
 
   - Flycheck now requires flake8 3.0 or newer
+  - Remove ``--config`` option in ``lua-luacheck`` in favour of ``luacheck``'s
+    own ``.luacheckrc`` detection. Therefore ``flycheck-luacheckrc`` is
+    no longer used [GH-1057]
 
 - New syntax checkers:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -624,8 +624,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _Luacheck: https://github.com/mpeterv/luacheck
 
-      .. syntax-checker-config-file:: flycheck-luacheckrc
-
    .. syntax-checker:: lua
 
       Check syntax with the `Lua compiler <http://www.lua.org/>`_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -7590,16 +7590,11 @@ See URL `http://lesscss.org'."
           line-end))
   :modes less-css-mode)
 
-(flycheck-def-config-file-var flycheck-luacheckrc lua-luacheck ".luacheckrc"
-  :safe #'stringp
-  :package-version '(flycheck . "0.23"))
-
 (flycheck-define-checker lua-luacheck
   "A Lua syntax checker using luacheck.
 
 See URL `https://github.com/mpeterv/luacheck'."
   :command ("luacheck"
-            (config-file "--config" flycheck-luacheckrc)
             "--formatter" "plain"
             "--codes"                   ; Show warning codes
             "--no-color"

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3463,27 +3463,22 @@ Why not:
    "language/less/syntax-error.less" 'less-css-mode
    '(1 1 error "Unrecognised input" :checker less)))
 
-(flycheck-ert-def-checker-test luacheck lua syntax-error
+(flycheck-ert-def-checker-test lua-luacheck lua syntax-error
   (flycheck-ert-should-syntax-check
    "language/lua/syntax-error.lua" 'lua-mode
-   '(5 7 error "unfinished string" :id "E011" :checker luacheck)))
+   '(5 7 error "unfinished string" :id "E011" :checker lua-luacheck)))
 
-(flycheck-ert-def-checker-test luacheck lua warnings
+(flycheck-ert-def-checker-test lua-luacheck lua warnings
   (flycheck-ert-should-syntax-check
    "language/lua/warnings.lua" 'lua-mode
    '(1 1 warning "setting non-standard global variable 'global_var'"
-       :id "W111" :checker luacheck)
+       :id "W111" :checker lua-luacheck)
    '(3 16 warning "unused function 'test'"
-       :id "W211" :checker luacheck)
+       :id "W211" :checker lua-luacheck)
    '(3 21 warning "unused argument 'arg'"
-       :id "W212" :checker luacheck)
+       :id "W212" :checker lua-luacheck)
    '(4 11 warning "variable 'var2' is never set"
-       :id "W221" :checker luacheck)))
-
-(flycheck-ert-def-checker-test lua-luacheck lua no-warnings
-  (let ((flycheck-luacheckrc "luacheckrc"))
-    (flycheck-ert-should-syntax-check
-     "language/lua/warnings.lua" 'lua-mode)))
+       :id "W221" :checker lua-luacheck)))
 
 (flycheck-ert-def-checker-test lua lua nil
   (let ((flycheck-disabled-checkers '(lua-luacheck)))

--- a/test/resources/language/lua/luacheckrc
+++ b/test/resources/language/lua/luacheckrc
@@ -1,2 +1,0 @@
-global = false
-unused = false


### PR DESCRIPTION
As discussed in #1047, `luacheck` is capable of finding its config file `.luacheckrc` itself, it also works better with `--filename` option.

Therefore, we should remove `config-file` call for `lua-luacheck`