### PR TITLE
Refine review and merge rules

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,2 @@
-approvals = 2
+approvals = 1
 pattern = "(?i)LGTM"

--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -134,11 +134,17 @@ mandatory for pull requests, though, we will test your changes, too.
 
    .. _CLA: https://gist.github.com/lunaryorn/c9c0d656fe7e704da2f734779242ec99
 
-All pull requests are reviewed by a :ref:`maintainer <flycheck-maintainers>`.
-Feel free to mention individual developers (e.g. ``@lunaryorn``) to request a
-review from a specific person, or ``@flycheck/maintainers`` if you have general
-questions or if your pull request was waiting for review too long.
+All pull requests go through a two-stage review process:
 
+* :ref:`Maintainer <flycheck-maintainers>` review the general idea and direction
+  of the pull request and leave a ``LGTM`` comment if they believe that the
+  change is a good addition to Flycheck.  We currently require at least one
+  approval from a maintainer.
+* :ref:`All contributors <flycheck-language-teams>`—language teams in
+  particular—check the technical implementation of a pull request through `pull
+  request reviews`_, and either approve it or request changes.  We currently
+  require at least one approval and no requested changes
+.
 .. important::
 
    We have a comprehensive :ref:`flycheck-style-guide` that explains what
@@ -148,12 +154,20 @@ questions or if your pull request was waiting for review too long.
    Take a look at it to see what we look for in a code review.
 
 Additionally all pull requests go through automated tests on `Travis CI`_ which
-check code style, run unit tests, etc.
+check code style, run unit tests, etc
 
-After the pull request was reviewed and if all tests passed maintainers will
-leave a ``LGTM`` comment at which point the pull request is ready for being
-merged.
+Feel free to mention individual contributors (e.g. ``@lunaryorn``) or entire
+teams (e.g. ``@flycheck/maintainers`` or ``@flycheck/javascript``) to ask for
+help or feedback or request a review.  Please mention the maintainers
+(``@flycheck/maintainers``) if you think that your pull request has been waiting
+for review too long.  You can expect a first response to any pull request in a
+couple of days.
 
+Once the pull request passed review and automated tests we will merge it.  We
+may also ask you whether you'd like to join Flycheck and help us, thus giving
+you commit access to our repository and let you merge your own pull request.
+
+.. _pull request reviews: https://help.github.com/articles/about-pull-request-reviews/
 .. _Travis CI: https://travis-ci.org/flycheck/flycheck/pull_requests
 
 Writing documentation

--- a/doc/contributor/maintaining.rst
+++ b/doc/contributor/maintaining.rst
@@ -66,46 +66,81 @@ Our workflow implies a couple of rules about which branches to push code to:
 
 .. _pull request: https://help.github.com/articles/using-pull-requests/
 
-.. _flycheck-pull-requests:
+.. _flycheck-pull-requests-reviews:
 
-Pull requests
--------------
+Pull requests reviews
+---------------------
 
-Please review pull requests according to our :ref:`style guide
-<flycheck-style-guide>`, and consider whether you personally think that the
-change is a good addition to Flycheck.
+We review all pull requests, and require two different kinds of approval:
 
-**All pull requests require approval of a maintainer**.
+* At least one maintainer must approve the idea and direction with a ``LGTM``
+  comment.
+* At least one contributor (maintainer or otherwise) must approve the
+  implementation by leaving an approved `pull request review`_, and no
+  contributors must have requested changes.
 
-To state your approval as a maintainer add a comment that contains ``LGTM``.
-The LGTM.co will look for these comments and unlock the pull request once enough
-maintainers approved it.  We require approvals from multiple maintainers, see
-``.lgtm`` for the exact amount of approvals required to accept a pull request.
+.. _pull request review: https://help.github.com/articles/about-pull-request-reviews/
 
-.. important::
+As a maintainer
+~~~~~~~~~~~~~~~
 
