### PR TITLE
Display errors from other files

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -797,6 +797,12 @@ This variable is a normal hook.  See Info node `(elisp)Hooks'."
   :group 'flycheck-faces
   :package-version '(flycheck . "0.16"))
 
+(defface flycheck-error-list-filename
+  '((t :inherit buffer-menu-buffer))
+  "Face for filenames in the error list."
+  :group 'flycheck-faces
+  :package-version '(flycheck . "0.25"))
+
 (defface flycheck-error-list-column-number
   '((t :inherit font-lock-constant-face))
   "Face for line numbers in the error list."
@@ -3130,18 +3136,11 @@ Return ERRORS, modified in-place."
 
 Return t if ERR may be shown for the current buffer, or nil
 otherwise."
-  (flycheck-error-with-buffer err
-    (let ((file-name (flycheck-error-filename err))
-          (message (flycheck-error-message err)))
-      (and
-       ;; The error is relevant for the current buffer if it's got no file-name
-       ;; and the current buffer has no file name, too, or if it refers to the
-       ;; same file as the current buffer.
-       (or (and (not file-name) (not buffer-file-name))
-           (flycheck-same-files-p file-name (buffer-file-name)))
-       message
-       (not (string-empty-p message))
-       (flycheck-error-line err)))))
+  (let ((message (flycheck-error-message err)))
+    (and
+     message
+     (not (string-empty-p message))
+     (flycheck-error-line err))))
 
 (defun flycheck-relevant-errors (errors)
   "Filter the relevant errors from ERRORS.
@@ -3628,25 +3627,26 @@ Return the created overlay."
   ;; We must have a proper error region for the sake of fringe indication,
   ;; error display and error navigation, even if the highlighting is disabled.
   ;; We erase the highlighting later on in this case
-  (pcase-let* ((`(,beg . ,end) (flycheck-error-region-for-mode
-                                err (or flycheck-highlighting-mode 'lines)))
-               (overlay (make-overlay beg end))
-               (level (flycheck-error-level err))
-               (category (flycheck-error-level-overlay-category level)))
-    (unless (flycheck-error-level-p level)
-      (error "Undefined error level: %S" level))
-    (setf (overlay-get overlay 'flycheck-overlay) t)
-    (setf (overlay-get overlay 'flycheck-error) err)
-    (setf (overlay-get overlay 'category) category)
-    (unless flycheck-highlighting-mode
-      ;; Erase the highlighting from the overlay if requested by the user
-      (setf (overlay-get overlay 'face) nil))
-    (when flycheck-indication-mode
-      (setf (overlay-get overlay 'before-string)
-            (flycheck-error-level-make-fringe-icon
-             level flycheck-indication-mode)))
-    (setf (overlay-get overlay 'help-echo) #'flycheck-help-echo)
-    overlay))
+  (when (eq (flycheck-error-buffer err) (current-buffer))
+    (pcase-let* ((`(,beg . ,end) (flycheck-error-region-for-mode
+                                  err (or flycheck-highlighting-mode 'lines)))
+                 (overlay (make-overlay beg end))
+                 (level (flycheck-error-level err))
+                 (category (flycheck-error-level-overlay-category level)))
+      (unless (flycheck-error-level-p level)
+        (error "Undefined error level: %S" level))
+      (setf (overlay-get overlay 'flycheck-overlay) t)
+      (setf (overlay-get overlay 'flycheck-error) err)
+      (setf (overlay-get overlay 'category) category)
+      (unless flycheck-highlighting-mode
+        ;; Erase the highlighting from the overlay if requested by the user
+        (setf (overlay-get overlay 'face) nil))
+      (when flycheck-indication-mode
+        (setf (overlay-get overlay 'before-string)
+              (flycheck-error-level-make-fringe-icon
+               level flycheck-indication-mode)))
+      (setf (overlay-get overlay 'help-echo) #'flycheck-help-echo)
+      overlay)))
 
 (defun flycheck-help-echo (_window object pos)
   "Construct a tooltip message.
@@ -3790,7 +3790,16 @@ Intended for use with `next-error-function'."
   (let ((pos (flycheck-next-error-pos n reset)))
     (if pos
         (goto-char pos)
-      (user-error "No more Flycheck errors"))))
+      (let ((result (cl-remove-if
+                     (lambda (err)
+                       (eq (current-buffer)
+                           (flycheck-error-buffer err)))
+                     flycheck-current-errors)))
+        (if result
+            (let ((error (car result)))
+              (flycheck-jump-to-error error)
+              (flycheck-buffer))
+          (user-error "No more Flycheck errors"))))))
 
 (defun flycheck-next-error (&optional n reset)
   "Visit the N-th error from the current point.
@@ -3850,7 +3859,8 @@ message to stretch arbitrarily far."
             message checker-name)))
 
 (defconst flycheck-error-list-format
-  `[("Line" 5 flycheck-error-list-entry-< :right-align t)
+  `[("File" 6)
+    ("Line" 5 flycheck-error-list-entry-< :right-align t)
     ("Col" 3 nil :right-align t)
     ("Level" 8 flycheck-error-list-entry-level-<)
     ("ID" 6 t)
@@ -3970,6 +3980,7 @@ string with attached text properties."
 Return a list with the contents of the table cell."
   (let* ((level (flycheck-error-level error))
          (level-face (flycheck-error-level-error-list-face level))
+         (filename (flycheck-error-filename error))
          (line (flycheck-error-line error))
          (column (flycheck-error-column error))
          (message (or (flycheck-error-message error)
@@ -3981,7 +3992,12 @@ Return a list with the contents of the table cell."
          (msg-and-checker (flycheck-error-list-make-last-column flushed-msg checker))
          (explainer (flycheck-checker-get checker 'error-explainer)))
     (list error
-          (vector (flycheck-error-list-make-number-cell
+          (vector (flycheck-error-list-make-cell
+                   (if filename
+                       (file-name-nondirectory filename)
+                     "")
+                   'flycheck-error-list-filename)
+                  (flycheck-error-list-make-number-cell
                    line 'flycheck-error-list-line-number)
                   (flycheck-error-list-make-number-cell
                    column 'flycheck-error-list-column-number)
@@ -4143,22 +4159,36 @@ LEVEL is either an error level symbol, or nil, to remove the filter."
 
 POS defaults to `point'."
   (interactive)
-  (-when-let* ((error (tabulated-list-get-id pos))
-               (buffer (flycheck-error-buffer error)))
-    (when (buffer-live-p buffer)
-      (if (eq (window-buffer) (get-buffer flycheck-error-list-buffer))
-          ;; When called from within the error list, keep the error list,
-          ;; otherwise replace the current buffer.
-          (pop-to-buffer buffer 'other-window)
-        (switch-to-buffer buffer))
-      (let ((pos (flycheck-error-pos error)))
-        (unless (eq (goto-char pos) (point))
-          ;; If widening gets in the way of moving to the right place, remove it
-          ;; and try again
-          (widen)
-          (goto-char pos)))
-      ;; Re-highlight the errors
-      (flycheck-error-list-highlight-errors 'preserve-pos))))
+  (-when-let* ((error (tabulated-list-get-id pos)))
+    (flycheck-jump-to-error error)))
+
+(defun flycheck-jump-to-error (error)
+  "Go to the location of ERROR."
+  (let ((buffer (flycheck-error-buffer error))
+        (filename (flycheck-error-filename error)))
+    (cond
+     ((buffer-live-p buffer)
+      (flycheck-jump-in-buffer buffer error))
+     ((file-exists-p filename)
+      (let ((buffer (find-file filename)))
+        (setf (flycheck-error-buffer error) buffer)
+        (flycheck-jump-in-buffer buffer error))))))
+
+(defun flycheck-jump-in-buffer (buffer error)
+  "In BUFFER, jump to ERROR."
+  (if (eq (window-buffer) (get-buffer flycheck-error-list-buffer))
+      ;; When called from within the error list, keep the error list,
+      ;; otherwise replace the current buffer.
+      (pop-to-buffer buffer 'other-window)
+    (switch-to-buffer buffer))
+  (let ((pos (flycheck-error-pos error)))
+    (unless (eq (goto-char pos) (point))
+      ;; If widening gets in the way of moving to the right place, remove it
+      ;; and try again
+      (widen)
+      (goto-char pos)))
+  ;; Re-highlight the errors
+  (flycheck-error-list-highlight-errors 'preserve-pos))
 
 (defun flycheck-error-list-explain-error (&optional pos)
   "Explain the error at POS in the error list.

--- a/flycheck.el
+++ b/flycheck.el
@@ -801,7 +801,7 @@ This variable is a normal hook.  See Info node `(elisp)Hooks'."
   '((t :inherit buffer-menu-buffer))
   "Face for filenames in the error list."
   :group 'flycheck-faces
-  :package-version '(flycheck . "0.25"))
+  :package-version '(flycheck . "0.31"))
 
 (defface flycheck-error-list-column-number
   '((t :inherit font-lock-constant-face))

--- a/flycheck.el
+++ b/flycheck.el
@@ -4165,15 +4165,10 @@ POS defaults to `point'."
 
 (defun flycheck-jump-to-error (error)
   "Go to the location of ERROR."
-  (let ((buffer (flycheck-error-buffer error))
-        (filename (flycheck-error-filename error)))
-    (cond
-     ((buffer-live-p buffer)
-      (flycheck-jump-in-buffer buffer error))
-     ((file-exists-p filename)
-      (let ((buffer (find-file filename)))
-        (setf (flycheck-error-buffer error) buffer)
-        (flycheck-jump-in-buffer buffer error))))))
+  (let ((error-copy (copy-flycheck-error error))
+        (buffer (find-file-noselect (flycheck-error-filename error))))
+    (setf (flycheck-error-buffer error-copy) buffer)
+    (flycheck-jump-in-buffer buffer error-copy)))
 
 (defun flycheck-jump-in-buffer (buffer error)
   "In BUFFER, jump to ERROR."

--- a/flycheck.el
+++ b/flycheck.el
@@ -3790,7 +3790,7 @@ Intended for use with `next-error-function'."
   (let ((pos (flycheck-next-error-pos n reset)))
     (if pos
         (goto-char pos)
-      (let ((result (cl-remove-if
+      (let ((result (seq-remove
                      (lambda (err)
                        (eq (current-buffer)
                            (flycheck-error-buffer err)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -3627,7 +3627,8 @@ Return the created overlay."
   ;; We must have a proper error region for the sake of fringe indication,
   ;; error display and error navigation, even if the highlighting is disabled.
   ;; We erase the highlighting later on in this case
-  (when (eq (flycheck-error-buffer err) (current-buffer))
+  (when (equal (flycheck-error-filename err)
+               (buffer-file-name (current-buffer)))
     (pcase-let* ((`(,beg . ,end) (flycheck-error-region-for-mode
                                   err (or flycheck-highlighting-mode 'lines)))
                  (overlay (make-overlay beg end))

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -154,7 +154,8 @@
                                               'face 'default)
                                   checker-name)))
             (expect (aref cells 5) :to-equal
-                    (list message 'type 'flycheck-error-list))))
+                    (list message 'type 'flycheck-error-list
+                          'help-echo message))))
 
         (it "has a default message in the 6th cell if there is no message"
           (cl-letf* (((flycheck-error-message warning) nil)
@@ -164,7 +165,8 @@
                                                   'face 'default)
                                       checker-name)))
             (expect (aref cells 5) :to-equal
-                    (list message 'type 'flycheck-error-list)))))))
+                    (list message 'type 'flycheck-error-list
+                          'help-echo message)))))))
 
   (describe "Filter"
     (it "kills the filter variable when resetting the filter"

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -67,34 +67,40 @@
     (it "has a local header line"
       (flycheck/with-error-list-buffer
         (expect header-line-format
-                :to-equal "  Line Col Level ID Message (Checker) ")
+                :to-equal " File  Line Col Level ID Message (Checker) ")
         (expect 'header-line-format :to-be-local))))
 
   (describe "Columns"
-    (it "has the line number in the 1st column"
+    (it "has the file name in the 1st column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 0)
                 :to-equal
-                '("Line" 5 flycheck-error-list-entry-< :right-align t))))
+                '("File" 6))))
 
-    (it "has the column number in the 2nd column"
+    (it "has the line number in the 2nd column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 1)
-                :to-equal '("Col" 3 nil :right-align t))))
+                :to-equal
+                '("Line" 5 flycheck-error-list-entry-< :right-align t))))
 
-    (it "has the error level in the 3rd column"
+    (it "has the column number in the 3rd column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 2)
-                :to-equal '("Level" 8 flycheck-error-list-entry-level-<))))
+                :to-equal '("Col" 3 nil :right-align t))))
 
-    (it "has the error ID in the 4th column"
+    (it "has the error level in the 4th column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 3)
-                :to-equal '("ID" 6 t))))
+                :to-equal '("Level" 8 flycheck-error-list-entry-level-<))))
 
-    (it "has the error message in the 5th column"
+    (it "has the error ID in the 5th column"
       (flycheck/with-error-list-buffer
         (expect (aref tabulated-list-format 4)
+                :to-equal '("ID" 6 t))))
+
+    (it "has the error message in the 6th column"
+      (flycheck/with-error-list-buffer
+        (expect (aref tabulated-list-format 5)
                 :to-equal '("Message (Checker)" 0 t)))))
 
   (describe "Entry"
@@ -107,35 +113,35 @@
       (it "has the error object as ID"
         (expect (car entry) :to-be warning))
 
-      (it "has the line number in the 1st cell"
-        (expect (aref cells 0) :to-equal
+      (it "has the line number in the 2nd cell"
+        (expect (aref cells 1) :to-equal
                 (list "10"
                       'type 'flycheck-error-list
                       'face 'flycheck-error-list-line-number)))
 
-      (it "has the column number in the 2nd cell"
-        (expect (aref cells 1) :to-equal
+      (it "has the column number in the 3rd cell"
+        (expect (aref cells 2) :to-equal
                 (list "12"
                       'type 'flycheck-error-list
                       'face 'flycheck-error-list-column-number)))
 
-      (it "has an empty 2nd cell if there is no column number"
+      (it "has an empty 3rd cell if there is no column number"
         (cl-letf* (((flycheck-error-column warning) nil)
                    (entry (flycheck-error-list-make-entry warning))
                    (cells (cadr entry)))
-          (expect (aref cells 1) :to-equal
+          (expect (aref cells 2) :to-equal
                   (list ""
                         'type 'flycheck-error-list
                         'face 'flycheck-error-list-column-number))))
 
-      (it "has the error level in the 3rd cell"
-        (expect (aref cells 2) :to-equal
+      (it "has the error level in the 4th cell"
+        (expect (aref cells 3) :to-equal
                 (list "warning"
                       'type 'flycheck-error-list
                       'face (flycheck-error-level-error-list-face 'warning))))
 
-      (it "has the error ID in the 4th cell"
-        (expect (aref cells 3) :to-equal
+      (it "has the error ID in the 5th cell"
+        (expect (aref cells 4) :to-equal
                 (list "W1"
                       'type 'flycheck-error-list-explain-error
                       'face 'flycheck-error-list-id
@@ -143,24 +149,22 @@
 
       (let ((checker-name (propertize "emacs-lisp-checkdoc"
                                       'face 'flycheck-error-list-checker-name)))
-        (it "has the error message in the 5th cell"
+        (it "has the error message in the 6th cell"
           (let* ((message (format (propertize "A foo warning (%s)"
                                               'face 'default)
                                   checker-name)))
-            (expect (aref cells 4) :to-equal
-                    (list message 'type 'flycheck-error-list
-                          'help-echo message))))
+            (expect (aref cells 5) :to-equal
+                    (list message 'type 'flycheck-error-list))))
 
-        (it "has a default message in the 5th cell if there is no message"
+        (it "has a default message in the 6th cell if there is no message"
           (cl-letf* (((flycheck-error-message warning) nil)
                      (entry (flycheck-error-list-make-entry warning))
                      (cells (cadr entry))
                      (message (format (propertize "Unknown warning (%s)"
                                                   'face 'default)
                                       checker-name)))
-            (expect (aref cells 4) :to-equal
-                    (list message 'type 'flycheck-error-list
-                          'help-echo message)))))))
+            (expect (aref cells 5) :to-equal
+                    (list message 'type 'flycheck-error-list)))))))
 
   (describe "Filter"
     (it "kills the filter variable when resetting the filter"


### PR DESCRIPTION
As a huge fan of the quickfix list in Vim, when I came to Emacs I was amazed to find flycheck, but sad to see that project-wide errors don't show up in flycheck-list-errors.  My main use-case for a flycheck-like list of errors is to make a change to a function signature, and immediately jump to all my other files where I broke things.

I found @chrisdone's PR implementing this [here](https://github.com/flycheck/flycheck/pull/972), but the PR was abandoned.

**This** PR revives #972 and addresses the code review comments.  I've also rebased and can confirm that all cask tests pass locally.