### PR TITLE
Add nix checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@
 
   - Protobuf with ``protoc`` [GH-1125]
   - systemd-analyze with ``systemd-analyze`` [GH-1135]
+  - Nix with ``nix-instantiate`` [GH-1164]
   - Dockerfile with ``hadolint`` [GH-1194]
   - AsciiDoc with ``asciidoctor`` [GH-1167]
   - CSS/SCSS/LESS with ``stylelint`` [GH-903]

--- a/Cask
+++ b/Cask
@@ -32,6 +32,7 @@
  (depends-on "lua-mode")
  (depends-on "markdown-mode")
  (depends-on "mmm-mode")
+ (depends-on "nix-mode")
  (depends-on "php-mode")
  (depends-on "processing-mode")
  (depends-on "protobuf-mode")

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -693,6 +693,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. syntax-checker-config-file:: flycheck-markdown-mdl-style
 
+.. supported-language:: Nix
+
+   .. syntax-checker:: nix
+
+      Check Nix with nix-instantiate_.
+
+      .. _nix-instantiate: https://nixos.org/nix/manual/#sec-nix-instantiate
+
 .. supported-language:: Perl
 
    Flycheck checks Perl with `perl` and `perl-perlcritic`.

--- a/flycheck.el
+++ b/flycheck.el
@@ -221,6 +221,7 @@ attention to case differences."
     racket
     rpm-rpmlint
     markdown-mdl
+    nix
     rst-sphinx
     rst
     ruby-rubocop
@@ -8708,6 +8709,17 @@ See URL `https://github.com/mivok/markdownlint'."
     (flycheck-sanitize-errors
      (flycheck-remove-error-file-names "(stdin)" errors)))
   :modes (markdown-mode gfm-mode))
+
+(flycheck-define-checker nix
+  "Nix checker using nix-instantiate.
+
+See URL `https://nixos.org/nix/manual/#sec-nix-instantiate'."
+  :command ("nix-instantiate" "--parse" source-inplace)
+  :error-patterns
+  ((error line-start
+          "error: " (message) " at " (file-name) ":" line ":" column
+          line-end))
+  :modes nix-mode)
 
 (defun flycheck-locate-sphinx-source-directory ()
   "Locate the Sphinx source directory for the current buffer.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3766,6 +3766,11 @@ Why not:
    "language/markdown.md" 'markdown-mode
    '(1 nil error "First header should be a h1 header" :id "MD002" :checker markdown-mdl)))
 
+(flycheck-ert-def-checker-test nix nix nil
+  (flycheck-ert-should-syntax-check
+   "language/nix.nix" 'nix-mode
+   '(3 1 error "syntax error, unexpected IN, expecting ';'," :checker nix)))
+
 (ert-deftest flycheck-locate-sphinx-source-directory/not-in-a-sphinx-project ()
   :tags '(language-rst)
   (flycheck-ert-with-resource-buffer "language/rst/errors.rst"

--- a/test/resources/language/nix.nix
+++ b/test/resources/language/nix.nix
@@ -1,0 +1,4 @@
+let
+  number = 42
+in
+  number * 10


### PR DESCRIPTION
Hi:
I've added checker for [nix](https://nixos.org/nix/)


```
make LANGUAGE=nix integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-buttercup.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (language nix))'
Running tests on Emacs 26.0.50.1, built at 2016-11-14
Running 1 tests (2016-11-16 20:05:21-0500)
   passed  1/1  flycheck-define-checker/nix/default

Ran 1 tests, 1 results as expected (2016-11-16 20:05:22-0500)

```
