### PR TITLE
Use a Unicode ellipsis for truncation in the error list

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3826,6 +3826,8 @@ the beginning of the buffer."
         ;; `revert-buffer' updates the mode line for us, so all we need to do is
         ;; set the corresponding mode line construct.
         mode-line-buffer-identification flycheck-error-list-mode-line)
+  ;; See https://github.com/flycheck/flycheck/issues/1101
+  (setq-local truncate-string-ellipsis "…")
   (tabulated-list-init-header))
 
 (defvar-local flycheck-error-list-source-buffer nil


### PR DESCRIPTION
As discussed in #1101 :)