### PR TITLE
add rjsx-mode to list of javascript modes

### DIFF
--- a/Cask
+++ b/Cask
@@ -25,6 +25,7 @@
  (depends-on "haskell-mode")
  (depends-on "js2-mode")
  (depends-on "js3-mode")
+ (depends-on "rjsx-mode")
  (depends-on "json-mode")
  (depends-on "less-css-mode")
  (depends-on "lua-mode")

--- a/flycheck.el
+++ b/flycheck.el
@@ -7602,7 +7602,7 @@ See URL `http://www.jshint.com'."
   (lambda (errors)
     (flycheck-remove-error-file-names
      "stdin" (flycheck-dequalify-error-ids errors)))
-  :modes (js-mode js2-mode js3-mode)
+  :modes (js-mode js2-mode js3-mode rjsx-mode)
   :next-checkers ((warning . javascript-jscs)))
 
 (flycheck-def-option-var flycheck-eslint-rules-directories nil javascript-eslint
@@ -7651,7 +7651,7 @@ See URL `https://github.com/eslint/eslint'."
             (flycheck-sanitize-errors errors))
     errors)
   :enabled (lambda () (flycheck-eslint-config-exists-p))
-  :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode)
+  :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode rjsx-mode)
   :next-checkers ((warning . javascript-jscs))
   :verify
   (lambda (_)
@@ -7677,7 +7677,7 @@ See URL `https://developers.google.com/closure/utilities'."
   :error-patterns ((warning
                     line-start (file-name) ":" line ":("
                     (id (one-or-more digit)) ") " (message) line-end))
-  :modes (js-mode js2-mode js3-mode)
+  :modes (js-mode js2-mode js3-mode rjsx-mode)
   :next-checkers ((warning . javascript-jscs)))
 
 (defun flycheck-parse-jscs (output checker buffer)
@@ -7711,7 +7711,7 @@ See URL `http://www.jscs.info'."
                   (flycheck-remove-error-ids
                    (flycheck-sanitize-errors
                     (flycheck-remove-error-file-names "input" errors))))
-  :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode))
+  :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode rjsx-mode))
 
 (flycheck-define-checker javascript-standard
   "A Javascript code and style checker for the (Semi-)Standard Style.
@@ -7726,7 +7726,7 @@ See URL `https://github.com/feross/standard' and URL
   :standard-input t
   :error-patterns
   ((error line-start "  <text>:" line ":" column ":" (message) line-end))
-  :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode))
+  :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode rjsx-mode))
 
 (flycheck-define-checker json-jsonlint
   "A JSON syntax and style checker using jsonlint.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3286,7 +3286,8 @@ Why not:
 (defconst flycheck-test-javascript-modes '(js-mode
                                            js2-mode
                                            js3-mode
-                                           js2-jsx-mode))
+                                           js2-jsx-mode
+                                           rjsx-mode))
 
 (when (version<= "25" emacs-version)
   (add-to-list 'flycheck-test-javascript-modes 'js-jsx-mode))
@@ -3298,7 +3299,7 @@ Why not:
         (js2-mode-show-strict-warnings nil)
         (js3-mode-show-parse-errors nil))
     (flycheck-ert-should-syntax-check
-     "language/javascript/syntax-error.js" '(js-mode js2-mode js3-mode)
+     "language/javascript/syntax-error.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(3 4 error "Unmatched '('." :checker javascript-jshint :id "E019")
      '(3 25 error "Expected an identifier and instead saw ')'."
          :checker javascript-jshint :id "E030")
@@ -3310,7 +3311,7 @@ Why not:
   (let ((flycheck-jshintrc "jshintrc")
         (flycheck-disabled-checkers '(javascript-jscs)))
     (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode)
+     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(4 9 warning "'foo' is defined but never used." :id "W098"
          :checker javascript-jshint))))
 
@@ -3335,7 +3336,7 @@ Why not:
   (let ((flycheck-disabled-checkers
          '(javascript-jshint javascript-eslint javascript-jscs)))
     (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode)
+     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(4 nil warning "Single-quoted string preferred over double-quoted string."
          :id "0131" :checker javascript-gjslint)
      '(4 nil warning "Extra space before \"]\""
@@ -3366,7 +3367,7 @@ Why not:
   (let ((flycheck-jshintrc "jshintrc")
         (flycheck-jscsrc "jscsrc"))
     (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode)
+     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(4 3 error "Expected indentation of 2 characters"
          :checker javascript-jscs)
      '(4 9 warning "'foo' is defined but never used." :id "W098"
@@ -3392,7 +3393,7 @@ Why not:
   (let ((flycheck-jscsrc "jscsrc")
         (flycheck-disabled-checkers '(javascript-jshint javascript-eslint)))
     (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode)
+     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(4 nil warning "Single-quoted string preferred over double-quoted string."
          :id "0131" :checker javascript-gjslint)
      '(4 nil warning "Extra space before \"]\""


### PR DESCRIPTION
I'm adding [`rjsx-mode`](https://github.com/felipeochoa/rjsx-mode/) to the list of javascript modes, per discussion on .felipeochoa/rjsx-mode#17. Note that I wasn't able to test locally, but have added `rjsx-mode` to some of the test definitions. From what I can tell, I think Travis only runs elisp tests, so if somone can clone and run the javascript tests, that would be great!  😳 