### PR TITLE
go-test, go-vet, and go-errcheck should use flycheck-go-build-tags.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@
   - Protobuf with ``protoc`` [GH-1125]
   - systemd-analyze with ``systemd-analyze`` [GH-1135]
 
+- Improvements:
+
+  - Use option ``flycheck-go-build-tags`` to for ``go-test``,
+    ``go-vet`` and ``go-errcheck`` as well.
+
 30 (Oct 12, 2016)
 =================
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -387,6 +387,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          Whether to check for shadowed variables, in Go 1.6 or newer.
 
+      .. defcustom:: flycheck-go-build-tags
+
+         A list of build tags.
+
       .. _vet: https://golang.org/cmd/vet/
 
    .. syntax-checker:: go-build
@@ -405,8 +409,9 @@ to view the docstring of the syntax checker.  Likewise, you may use
          `go-test`
 
       .. defcustom:: flycheck-go-build-tags
+         :noindex:
 
-         A list of build tags.
+         See `flycheck-go-build-tags`
 
    .. syntax-checker:: go-test
 
@@ -421,6 +426,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          See `flycheck-go-build-install-deps`.
 
+      .. defcustom:: flycheck-go-build-tags
+         :noindex:
+
+         See `flycheck-go-build-tags`
+
    .. syntax-checker:: go-errcheck
 
       Check for unhandled error returns in Go with errcheck_.
@@ -431,6 +441,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
          28th, 2015) or newer.
 
       .. _errcheck: https://github.com/kisielk/errcheck
+
+      .. defcustom:: flycheck-go-build-tags
+         :noindex:
+
+         See `flycheck-go-build-tags`
 
    .. syntax-checker:: go-unconvert
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7089,6 +7089,7 @@ See URL `https://golang.org/cmd/go/' and URL
             (option "-printfuncs=" flycheck-go-vet-print-functions concat
                     flycheck-option-comma-separated-list)
             (option-flag "-shadow" flycheck-go-vet-shadow)
+            (option-list "-tags=" flycheck-go-build-tags concat)
             (eval (when (eq flycheck-go-vet-shadow 'strict) "-shadowstrict"))
             source)
   :error-patterns
@@ -7175,6 +7176,7 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
 Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
   :command ("go" "test"
             (option-flag "-i" flycheck-go-build-install-deps)
+            (option-list "-tags=" flycheck-go-build-tags concat)
             "-c" "-o" null-device)
   :error-patterns
   ((error line-start (file-name) ":" line ": "
@@ -7194,7 +7196,10 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
 Requires errcheck newer than commit 8515d34 (Aug 28th, 2015).
 
 See URL `https://github.com/kisielk/errcheck'."
-  :command ("errcheck" "-abspath" ".")
+  :command ("errcheck"
+            "-abspath"
+            (option-list "-tags=" flycheck-go-build-tags concat)
+            ".")
   :error-patterns
   ((warning line-start
             (file-name) ":" line ":" column (or (one-or-more "\t") ": " ":\t")


### PR DESCRIPTION
Go test should use the same build tags as go build. Currently `_test.go` files aren't checked using build tags. This is problematic because I use build tags to disable code that cannot be compiled locally, so the end result is that I cannot syntax check `_test.go` files.
