### PR TITLE
Add systemd unit config checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - New syntax checkers:
 
   - Protobuf with ``protoc`` [GH-1125]
+  - systemd-analyze with ``systemd-analyze`` [GH-1135]
 
 30 (Oct 12, 2016)
 =================

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1083,6 +1083,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check SQL syntax with `Sqlint <https://github.com/purcell/sqlint>`_.
 
+.. supported-language:: systemd Unit Configuration
+
+   .. syntax-checker:: systemd-analyze
+
+      Check systemd unit configuration file syntax with `systemd-analyze`_.
+
+      .. _systemd-analyze: https://www.freedesktop.org/software/systemd/man/systemd-analyze.html
+
 .. supported-language:: TeX/LaTeX
 
    Flycheck checks TeX and LaTeX with either `tex-chktex` or `tex-lacheck`.

--- a/flycheck.el
+++ b/flycheck.el
@@ -247,6 +247,7 @@ attention to case differences."
     slim
     slim-lint
     sql-sqlint
+    systemd-analyze
     tex-chktex
     tex-lacheck
     texinfo
@@ -9159,6 +9160,15 @@ See URL `https://github.com/purcell/sqlint'."
                                  (one-or-more not-newline)))
           line-end))
   :modes (sql-mode))
+
+(flycheck-define-checker systemd-analyze
+  "A systemd unit checker using systemd-analyze(1).
+
+See URL `https://www.freedesktop.org/software/systemd/man/systemd-analyze.html'."
+  :command ("systemd-analyze" "verify" source-original)
+  :error-patterns
+  ((error line-start "[" (file-name) ":" line "] " (message) line-end))
+  :modes (systemd-mode))
 
 (flycheck-def-config-file-var flycheck-chktexrc tex-chktex ".chktexrc"
   :safe #'stringp)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4016,6 +4016,16 @@ Why not:
    `(1 15 error "unterminated quoted string at or near \"';\n  \" (scan.l:1087)"
        :checker sql-sqlint)))
 
+(flycheck-ert-def-checker-test systemd-analyze systemd nil
+  (flycheck-ert-should-syntax-check
+   "language/systemd-analyze-test.service" 'systemd-mode
+   '(3 nil error "Invalid URL, ignoring: foo://bar"
+       :checker systemd-analyze)
+   '(6 nil error "Unknown lvalue 'ExecSmart' in section 'Service'"
+       :checker systemd-analyze)
+   '(8 nil error "Unknown section 'Dog'. Ignoring."
+       :checker systemd-analyze)))
+
 (flycheck-ert-def-checker-test tex-chktex (tex latex) nil
   (flycheck-ert-should-syntax-check
    "language/tex.tex" 'latex-mode

--- a/test/resources/language/systemd-analyze-test.service
+++ b/test/resources/language/systemd-analyze-test.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Test file for flycheck systemd-analyze checker
+Documentation=foo://bar
+
+[Service]
+ExecSmart=
+
+[Dog]


### PR DESCRIPTION
adds a checker and entry in languages.rst for a systemd unit config checker using systemd-analyze. see #1135
