### PR TITLE
Check whether buffers are really saved to disk

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2191,7 +2191,8 @@ current buffer as BUFFER.
 
 Return non-nil if the BUFFER is backed by a file, and not
 modified, or nil otherwise."
-  (and (buffer-file-name buffer) (not (buffer-modified-p buffer))))
+  (let ((file-name (buffer-file-name buffer)))
+    (and file-name (file-exists-p file-name) (not (buffer-modified-p buffer)))))
 
 
 ;;; Extending generic checkers

--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -46,6 +46,35 @@
         (goto-char (point-min))
         (narrow-to-region (point-min) (point-min))
         (expect (buffer-string) :to-equal "")
-        (expect (flycheck-buffer-empty-p) :not :to-be-truthy)))))
+        (expect (flycheck-buffer-empty-p) :not :to-be-truthy))))
+
+  (describe "flycheck-buffer-saved-p"
+
+    (it "considers an unmodified buffer without backing file unsaved"
+      (with-temp-buffer
+        (expect (flycheck-buffer-saved-p) :not :to-be-truthy)))
+
+    (it "considers a modified buffer without backing file unsaved"
+      (with-temp-buffer
+        (set-buffer-modified-p t)
+        (expect (flycheck-buffer-saved-p) :not :to-be-truthy)))
+
+    (it "considers an unmodified buffer with backing file saved"
+      (spy-on 'file-exists-p :and-return-value t)
+      (spy-on 'buffer-file-name :and-return-value "test-buffer-name")
+      (with-temp-buffer
+        (expect (flycheck-buffer-saved-p) :to-be-truthy))
+      (expect (spy-calls-count 'file-exists-p) :to-equal 1)
+      (expect (spy-calls-count 'buffer-file-name) :to-equal 1))
+
+    (it "considers a modified buffer with backing file unsaved"
+      (spy-on 'file-exists-p :and-return-value t)
+      (spy-on 'buffer-file-name :and-return-value "test-buffer-name")
+      (with-temp-buffer
+        (set-buffer-modified-p t)
+        (expect (flycheck-buffer-saved-p) :not :to-be-truthy))
+      (expect (spy-calls-count 'file-exists-p) :to-equal 1)
+      (expect (spy-calls-count 'buffer-file-name) :to-equal 1))))
+
 
 ;;; test-util.el ends here


### PR DESCRIPTION

flycheck-buffer-saved-p checked if the current buffer visited a file,
but not if the file existed. So visiting a file that did not exist
returned true.
This caused breakages with checkers such as puppet-lint that don't take
input from stdin, used this predicate and expected a concrete file to
exist.
This commit makes flycheck-buffer-saved-p use file-exists-p to ensure
that the buffer visits a concrete file. It also adds tests for
flycheck-buffer-saved-p.

Fixes GH-1148