### PR TITLE
Add configuration entry for cargo's rustc command.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@
 
   - Elixir with ``dogma`` [GH-969]
 
+- New features:
+
+  - Add ``flycheck-cargo-rustc-args`` to pass multiple arguments to cargo rustc
+    subcommand [GH-1079]
+
 29 (Aug 28, 2016)
 =================
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -903,7 +903,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. defcustom:: flycheck-rust-args
 
-         A list of additional arguments.
+         A list of additional arguments that are passed to rustc.
+
+      .. defcustom:: flycheck-cargo-rustc-args
+
+         A list of additional arguments passed to the cargo rustc subcommand
 
       .. defcustom:: flycheck-rust-check-tests
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -8380,6 +8380,9 @@ See URL `http://jruby.org/'."
   :modes (enh-ruby-mode ruby-mode)
   :next-checkers ((warning . ruby-rubylint)))
 
+(flycheck-def-args-var flycheck-cargo-rustc-args (rust-cargo)
+  :package-version '(flycheck . "30"))
+
 (flycheck-def-args-var flycheck-rust-args (rust-cargo rust)
   :package-version '(flycheck . "0.24"))
 
@@ -8454,6 +8457,7 @@ rustc command.  See URL `https://www.rust-lang.org'."
                    ((string= flycheck-rust-crate-type "lib") "--lib")
                    (flycheck-rust-binary-name
                     (list "--bin" flycheck-rust-binary-name))))
+            (eval flycheck-cargo-rustc-args)
             "--" "-Z" "no-trans"
             ;; Passing the "unstable-options" flag may raise an error in the
             ;; future.  For the moment, we need it to access JSON output in all


### PR DESCRIPTION
This new configuration entry allows arguments to be passed to cargo's
rustc subcommand, mirroring the preexisting configuration entry
for rustc itself.

This enables the user to specify cargo related flags like --features,
number of worker threads with much be passed to cargo rust before the --
which delineates the rustc subcommand's args from rustc proper's