### PR TITLE
Run slim-lint inplace instead from a temp location

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8896,7 +8896,7 @@ See URL `http://slim-lang.com'."
   "A Slim linter.
 
 See URL `https://github.com/sds/slim-lint'."
-  :command ("slim-lint" "--reporter=checkstyle" source)
+  :command ("slim-lint" "--reporter=checkstyle" source-inplace)
   :error-parser flycheck-parse-checkstyle
   :modes slim-mode)
 


### PR DESCRIPTION
The `slim-lint` utility makes use of a few different configuration files during its run. The main one is `.slim-lint.yml` but `.ruboconf.yml` can also be used if you have Rubocop checks enabled. Flycheck with `slim-lint` was not taking these files into account since the source was being copied to a temp location.

I don't know enough about flycheck to understand the downsides of running this inplace vs from a temp location. This just scratches my own itch of getting the correct warnings reporting while editing files.

I did look first at passing a file to `slim-lint`, which would work for `.slim-lint.yml` but not for `.ruboconf.yml`.
