### PR TITLE
Remove .lgtm file

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 1
-pattern = "(?i)LGTM"


### PR DESCRIPTION
Now that LGTM.co has been discontinued, we removed the hook and don't need this
file anymore.

Closes GH-1179.