### PR TITLE
Add a style guide for contributors and maintainers

### DIFF
--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -1,3 +1,5 @@
+.. _flycheck-contributors-guide:
+
 =====================
  Contributor’s Guide
 =====================
@@ -113,8 +115,8 @@ Flycheck. Github provides great documentation about `Pull Requests`_.
 
 Please make your pull requests against the ``master`` branch.
 
-Use ``make specs test`` to test your pull request locally. When making changes
-to syntax checkers of a specific language, it’s also a good idea to run
+Use ``make check specs unit`` to test your pull request locally. When making
+changes to syntax checkers of a specific language, it’s also a good idea to run
 :samp:`make LANGUAGE={language} integ` and check whether the tests for the
 particular language still work.  A successful ``make integ`` is by no means
 mandatory for pull requests, though, we will test your changes, too.
@@ -135,7 +137,9 @@ mandatory for pull requests, though, we will test your changes, too.
 All pull requests are reviewed by a :ref:`maintainer <flycheck-maintainers>`.
 Feel free to mention individual developers (e.g. ``@lunaryorn``) to request a
 review from a specific person, or ``@flycheck/maintainers`` if you have general
-questions or if your pull request was waiting for review too long.
+questions or if your pull request was waiting for review too long.  Take a look
+at our :ref:`flycheck-style-guide` to see what we look for and how we expect
+code to look like.
 
 Additionally all pull requests go through automated tests on `Travis CI`_ which
 check code style, run unit tests, etc.

--- a/doc/contributor/maintaining.rst
+++ b/doc/contributor/maintaining.rst
@@ -1,3 +1,5 @@
+.. _flycheck-maintainers-guide:
+
 ====================
  Maintainer’s Guide
 ====================
@@ -66,6 +68,10 @@ Our workflow implies a couple of rules about which branches to push code to:
 Pull requests
 -------------
 
+Please review pull requests according to our :ref:`style guide
+<flycheck-style-guide>`, and consider whether you personally think that the
+change is a good addition to Flycheck.
+
 **All pull requests require approval of a maintainer**.
 
 To state your approval as a maintainer add a comment that contains ``LGTM``.
@@ -85,11 +91,6 @@ maintainers approved it.  We require approvals from multiple maintainers, see
    **contributor**.  In this case they’ll be able to directly merge their own
    pull request after making changes to it which decreases the turn-around time
    for pull requests.
-
-Review guidelines
-~~~~~~~~~~~~~~~~~
-
-.. todo:: Write pull request review guidelines
 
 Merge guidelines
 ~~~~~~~~~~~~~~~~

