### PR TITLE
Strip trailing newlines in error messages

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3875,12 +3875,15 @@ Return a list with the contents of the table cell."
 (defun flycheck-flush-multiline-message (msg)
   "Prepare error message MSG for display in the error list.
 
-Prepend all lines of MSG except the first with enough space to
-ensure that they line up properly once the message is displayed."
+Strip trailing blanks and prepend all lines of MSG except the
+first with enough space to ensure that they line up properly once
+the message is displayed."
   (let* ((msg-offset (flycheck-compute-message-column-offset))
-         (spc (propertize " " 'display `(space . (:width ,msg-offset))))
-         (rep (concat "\\1" spc "\\2")))
-    (replace-regexp-in-string "\\([\r\n]+\\)\\(.\\)" rep msg)))
+         (spc (propertize " " 'display `(space . (:width ,msg-offset)))))
+    (replace-regexp-in-string
+     "[\r\n]+" (concat "\\&" spc)
+     (replace-regexp-in-string
+      "[\n\t ]+\\'" "" msg))))
 
 (defun flycheck-error-list-current-errors ()
   "Read the list of errors in `flycheck-error-list-source-buffer'."

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -48,6 +48,11 @@
     (flycheck/with-error-list-buffer
       (expect (derived-mode-p 'tabulated-list-mode) :to-be-truthy)))
 
+  (describe "Functions"
+    (it "strip trailing blanks in error messages"
+      (expect (flycheck-flush-multiline-message "Test\n\t   \n")
+              :to-equal "Test")))
+
   (describe "Format"
     (it "sets the error list format locally"
       (flycheck/with-error-list-buffer


### PR DESCRIPTION
(will need rebasing after #1066; also needs a test)

This prevents the checker name to pe pushed on its own line with multiline messages that have trailing newlines.
