### PR TITLE
Fix missing backquote in Tune error list example

### DIFF
--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -79,7 +79,7 @@ VisualStudio, Eclipse, etc. with the following code in your :term:`init file`:
 .. code-block:: elisp
 
    (add-to-list 'display-buffer-alist
-                (,(rx bos "*Flycheck errors*" eos)
+                `(,(rx bos "*Flycheck errors*" eos)
                  (display-buffer-reuse-window
                   display-buffer-in-side-window)
                  (side            . bottom)


### PR DESCRIPTION
In the "List all errors" documentation page, the "Tune error list example" seems to be missing a backquote. I think it's safe there for RST because it's in a literal code-bock. I don't know enough elisp to be sure this is correct but it didn't work without it and it works with it (I'm using Emacs 25.1.1).