### PR TITLE
ESLint support for :enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
     no longer used [GH-1057]
   - ``:modes`` is now mandatory for syntax checker definitions [GH-1071]
   - Remove jade checker [GH-951] [GH-1084]
+  - Remove ``javascript-eslintrc`` and instead rely on eslint's own configuration file
+    search [GH-1085]
 
 - New syntax checkers:
 
@@ -21,6 +23,10 @@
   - Add ``flycheck-cargo-rustc-args`` to pass multiple arguments to cargo rustc
     subcommand [GH-1079]
   - Add ``:enabled`` property to ``flycheck-define-checker`` [GH-1089]
+
+- Improvements:
+
+  - Do not use ``javascript-eslint`` if eslint cannot find a valid configuration [GH-1085]
 
 29 (Aug 28, 2016)
 =================

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -549,11 +549,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check syntax and lint with `ESLint <http://eslint.org/>`_.
 
+      .. note::
+
+         Flycheck does not use this syntax checker if eslint cannot find a valid
+         configuration file.
+
       .. defcustom:: flycheck-eslint-rules-directories
 
          A list of directories with custom rules.
-
-      .. syntax-checker-config-file:: flycheck-eslintrc
 
    .. syntax-checker:: javascript-jshint
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7489,16 +7489,11 @@ for more information about the custom directories."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "29"))
 
-(flycheck-def-config-file-var flycheck-eslintrc javascript-eslint nil
-  :safe #'stringp
-  :package-version '(flycheck . "0.20"))
-
 (flycheck-define-checker javascript-eslint
   "A Javascript syntax and style checker using eslint.
 
 See URL `https://github.com/eslint/eslint'."
   :command ("eslint" "--format=checkstyle"
-            (config-file "--config" flycheck-eslintrc)
             (option-list "--rulesdir" flycheck-eslint-rules-directories)
             "--stdin" "--stdin-filename" source-original)
   :standard-input t
@@ -7518,6 +7513,12 @@ See URL `https://github.com/eslint/eslint'."
                                    (flycheck-error-message err))))
                           (flycheck-sanitize-errors errors))
                   errors)
+  :enabled (lambda (checker)
+             (let* ((default-directory (flycheck-compute-working-directory checker))
+                    (executable (flycheck-find-checker-executable checker))
+                    (exitcode (call-process executable nil nil nil
+                                            "--print-config" ".")))
+               (eq exitcode 0)))
   :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode)
   :next-checkers ((warning . javascript-jscs)))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3321,17 +3321,16 @@ Why not:
   (let ((flycheck-disabled-checkers '(javascript-jshint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/syntax-error.js" flycheck-test-javascript-modes
-     '(3 26 error "Parsing error: Unexpected token )" :checker javascript-eslint))))
+     '(3 25 error "Parsing error: Unexpected token )" :checker javascript-eslint))))
 
 (flycheck-ert-def-checker-test javascript-eslint javascript warning
   :tags '(checkstyle-xml)
-  (let ((flycheck-eslintrc "eslint.json")
-        (flycheck-disabled-checkers '(javascript-jshint javascript-jscs)))
+  (let ((flycheck-disabled-checkers '(javascript-jshint javascript-jscs)))
     (flycheck-ert-should-syntax-check
      "language/javascript/warnings.js" flycheck-test-javascript-modes
-     '(3 2 warning "Use the function form of \"use strict\"." :id "strict"
+     '(3 2 warning "Use the function form of 'use strict'." :id "strict"
          :checker javascript-eslint)
-     '(4 9 warning "\"foo\" is defined but never used" :id "no-unused-vars"
+     '(4 9 warning "'foo' is defined but never used." :id "no-unused-vars"
          :checker javascript-eslint))))
 
 (flycheck-ert-def-checker-test javascript-gjslint javascript nil

--- a/test/resources/language/javascript/.eslintrc.json
+++ b/test/resources/language/javascript/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules" : {
+    "strict": 1,
+    "no-unused-vars": 1
+  }
+}


### PR DESCRIPTION
Here is `:enabled` for ESLint checker and some test fixes.

There is one issue with tests. ESLint integration tests will run on GNU Emacs 24.5. When using 25.1, both tests are skipped for some reason. In both versions of GNU Emacs `:enabled` will run and return right value, and my best guess that this is probably doe to some ERT change in 25.1.

Fixes and closes GH-1085