### PR TITLE
Check that error message is non-nil before replacing temp filename

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5332,16 +5332,12 @@ function `buffer-file-name'."
       (when (seq-some (apply-partially #'flycheck-same-files-p
                                        (expand-file-name filename cwd))
                       buffer-files)
-        (let ((new-filename (buffer-file-name)))
-          (setf (flycheck-error-filename err) new-filename)
-          (when new-filename
-            (setf (flycheck-error-message err)
-                  (replace-regexp-in-string
-                   (regexp-quote filename)
-                   new-filename
-                   (flycheck-error-message err)
-                   'fixed-case
-                   'literal)))))))
+        (setf (flycheck-error-filename err) buffer-file-name)
+        (when (and buffer-file-name (flycheck-error-message err))
+          (setf (flycheck-error-message err)
+                (replace-regexp-in-string
+                 (regexp-quote filename) buffer-file-name
+                 (flycheck-error-message err) 'fixed-case 'literal))))))
   err)
 
 


### PR DESCRIPTION
**Check that error message is non-nil before replacing temp filename**
The issue was introduced by GH-1030.  Some command checkers may produce
nil messages (with a custom error filter to handle them), so guard
against that case before replacing filename in error message.
