### PR TITLE
Require :mode for all syntax checkers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@
   - Remove ``--config`` option in ``lua-luacheck`` in favour of ``luacheck``'s
     own ``.luacheckrc`` detection. Therefore ``flycheck-luacheckrc`` is
     no longer used [GH-1057]
+  - ``:modes`` is now mandatory for syntax checker definitions [GH-1071]
 
 - New syntax checkers:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -1440,12 +1440,8 @@ have any `:modes', but a `:predicate' that returns non-nil for
 the current buffer."
   (let (checkers)
     (dolist (checker flycheck-checkers)
-      (let ((modes (flycheck-checker-get checker 'modes))
-            (predicate (flycheck-checker-get checker 'predicate)))
-        (when (or (memq major-mode modes)
-                  (and (not modes)
-                       (functionp predicate)
-                       (funcall predicate)))
+      (let ((modes (flycheck-checker-get checker 'modes)))
+        (when (memq major-mode modes)
           (push checker checkers))))
     (nreverse checkers)))
 
@@ -1595,15 +1591,12 @@ are mandatory.
      A major mode symbol or a list thereof, denoting major modes
      to use this syntax checker in.
 
-     If given this syntax checker is only used in buffers whose
-     `major-mode' is `eq' to any mode in MODES.
+     This syntax checker will only be used in buffers whose
+     `major-mode' is contained in MODES.
 
-     If `:predicate' is also given, the syntax checker will only
+     If `:predicate' is also given the syntax checker will only
      be used in buffers for which the `:predicate' returns
      non-nil.
-
-     This property is optional, however at least one of `:modes'
-     or `:predicate' must be given.
 
 `:predicate FUNCTION'
      A function to determine whether to use the syntax checker in
@@ -1613,11 +1606,9 @@ are mandatory.
      non-nil if this syntax checker shall be used to check the
      current buffer.  Otherwise it shall return nil.
 
-     If `:modes' is also given, FUNCTION is only called in
-     matching major modes.
+     FUNCTION is only called in matching major modes.
 
-     This property is optional, however at least one of `:modes'
-     or `:predicate' must be given.
+     This property is optional.
 
 `:error-filter FUNCTION'
      A function to filter the errors returned by this checker.
@@ -1700,8 +1691,8 @@ Signal an error, if any property has an invalid value."
     (unless (or (null verify) (functionp verify))
       (error ":verify %S of syntax checker %S is not a function"
              symbol verify))
-    (unless (or modes predicate)
-      (error "Missing :modes or :predicate in syntax checker %s" symbol))
+    (unless modes
+      (error "Missing :modes in syntax checker %s" symbol))
     (dolist (mode modes)
       (unless (symbolp mode)
         (error "Invalid :modes %s in syntax checker %s, %s must be a symbol"
@@ -1761,7 +1752,7 @@ nil otherwise."
         (predicate (flycheck-checker-get checker 'predicate)))
     (and (flycheck-valid-checker-p checker)
          (not (flycheck-disabled-checker-p checker))
-         (or (not modes) (memq major-mode modes))
+         (memq major-mode modes)
          (funcall predicate))))
 
 (defun flycheck-may-use-next-checker (next-checker)
@@ -1849,15 +1840,12 @@ Pop up a help buffer with the documentation of CHECKER."
         (let ((modes-start (with-current-buffer standard-output (point-max))))
           ;; Track the start of the modes documentation, to properly re-fill
           ;; it later
-          (if (not modes)
-              ;; Syntax checkers without modes must have a predicate
-              (princ "  This syntax checker checks syntax if a custom predicate holds")
-            (princ "  This syntax checker checks syntax in the major mode(s) ")
-            (princ (string-join
-                    (seq-map (apply-partially #'format "`%s'") modes)
-                    ", "))
-            (when predicate
-              (princ ", and uses a custom predicate")))
+          (princ "  This syntax checker checks syntax in the major mode(s) ")
+          (princ (string-join
+                  (seq-map (apply-partially #'format "`%s'") modes)
+                  ", "))
+          (when predicate
+            (princ ", and uses a custom predicate"))
           (princ ".")
           (when next-checkers
             (princ "  It runs the following checkers afterwards:"))
@@ -1953,11 +1941,9 @@ into the verification results."
         (let* ((modes (flycheck-checker-get checker 'modes))
                (mm-supported (memq major-mode modes))
                (message-and-face
-                (cond
-                 ((not modes) '("No restriction" . success))
-                 (mm-supported (cons (format "`%s' supported" major-mode)
-                                     'success))
-                 (t (cons (format "`%s' not supported" major-mode) 'error)))))
+                (if mm-supported
+                    (cons (format "`%s' supported" major-mode) 'success)
+                  (cons (format "`%s' not supported" major-mode) 'error))))
           (push (flycheck-verification-result-new
                  :label "major mode"
                  :message (car message-and-face)

--- a/test/specs/test-generic-checkers.el
+++ b/test/specs/test-generic-checkers.el
@@ -1,0 +1,43 @@
+;;; test-generic-checkers.el --- Flycheck Specs: Generic checkers  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016 Sebastian Wiesner and Flycheck contributors
+
+;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for generic syntax checkers
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'flycheck-buttercup)
+
+(describe "Generic syntax checkers"
+  (describe "Major mode"
+    (it "supports a major mode"
+      (cl-letf (((flycheck-checker-get 'foo 'modes) '(bar-mode foo-mode)))
+        (expect (flycheck-checker-supports-major-mode-p 'foo 'foo-mode)
+                :to-be-truthy)))
+
+    (it "does not support a major mode"
+      (cl-letf (((flycheck-checker-get 'foo 'modes) '(bar-mode foo-mode)))
+        (expect (flycheck-checker-supports-major-mode-p 'foo 'spam-mode)
+                :not :to-be-truthy)))))
+
+;;; test-generic-checkers.el ends here


### PR DESCRIPTION
Follow up of #961: We've got no built-in syntax checkers without `:mode` anyway, thus making it mandatory simplifies our code.  

Should we need a more generic system I think we should rather take the route of supporting derived modes. Even a hypothetical ispell checker could probably not support all modes: There are fundamental differences between programming languages and text and likely you'll need to syntax checkers for these anyway.

This pull request is still WIP (missing some tests and doc updates), but I'm opening it anyway for discussion.

/cc @cpitclaudel 