-   LGTM.co does not require repeated approval after changes to the pull
-   request.  Hence you can “approve early”, i.e. approve before the pull request
-   is polished.
+* Consider whether you personally think that the change is a good addition to
+  Flycheck.
+* Weight the expected benefits and impact of the feature against the
+  expected complexity.
+* Check whether the pull request complies with our :ref:`style guide
+  <flycheck-style-guide>`, but don't go too much into technical details.
+* Don't review for technical details.  It's the idea and direction that counts.
 
-   And it’s absolutely fine to do so.  If there are only minor changes left, if
-   you trust the pull request author to address remaining issues, **feel free to
-   approve early**, all the more if the pull request author is already a
-   **contributor**.  In this case they’ll be able to directly merge their own
-   pull request after making changes to it which decreases the turn-around time
-   for pull requests.
+If you would like to see the pull request in Flycheck leave a ``LGTM`` comment.
+The LGTM.co service will look for these comments and unlock the pull request
+once enough maintainers approved it.  The exact rules are in the :file:`.lgtm`
+file, the list of maintainers is in the :file:`MAINTAINERS` file.
+
+As a contributor
+~~~~~~~~~~~~~~~~
+
+* Check the technical implementation.
+* Consider the impact on syntax checking for a language.
+* Check whether the tests pass.
+* Check whether the PR complies with our :ref:`style guide
+  <flycheck-style-guide>`.
+* Challenge the technical implementation of a pull request, and ask questions
+  about dubious code.
+* Consider whether there might be a simpler approach or a better solution to the
+  problem that the PR solves.
+
+If you find any issues please leave a :ref:`pull request review` that requests
+for changes.  Please try to leave an inline comment wherever possible and try to
+suggest a better solution, to make it easy for the PR author to discover and fix
+the issues.
+
+If you didn't find any issues leave a :ref:`pull request review` that approves
+the changes.
+
+In doubt request changes first and let the PR author explain their intention and
+implementation.  You can still approve the review afterwards if you are
+satisfied.
 
 Merge guidelines
 ~~~~~~~~~~~~~~~~
 
-If a pull request was approved you may directly merge it.  For smaller pull
-requests please “Squash and Merge” to keep a linear history, otherwise merge
-normally.  What constitutes a "small" pull request is at your discretion.  Apply
-common sense :)
+Any contributor may merge approved pull requests.  Our protection rules for the
+``master`` branch ensure that only approved pull requests can be merged, so if
+the "Merge" button is green go ahead and press it :)
 
-You may also add the author of the pull request to the "Core developers" team to
-give them commit access to the Flycheck repository and ask them merge the pull
-request themselves.  That's a good way to gain new contributors.
+We require proper merges for pull requests, to preserve the fact that a change
+came from a pull request in the git history and to retain any commit signatures
+that may exist.  As such you can't squash-merge or rebase-merge through GitHub's
+UI.
+
+.. important::
+
+   Before merging please take an extra look at the commits to make sure that the
+   commits were properly squashed and have good commit messages.
+
+   Ask the contributor to improve the commit messages and squash the commits
+   first, by requesting changes with a pull request review.
 
 .. _flycheck-git-signatures:
 
@@ -252,8 +287,8 @@ New maintainers
 
 To propose a new maintainer open a pull request that adds the user to
 ``MAINTAINERS`` and ``doc/community/people.rst``.  The pull request is subject
-to the :ref:`same rules <flycheck-pull-requests>` as all other pull requests.
-Notably it goes through the same approval process.
+to the :ref:`same rules <flycheck-pull-requests-reviews>` as all other pull
+requests.  Notably it goes through the same approval process.
 
 Once merged please also
 


### PR DESCRIPTION
See #1094 and #1118 for background.

This PR changes our review process to make use of github pull request reviews for the technical aspect, leaving LGTM for the general direction and idea only.  Opens up reviews to all contributors, so all contributors can now accept pull requests that they like, in particular for the language that they help support.

It also requires proper merges for PRs now, to retain the history and preserve commit signatures.

# TODO (after merging)

- [ ] Make approved pull request reviews mandatory for the `master` branch
- [ ] Disable squash-merges and rebase-merges.


