### PR TITLE
Add Dockerfile checker with hadolint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 
   - Protobuf with ``protoc`` [GH-1125]
   - systemd-analyze with ``systemd-analyze`` [GH-1135]
+  - Dockerfile with ``hadolint`` [GH-1194]
 
 - New features:
 

--- a/Cask
+++ b/Cask
@@ -15,6 +15,7 @@
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")
  (depends-on "d-mode")
+ (depends-on "dockerfile-mode")
  (depends-on "erlang")
  (depends-on "ess")
  (depends-on "geiser")

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -256,6 +256,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Flycheck extension which provides a syntax checker to run D unittests
          on the fly and report the results with Flycheck.
 
+.. supported-language:: Dockerfile
+
+   .. syntax-checker:: dockerfile-hadolint
+
+      Check syntax and code style with hadolint_
+
+      .. _hadolint: http://hadolint.lukasmartinelli.ch/
+
 .. supported-language:: Elixir
 
    .. syntax-checker:: elixir-dogma

--- a/flycheck.el
+++ b/flycheck.el
@@ -177,6 +177,7 @@ attention to case differences."
     coq
     css-csslint
     d-dmd
+    dockerfile-hadolint
     elixir-dogma
     emacs-lisp
     emacs-lisp-checkdoc
@@ -6580,6 +6581,25 @@ Requires DMD 2.066 or newer.  See URL `http://dlang.org/'."
    (info line-start (file-name) "(" line "," column "): "
          (one-or-more " ") (message) line-end))
   :modes d-mode)
+
+(flycheck-define-checker dockerfile-hadolint
+  "A Dockerfile syntax checker using the hadolint.
+
+See URL `http://hadolint.lukasmartinelli.ch/'."
+  :command ("hadolint" "-")
+  :standard-input t
+  :error-patterns
+  ((error line-start
+          (file-name) ":" line ":" column " " (message)
+          line-end)
+   (warning line-start
+            (file-name) ":" line " " (id (one-or-more alnum)) " " (message)
+            line-end))
+  :error-filter
+  (lambda (errors)
+    (flycheck-sanitize-errors
+     (flycheck-remove-error-file-names "/dev/stdin" errors)))
+  :modes dockerfile-mode)
 
 (defun flycheck-elixir--find-default-directory (_checker)
   "Come up with a suitable default directory to run CHECKER in.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2955,6 +2955,24 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
    '(13 1 info "instantiated from here: U!()"
         :checker d-dmd)))
 
+(flycheck-ert-def-checker-test dockerfile-hadolint dockerfile error
+  (flycheck-ert-should-syntax-check
+   "language/dockerfile/Dockerfile.error" 'dockerfile-mode
+   '(2 1 error "unexpected 'I' expecting space, \"\\t\", \"ONBUILD\", \"FROM\", \"COPY\", \"RUN\", \"WORKDIR\", \"ENTRYPOINT\", \"VOLUME\", \"EXPOSE\", \"ENV\", \"ARG\", \"USER\", \"LABEL\", \"STOPSIGNAL\", \"CMD\", \"SHELL\", \"MAINTAINER\", \"ADD\", \"#\", \"HEALTHCHECK\" or end of input"
+       :id nil :checker dockerfile-hadolint)))
+
+(flycheck-ert-def-checker-test dockerfile-hadolint dockerfile warnings
+  (flycheck-ert-should-syntax-check
+   "language/dockerfile/Dockerfile.warning" 'dockerfile-mode
+   '(1 nil warning "Always tag the version of an image explicitly."
+       :id "DL3006" :checker dockerfile-hadolint)
+   '(2 nil warning "Do not use apt-get upgrade or dist-upgrade."
+       :id "DL3005" :checker dockerfile-hadolint)
+   '(2 nil warning "Delete the apt-get lists after installing something"
+       :id "DL3009" :checker dockerfile-hadolint)
+   '(3 nil warning "Use absolute WORKDIR"
+       :id "DL3000" :checker dockerfile-hadolint)))
+
 (flycheck-ert-def-checker-test (emacs-lisp emacs-lisp-checkdoc) emacs-lisp nil
   (flycheck-ert-should-syntax-check
    "language/emacs-lisp/warnings.el" 'emacs-lisp-mode

--- a/test/resources/language/dockerfile/Dockerfile.error
+++ b/test/resources/language/dockerfile/Dockerfile.error
@@ -1,0 +1,2 @@
+FROM debian
+INVALID_COMMAND

--- a/test/resources/language/dockerfile/Dockerfile.warning
+++ b/test/resources/language/dockerfile/Dockerfile.warning
@@ -1,0 +1,3 @@
+FROM debian
+RUN apt-get update && apt-get upgrade
+WORKDIR usr/src/app


### PR DESCRIPTION
Hi:

This PR adds Dockerfile checker with [hadolint](http://hadolint.lukasmartinelli.ch/)

Tests:

```
make LANGUAGE=dockerfile integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck.el
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-buttercup.el
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-ert.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (language dockerfile))'
Running tests on Emacs 26.0.50.2, built at 2017-01-11
Running 2 tests (2017-01-12 15:07:08-0500)
   passed  1/2  flycheck-define-checker/dockerfile-hadolint/error
   passed  2/2  flycheck-define-checker/dockerfile-hadolint/warnings

Ran 2 tests, 2 results as expected (2017-01-12 15:07:10-0500)
```