### PR TITLE
Remove :standard-input nil from sass-lint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8797,7 +8797,6 @@ See URL `https://github.com/sasstools/sass-lint'."
             "--format" "Checkstyle"
             (config-file "--config" flycheck-sass-lintrc)
             source)
-  :standard-input nil
   :error-parser flycheck-parse-checkstyle
   :modes (sass-mode scss-mode))
 


### PR DESCRIPTION
That is the default value for standard-input anyway