### PR TITLE
Support debian

### DIFF
--- a/doc/community/people.rst
+++ b/doc/community/people.rst
@@ -109,6 +109,18 @@ TypeScript
 
 Mention with ``@flycheck/typescript``.
 
+Packagers
+=========
+
+We would like to thank all people who package Flycheck on behalf of
+distributions and support our development efforts with their feedback, their
+patches and their testing:
+
+* Sean Whitton (:gh:`spwhitton`) and the `Debian Emacs addon team`_ (Debian
+  packages)
+
+.. _Debian Emacs addon team: https://pkg-emacsen.alioth.debian.org/
+
 Acknowledgements
 ================
 

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -92,24 +92,35 @@ Add the following form to your init file to setup Flycheck with `use-package`_:
 Then press :kbd:`C-M-x` with point somewhere in this form to install and enable
 Flycheck for the current Emacs session.
 
-.. _flycheck-alternative-installation-methods:
+.. _flycheck-distribution-packages:
 
-Alternative installation methods
-================================
+Distribution packages
+---------------------
 
-Some users prefer to install Flycheck via other methods such as el-get, Git
-submodules, etc.
+Alternatively some distributions provide binary packages of Flycheck.  We
+officially support the following distributions:
 
-We do **not** support any of these methods, and advise against any alternative
-installation method.  We do not consider it a bug if Flycheck works when
-installed as above but not with a different installation method.
+* Debian 9 and newer: ``apt-get install elpa-flycheck flycheck-doc`` (the latter
+  for our manual).  The `Debian Emacs addon team`_ provides these packages.
+
+.. _Debian Emacs addon team: https://pkg-emacsen.alioth.debian.org/
+
+.. _flycheck-legacy-installation-methods:
+
+Legacy installation methods
+===========================
+
+Some users prefer to install Flycheck with legacy methods such as el-get, Git
+submodules, etc that were common before Emacs included a package manager.  There
+are also many 3rd party packages provided by various package managers.  We do
+neither support nor endorse any of these:
 
 .. warning::
 
    If you install Flycheck in any way other than :ref:`our official packages
    <flycheck-package-installation>` you do so **at your own risk**.
 
-Please beware of breakage and understand that while we do not actively work
+Please beware of breakage, and understand that while we do not actively work
 against alternative installation methods we will not make compromises to support
 alternative installation methods.  We will close issues reported for alternative
 installation if we fail to reproduce them with a proper installation of


### PR DESCRIPTION
I'd like to update the documentation to state that we officially support the `elpa-flycheck` Debian package by @spwhitton.  

While I'm personally still in favour of Emacs' built-in package manager I feel that given @spwhitton's [awesome work on the tests](https://ci.debian.net/packages/f/flycheck/) ❤️ we can absolutely recommend the package.  In fact as far as the integration with syntax checkers is concerned it's probably even more stable than our own MELPA packages :blush:

Plus, since Debian is so kind as to run our tests for us I feel we really should do them the favour to support their package, i.e. not make any packaging changes without @spwhitton's approval and make sure that new releases seamlessly propagate to Debian. :relaxed:

I'm also adding a packaging team in this PR which lists responsibilities for Flycheck packages.  It's main purpose is so that I can just do `@flycheck/packaging` in issues that affect packaging to bring all relevant people in at once.

I'd also like to take the opportunity to say my heartfelt thanks to @spwhitton! Thanks for your labour on our all-to-flaky integration tests, and for providing us with a CI to run them.  Many many thanks, it's a pleasure to work with you! ❤️ 
