### PR TITLE
Adds Asciidoctor as checker for AsciiDoc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
   - Protobuf with ``protoc`` [GH-1125]
   - systemd-analyze with ``systemd-analyze`` [GH-1135]
   - Dockerfile with ``hadolint`` [GH-1194]
+  - AsciiDoc with ``asciidoctor`` [GH-1167]
 
 - New features:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -50,6 +50,12 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: AsciiDoc
 
+   .. syntax-checker:: asciidoctor
+
+      Check AsciiDoc with the default Asciidoctor_ backend.
+
+      .. _Asciidoctor: http://asciidoctor.org
+
    .. syntax-checker:: asciidoc
 
       Check AsciiDoc_ with the standard AsciiDoc processor.

--- a/flycheck.el
+++ b/flycheck.el
@@ -160,6 +160,7 @@ attention to case differences."
 
 (defcustom flycheck-checkers
   '(ada-gnat
+    asciidoctor
     asciidoc
     c/c++-clang
     c/c++-gcc
@@ -5964,6 +5965,21 @@ See URL `http://www.methods.co.nz/asciidoc'."
    (info line-start
          "asciidoc: DEPRECATED: <stdin>: Line " line ": " (message)
          line-end))
+  :modes adoc-mode)
+
+(flycheck-define-checker asciidoctor
+  "An AsciiDoc syntax checker using the Asciidoctor compiler.
+
+See URL `http://asciidoctor.org'."
+  :command ("asciidoctor" "-o" null-device "-")
+  :standard-input t
+  :error-patterns
+  ((error line-start
+          "asciidoctor: ERROR: <stdin>: Line " line ": " (message)
+          line-end)
+   (warning line-start
+            "asciidoctor: WARNING: <stdin>: Line " line ": " (message)
+            line-end))
   :modes adoc-mode)
 
 (flycheck-def-args-var flycheck-clang-args c/c++-clang

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2712,6 +2712,12 @@ evaluating BODY."
    '(3 nil info "old tables syntax" :checker asciidoc)
    '(11 nil error "[tabledef-default] illegal width=%60%" :checker asciidoc)))
 
+(flycheck-ert-def-checker-test asciidoctor asciidoc nil
+  (flycheck-ert-should-syntax-check
+   "language/asciidoctor.adoc" 'adoc-mode
+   '(4 nil warning "section title out of sequence: expected level 1, got level 2" :checker asciidoctor)
+   '(6 nil error "unmatched macro: endif::[]" :checker asciidoctor)))
+
 (flycheck-ert-def-checker-test c/c++-clang (c c++) error
   (let ((flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-ert-should-syntax-check

--- a/test/resources/language/asciidoctor.adoc
+++ b/test/resources/language/asciidoctor.adoc
@@ -1,0 +1,6 @@
+= Document
+:doctype: article
+
+=== P1
+
+endif::[]


### PR DESCRIPTION
I broke `make specs` but I don't understand the error message. Help would be appreciated.

```
FAILED: Expected (asciidoctor) to `equal' nil

Ran 98 out of 99 specs, 1 failed, in 3.2 seconds.
```