### PR TITLE
Fix newline in cppcheck linter

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5550,7 +5550,9 @@ about Cppcheck."
                           (push (flycheck-error-new-at
                                  (flycheck-string-to-number-safe .line)
                                  nil
-                                 level message
+                                 level
+                                 ;; cppcheck return newline characters as "\012"
+                                 (replace-regexp-in-string "\\\\012" "\n" message)
                                  :id id
                                  :checker checker
                                  :buffer buffer

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2783,6 +2783,11 @@ evaluating BODY."
         (flycheck-cppcheck-inconclusive nil)
         (flycheck-cppcheck-checks '("style")))
     (flycheck-ert-should-syntax-check
+     "language/c_c++/style2.cpp" 'c++-mode
+     '(3 nil info "The scope of the variable 'i' can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. Here is an example where cppcheck will write that the scope for 'i' can be reduced:\nvoid f(int x)\n{\n    int i = 0;\n    if (x) {\n        // it's safe to move 'int i = 0;' here\n        for (int n = 0; n < 10; ++n) {\n            // it is possible but not safe to move 'int i = 0;' here\n            do_something(&i);\n        }\n    }\n}\nWhen you see this message it is always safe to reduce the variable scope 1 level."
+         :id "variableScope" :checker c/c++-cppcheck))
+
+    (flycheck-ert-should-syntax-check
      "language/c_c++/style.cpp" 'c-mode
      '(5 nil info "Unused variable: unused" :id "unusedVariable"
          :checker c/c++-cppcheck)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2791,18 +2791,14 @@ evaluating BODY."
      "language/c_c++/style.cpp" 'c-mode
      '(5 nil info "Unused variable: unused" :id "unusedVariable"
          :checker c/c++-cppcheck)
-     '(9 nil error "Division by zero." :id "zerodiv" :checker c/c++-cppcheck)
-     '(12 nil info "Suspicious expression. Boolean result is used in bitwise operation. The operator '!' and the comparison operators have higher precedence than bitwise operators. It is recommended that the expression is clarified with parentheses."
-          :id "clarifyCondition" :checker c/c++-cppcheck))
+     '(9 nil error "Division by zero." :id "zerodiv" :checker c/c++-cppcheck))
 
     (flycheck-ert-should-syntax-check
      "language/c_c++/style.cpp" 'c++-mode
      '(5 nil info "Unused variable: unused" :id "unusedVariable"
          :checker c/c++-cppcheck)
      '(9 nil error "Division by zero." :id "zerodiv" :checker c/c++-cppcheck)
-     '(12 nil info "Suspicious expression. Boolean result is used in bitwise operation. The operator '!' and the comparison operators have higher precedence than bitwise operators. It is recommended that the expression is clarified with parentheses."
-          :id "clarifyCondition" :checker c/c++-cppcheck)
-     '(14 nil warning "Parameter 'foo' is passed by value. It could be passed as a (const) reference which is usually faster and recommended in C++."
+     '(12 nil warning "Parameter 'foo' is passed by value. It could be passed as a (const) reference which is usually faster and recommended in C++."
           :id "passedByValue" :checker c/c++-cppcheck))))
 
 (flycheck-ert-def-checker-test cfengine cfengine error

--- a/test/resources/language/c_c++/style.cpp
+++ b/test/resources/language/c_c++/style.cpp
@@ -9,8 +9,6 @@ int f(int x)
     return x * 2 / null;
 }
 
-bool foo(bool a, bool b) { return a & b; }
-
 std::string foobar(const std::string foo) {
     return foo + "bar";
 }

--- a/test/resources/language/c_c++/style2.cpp
+++ b/test/resources/language/c_c++/style2.cpp
@@ -1,0 +1,7 @@
+void f(int x)
+{
+  int i = 0;
+  if (x) {
+    for ( ; i < 10; ++i) ;
+  }
+}


### PR DESCRIPTION
`cppcheck` returns newlines as "\\012"

demo.cpp

```cpp
void f(int x)
{
  int i = 0;
  if (x) {
    for ( ; i < 10; ++i) ;
  }
}
```

Which returns:

    cppcheck --quiet --xml-version\=2 --inline-suppr --enable\=style -x c\+\+ /tmp/demo.cpp
    <?xml version="1.0" encoding="UTF-8"?>
    <results version="2">
        <cppcheck version="1.77"/>
        <errors>
            <error id="variableScope" severity="style" msg="The scope of the variable &apos;i&apos; can be reduced." verbose="The scope of the variable &apos;i&apos; can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. Here is an example where cppcheck will write that the scope for &apos;i&apos; can be reduced:\012void f(int x)\012{\012    int i = 0;\012    if (x) {\012        // it&apos;s safe to move &apos;int i = 0;&apos; here\012        for (int n = 0; n &lt; 10; ++n) {\012            // it is possible but not safe to move &apos;int i = 0;&apos; here\012            do_something(&amp;i);\012        }\012    }\012}\012When you see this message it is always safe to reduce the variable scope 1 level." cwe="398">
                <location file="/tmp/demo.cpp" line="3"/>
            </error>
        </errors>
    </results>

Tests:

```
make SELECTOR='(tag cppcheck-xml)' integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck.el
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-buttercup.el
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-ert.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag cppcheck-xml))'
Running tests on Emacs 26.0.50.7, built at 2016-12-22
Running 1 tests (2017-01-04 00:34:01-0500)
   passed  1/1  flycheck-define-checker/c/c++-cppcheck/default

Ran 1 tests, 1 results as expected (2017-01-04 00:34:04-0500)
```
Tested with cppcheck version 1.77