### PR TITLE
Fix alignment bug in flycheck-compute-message-column-offset

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3869,9 +3869,10 @@ Return a list with the contents of the table cell."
                                          (padding (plist-get props :pad-right)))
                               (cons name (+ width (or padding 1)))))
                           tabulated-list-format))
-         (before-msg (seq-take-while (lambda (fmt)
-                                       (not (string= (car fmt) "Message")))
-                                     widths)))
+         (before-msg (seq-take-while
+                      (lambda (fmt)
+                        (not (string-match-p "^Message" (car fmt))))
+                      widths)))
     (apply #'+ tabulated-list-padding (seq-map #'cdr before-msg))))
 
 (defun flycheck-flush-multiline-message (msg)


### PR DESCRIPTION
Introduced by 7a82b38c094a43eee2ab42608f4e3bd0bf61bf28.  The check used
to locate the message column was overly strict.

Now that message is the last column, though, I wonder if we should just do `(butlast` on the list of columns instead of this convoluted check.