### PR TITLE
Add @ghprince to lua team

### DIFF
--- a/doc/community/people.rst
+++ b/doc/community/people.rst
@@ -79,6 +79,13 @@ Javascript
 
 Mention with ``@flycheck/javascript``.
 
+Lua
+~~~
+
+* Gordon Gao (:gh:`ghprince`)
+
+Mention with ``@flycheck/lua``.
+
 Puppet
 ~~~~~~
 


### PR DESCRIPTION
Following up their great work in #1047 and #1057 I'd like to add @ghprince as a regular contributor for a to-be-created Lua team.

@cpitclaudel Do you agree?

# TODO

- [x] Create Lua team in org
- [x] Invite @ghprince to lua team and the contributors team
- [x] @ghprince has accepted :blush:
- [x] Add @ghprince to our internal developer gitter chat.