--- a/doc/contributor/style-guide.rst
+++ b/doc/contributor/style-guide.rst
@@ -1,0 +1,118 @@
+.. _flycheck-style-guide:
+
+=============
+ Style Guide
+=============
+
+This document describes our code style.  It tells you what to look for when
+making changes to Flycheck, or when reviewing pull requests.
+
+Features
+========
+
+Flycheck’s scope and focus is providing the infrastructure and foundations for
+on-the-fly syntax checking.  Flycheck provides the basics but deep integration
+with particular programming languages is best left to :ref:`separate packages
+<flycheck-extensions>`.
+
+Whether a feature is within the scope of Flycheck is the :ref:`maintainer’s
+<flycheck-maintainers>` judgement call.  Generally we reserve the right to
+reject any pull request for being out of scope.
+
+* Avoid a *disproportionate amount of code* for a single syntax checker or
+  language.  Look at the built-in checkers for judgement.  A syntax checker that
+  requires a lot more code than any built-in checker is likely to be rejected.
+
+* Avoid *deep integration* with a particular UI or completion framework.  Emacs’
+  standard is our standard: We will reject code that is tied to Helm or Counsel.
+
+* Likewise do not deviate from Emacs’ default behaviour too much.  Stick to
+  Emacs’ standard for key bindings, interactive functions, etc.
+
+Style
+=====
+
+.. important::
+
+   ``make check compile`` must pass on Emacs 25 or newer.  This command checks
+   for some formatting issues and compilation errors.
+
+   Run ``make format`` with Emacs 25 to automatically reformat the Emacs Lisp
+   source files.
+
+* Generally try to fit into the style of the code you see.
+
+* Indent with the default indentation rules.
+
+* Follow the :infonode:`(elisp)Programming Tips` for Emacs Lisp.
+
+* Whitespace:
+
+  * 80 characters per line.
+  * Avoid tabs and trailing spaces.
+
+* Naming:
+
+  * Prefix all variables and functions with the name of the containing library,
+    i.e. ``flycheck-`` for everything that is in :file:`flycheck.el`.
+
+  * End boolean predicates with ``-p``, i.e. ``flycheck-valid-checker-p``.
+
+* Avoid macros, and use them for syntax only.
+
+* Adhere to the :infonode:`(elisp)Key Binding Conventions`.  Particularly do not
+  define keys in Emacs’ reserved keymaps or in the :samp:`C-c {LETTER}` space
+  for user bindings.
+
+Libraries
+=========
+
+* Do **not** advise built-in or 3rd party functions and commands.
+
+* Do **not** redefine built-in or 3rd party functions, unless for compatibility,
+  but then copy the newer definition verbatim.
+
+* Do **not** use ``with-eval-after-load`` and similar functions.
+
+* Dependencies:
+
+  * Use built-in Emacs libraries freely.
+  * Introduce external dependencies with care.  Prefer built-in
+    libraries. ``dash.el`` is fine, though.
+  * Avoid dependencies on language-specific libraries.
+
+* Avoid ``cl-lib``:
+
+  * Prefer ``seq`` over ``dash`` over ``cl-lib``.  Use list functions from
+    ``cl-lib`` only as the very last resort.
+  * Prefer ``let-alist`` and ``pcase`` over ``cl-destructuring-bind``.
+
+Tests
+=====
+
+* Add comprehensive buttercup specs for new functions and commands to
+  :file:`test/specs/`.  Check whether the specs fit into an existing spec file,
+  or add a new file instead.  In doubt, use a new file.
+
+* For new syntax checkers add at least one syntax checker integration test to
+  :file:`test/flycheck-test.el`.  Make sure that the test passes with
+  :samp:`make LANGUAGE={language} integ`.
+
+Documentation
+=============
+
+* Add docstrings to all functions and variables.
+
+* Follow the :infonode:`(elisp)Documentation Tips`.
+
+* Take care to update our manual:
+
+  * Document new interactive commands and user options in the :ref:`user guide
+    <flycheck-user-guide>`.
+  * Document new syntax checkers and new options for existing syntax checkers in
+    the :ref:`list of languages <flycheck-languages>`.
+  * Document new or changed version requirements for syntax checkers in the
+    :ref:`list of languages <flycheck-languages>`.
+  * Document changes to our build system and tooling in the :ref:`contributor’s
+    guide <flycheck-contributors-guide>` or the :ref:`maintainer’s guide
+    <flycheck-maintainers-guide>`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,6 +52,8 @@ features go through :ref:`Quickstart <flycheck-quickstart>` guide.
 
 .. _`known windows issues`: https://github.com/flycheck/flycheck/labels/B-Windows%20only
 
+.. _flycheck-user-guide:
+
 The User Guide
 ==============
 
@@ -107,6 +109,7 @@ The Contributor Guide explains how to contribute to Flycheck.
 .. toctree::
 
    contributor/contributing
+   contributor/style-guide
    contributor/maintaining
 
 Indices and Tables


### PR DESCRIPTION
I took some time to write up a style guide for Flycheck.  It should cover everything from code to documentation, tests, and even what features we consider appropriate for Flycheck.

@flycheck/maintainers @flycheck/contributors  Please take a look and tell me what you think about the rules, and whether anything is missing.