### PR TITLE
Suggest updating the checker when warning about suspicious output

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4955,8 +4955,11 @@ Resolve all errors in OUTPUT using CWD as working directory."
       ;; might report errors from other files (e.g. includes) even if there
       ;; are no errors in the file being checked.
       (funcall callback 'suspicious
-               (format "Checker %S returned non-zero exit code %s, but no errors from \
-output: %s\nChecker definition probably flawed." checker exit-status output)))
+               (format "Flycheck checker %S returned non-zero \
+exit code %s, but its output contained no errors: %s\nTry \
+installing a more recent version of %S, and please open a bug \
+report if the issue persists in the latest release.  Thanks!"
+                       checker exit-status output checker)))
     (funcall callback 'finished
              ;; Fix error file names, by substituting them backwards from the
              ;; temporaries.


### PR DESCRIPTION
Inspired by GH-1107.  Please feel free to suggest improvements to the wording :) Hopefully this will help users who get confusing error messages when using outdated checkers.

Once we have it, we could simply include a link to the upcoming "troubleshooting" section of the manual.