### PR TITLE
Allow rust checker to run when crate root is defined

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8745,8 +8745,7 @@ This syntax checker needs Rust 1.7 or newer.  See URL
   :error-parser flycheck-parse-rust
   :error-explainer flycheck-rust-error-explainer
   :modes rust-mode
-  :predicate (lambda ()
-               (and (not flycheck-rust-crate-root) (flycheck-buffer-saved-p))))
+  :predicate flycheck-buffer-saved-p)
 
 (defvar flycheck-sass-scss-cache-directory nil
   "The cache directory for `sass' and `scss'.")

--- a/flycheck.el
+++ b/flycheck.el
@@ -8741,7 +8741,7 @@ This syntax checker needs Rust 1.7 or newer.  See URL
             (option-list "-L" flycheck-rust-library-path concat)
             (eval flycheck-rust-args)
             (eval (or flycheck-rust-crate-root
-                      (flycheck-substitute-argument 'source-inplace 'rust))))
+                      (flycheck-substitute-argument 'source-original 'rust))))
   :error-parser flycheck-parse-rust
   :error-explainer flycheck-rust-error-explainer
   :modes rust-mode


### PR DESCRIPTION
Fixes issue where the `rust` checker is disabled when `flycheck-rust-crate-root` is defined.  

A change was introduced in pull request #817 which disabled this checker if `flycheck-rust-crate-root` was defined.  This change should ensure that:

- the checker can run if `flycheck-rust-crate-root` is defined;
- the checker will not run if the file has not been saved, which should still prevent the checker switching complained about in #817 

(NOTE: I was the original contributor of the `flycheck-rust-crate-root` variable in #417, I'm just returning to using rust again!)
