### PR TITLE
Update failing tests

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7425,7 +7425,9 @@ See URL `https://github.com/commercialhaskell/stack'."
             source)
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ":"
-            (or " " "\n    ") "Warning:" (optional "\n")
+            (or " " "\n    ") "Warning:"
+            (optional " " "[" (id (one-or-more not-newline)) "]")
+            (optional "\n")
             (message
              (one-or-more " ") (one-or-more not-newline)
              (zero-or-more "\n"
@@ -7473,7 +7475,9 @@ See URL `https://www.haskell.org/ghc/'."
             source)
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ":"
-            (or " " "\n    ") "Warning:" (optional "\n")
+            (or " " "\n    ") "Warning:"
+            (optional " " "[" (id (one-or-more not-newline)) "]")
+            (optional "\n")
             (message
              (one-or-more " ") (one-or-more not-newline)
              (zero-or-more "\n"

--- a/flycheck.el
+++ b/flycheck.el
@@ -8710,6 +8710,15 @@ Relative paths are relative to the file being checked."
     (with-output-to-string
       (call-process "rustc" nil standard-output nil "--explain" error-code))))
 
+(defun flycheck-rust-error-filter (errors)
+  "Filter ERRORS from rustc output that have no explanatory value."
+  (seq-remove (lambda (err)
+                (string-match-p
+                 (rx "aborting due to " (optional (one-or-more num) " ")
+                     "previous error")
+                 (flycheck-error-message err)))
+              errors))
+
 (flycheck-define-checker rust-cargo
   "A Rust syntax checker using Cargo.
 
@@ -8731,6 +8740,7 @@ rustc command.  See URL `https://www.rust-lang.org'."
             (option-list "-L" flycheck-rust-library-path concat)
             (eval flycheck-rust-args))
   :error-parser flycheck-parse-rust
+  :error-filter flycheck-rust-error-filter
   :error-explainer flycheck-rust-error-explainer
   :modes rust-mode
   :predicate (lambda ()
@@ -8758,6 +8768,7 @@ This syntax checker needs Rust 1.7 or newer.  See URL
             (eval (or flycheck-rust-crate-root
                       (flycheck-substitute-argument 'source-original 'rust))))
   :error-parser flycheck-parse-rust
+  :error-filter flycheck-rust-error-filter
   :error-explainer flycheck-rust-error-explainer
   :modes rust-mode
   :predicate flycheck-buffer-saved-p)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4059,11 +4059,9 @@ Why not:
 (flycheck-ert-def-checker-test typescript-tslint typescript nil
   (flycheck-ert-should-syntax-check
    "language/typescript/sample.ts" 'typescript-mode
-   '(1 10 warning "unused variable: 'invalidAlignment'"
-       :checker typescript-tslint :id "no-unused-variable")
-   '(2 7 warning "unused variable: 'a'"
-       :checker typescript-tslint :id "no-unused-variable")
-   '(3 15 warning "missing semicolon"
+   '(2 3 warning "Forbidden 'var' keyword, use 'let' or 'const' instead"
+       :checker typescript-tslint :id "no-var-keyword")
+   '(3 15 warning "Missing semicolon"
        :checker typescript-tslint :id "semicolon")))
 
 (flycheck-ert-def-checker-test verilog-verilator verilog error

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3197,18 +3197,20 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (let ((flycheck-disabled-checkers '(haskell-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Error.hs" 'haskell-mode
-     '(4 16 error "Couldn't match type `Bool' with `[Char]'
-Expected type: String
-  Actual type: Bool
-In the first argument of `putStrLn', namely `True'
-In the expression: putStrLn True" :checker haskell-stack-ghc))))
+     '(4 16 error "* Couldn't match type `Bool' with `[Char]'
+  Expected type: String
+    Actual type: Bool
+* In the first argument of `putStrLn', namely `True'
+  In the expression: putStrLn True
+  In an equation for `foo': foo = putStrLn True" :checker haskell-stack-ghc))))
 
 (flycheck-ert-def-checker-test (haskell-stack-ghc haskell-hlint) haskell literate
   (skip-unless (file-exists-p (getenv "HOME")))
   (let ((flycheck-disabled-checkers '(haskell-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Literate.lhs" 'literate-haskell-mode
-     '(6 1 warning "Top-level binding with no type signature: foo :: forall t. t"
+     '(6 1 warning "Top-level binding with no type signature: foo :: forall a. a"
+         :id "-Wmissing-signatures"
          :checker haskell-stack-ghc))))
 
 (flycheck-ert-def-checker-test (haskell-stack-ghc haskell-hlint) haskell
@@ -3223,7 +3225,9 @@ Found:
 Why not:
   spam = map lines" :checker haskell-hlint)
      '(4 1 warning "Top-level binding with no type signature:
-  spam :: [String] -> [[String]]" :checker haskell-stack-ghc)
+  spam :: [String] -> [[String]]"
+         :id "-Wmissing-signatures"
+         :checker haskell-stack-ghc)
      '(7 8 info "Redundant bracket
 Found:
   (putStrLn \"hello world\")
@@ -3240,17 +3244,19 @@ Why not:
   (let ((flycheck-disabled-checkers '(haskell-stack-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Error.hs" 'haskell-mode
-     '(4 16 error "Couldn't match type `Bool' with `[Char]'
-Expected type: String
-  Actual type: Bool
-In the first argument of `putStrLn', namely `True'
-In the expression: putStrLn True" :checker haskell-ghc))))
+     '(4 16 error "* Couldn't match type `Bool' with `[Char]'
+  Expected type: String
+    Actual type: Bool
+* In the first argument of `putStrLn', namely `True'
+  In the expression: putStrLn True
+  In an equation for `foo': foo = putStrLn True" :checker haskell-ghc))))
 
 (flycheck-ert-def-checker-test (haskell-ghc haskell-hlint) haskell literate
   (let ((flycheck-disabled-checkers '(haskell-stack-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Literate.lhs" 'literate-haskell-mode
-     '(6 1 warning "Top-level binding with no type signature: foo :: forall t. t"
+     '(6 1 warning "Top-level binding with no type signature: foo :: forall a. a"
+         :id "-Wmissing-signatures"
          :checker haskell-ghc))))
 
 (flycheck-ert-def-checker-test (haskell-ghc haskell-hlint) haskell
@@ -3265,6 +3271,7 @@ Why not:
   spam = map lines" :checker haskell-hlint)
      '(4 1 warning "Top-level binding with no type signature:
   spam :: [String] -> [[String]]"
+         :id "-Wmissing-signatures"
          :checker haskell-ghc)
      '(7 8 info "Redundant bracket
 Found:

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3847,7 +3847,7 @@ Why not:
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/src/syntax-error.rs" 'rust-mode
-     '(4 5 error "unresolved name `bla`" :checker rust :id "E0425"))))
+     '(4 5 error "unresolved name `bla` (unresolved name)" :checker rust :id "E0425"))))
 
 (flycheck-ert-def-checker-test rust rust type-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
@@ -3874,7 +3874,7 @@ Why not:
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/src/importing.rs" 'rust-mode
-     '(1 5 error "unresolved import `super::imported`. There are too many initial `super`s." :checker rust :id "E0432"))))
+     '(1 5 error "unresolved import `super::imported` (There are too many initial `super`s.)" :checker rust :id "E0432"))))
 
 (flycheck-ert-def-checker-test rust rust macro-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))

--- a/test/resources/language/typescript/sample.ts
+++ b/test/resources/language/typescript/sample.ts
@@ -1,4 +1,4 @@
 function invalidAlignment() {
-  let a:string = "test string";
+  var a:string = "test string";
   alert('Hi!')
 }

--- a/test/resources/language/typescript/tslint.json
+++ b/test/resources/language/typescript/tslint.json
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "no-unused-variable": true,
+    "no-var-keyword": true,
     "semicolon": true
   }
 }


### PR DESCRIPTION
I was looking at the tests failures reported in #1163, and managed to fix a few of them.

The rust failures were introduced by #1182.  I did not run the tests locally, and somehow it passed through our CI.

The haskell failures are due to small changes in GHC output.  There are now dots in the output:
```
Error.hs:4:16: error:
    • Couldn't match type ‘Bool’ with ‘[Char]’
      Expected type: String
        Actual type: Bool
    • In the first argument of ‘putStrLn’, namely ‘True’
      In the expression: putStrLn True
      In an equation for ‘foo’: foo = putStrLn True
```
I've added them to the tests as-is, but we could also trim them from the output.  Maybe @flycheck/haskell has an opinion on that.

The typescript failure was due to a deprecated rule, the same issue as #1174.
