### PR TITLE
add support for sass-lint (a pure node.js scss linter)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@
 - New syntax checkers:
 
   - Elixir with ``dogma`` [GH-969]
+  - sass and scss with ``sass-lint`` [GH-1070]
 
 29 (Aug 28, 2016)
 =================

--- a/doc/community/people.rst
+++ b/doc/community/people.rst
@@ -153,6 +153,7 @@ to Flycheck:
 * Damon Haley (:gh:`dhaley`)
 * David Caldwell (:gh:`caldwell`)
 * David Holm (:gh:`dholm`)
+* DEADB17 (:gh:`DEADB17`)
 * Deokhwan Kim (:gh:`dkim`)
 * Derek Chen-Becker (:gh:`dchenbecker`)
 * Derek Harland (:gh:`donkopotamus`)

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -935,6 +935,16 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: Sass
 
+   Flycheck checks SASS with `sass/scss-sass-lint`, falling back to `sass`.
+
+   .. syntax-checker:: sass/scss-sass-lint
+
+      Check ``sass`` and ``scss`` syntax and lint with SASS-Lint_.
+
+      .. _SASS-Lint: https://github.com/sasstools/sass-lint
+
+      .. syntax-checker-config-file:: flycheck-sass-lintrc
+
    .. syntax-checker:: sass
 
       Check syntax with the `Sass <http://sass-lang.com/>`_ compiler.
@@ -987,7 +997,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: SCSS
 
-   Flycheck checks SCSS with `scss-lint`, falling back to `scss`.
+   Flycheck checks SCSS with `scss-lint`, falling back to `sass/scss-sass-lint` first and
+   `scss` if neither is available.
 
    .. syntax-checker:: scss-lint
 
@@ -1000,6 +1011,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. _SCSS-Lint: https://github.com/brigade/scss-lint
 
       .. syntax-checker-config-file:: flycheck-scss-lintrc
+
+   .. syntax-checker:: sass/scss-sass-lint
+
+      Check ``sass`` and ``scss`` syntax and lint with SASS-Lint_.
+
+      .. _SASS-Lint: https://github.com/sasstools/sass-lint
+
+      .. syntax-checker-config-file:: flycheck-sass-lintrc
 
    .. syntax-checker:: scss
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -231,11 +231,12 @@ attention to case differences."
     ruby-jruby
     rust-cargo
     rust
-    sass
     scala
     scala-scalastyle
     scheme-chicken
     scss-lint
+    sass/scss-sass-lint
+    sass
     scss
     sh-bash
     sh-posix-dash
@@ -8541,6 +8542,24 @@ See URL `http://sass-lang.com'."
             " of " (one-or-more not-newline)
             line-end))
   :modes sass-mode)
+
+(flycheck-def-config-file-var flycheck-sass-lintrc sass/scss-sass-lint ".sass-lint.yml"
+  :safe #'stringp
+  :package-version '(flycheck . "30"))
+
+(flycheck-define-checker sass/scss-sass-lint
+  "A SASS/SCSS syntax checker using sass-Lint.
+
+See URL `https://github.com/sasstools/sass-lint'."
+  :command ("sass-lint"
+            "--verbose"
+            "--no-exit"
+            "--format" "Checkstyle"
+            (config-file "--config" flycheck-sass-lintrc)
+            source)
+  :standard-input nil
+  :error-parser flycheck-parse-checkstyle
+  :modes (sass-mode scss-mode))
 
 (flycheck-define-checker scala
   "A Scala syntax checker using the Scala compiler.


### PR DESCRIPTION
- a current limitation is that linting is performed on the file contents
  instead of the buffer and saving is required to re-lint

The functionality was not _designed_ but put together by looking at existing code and it might be missing obvious improvements.