### PR TITLE
systemd check: Use source rather than source-original 

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9219,7 +9219,7 @@ See URL `https://github.com/purcell/sqlint'."
   "A systemd unit checker using systemd-analyze(1).
 
 See URL `https://www.freedesktop.org/software/systemd/man/systemd-analyze.html'."
-  :command ("systemd-analyze" "verify" source-original)
+  :command ("systemd-analyze" "verify" source)
   :error-patterns
   ((error line-start "[" (file-name) ":" line "] " (message) line-end))
   :modes (systemd-mode))


### PR DESCRIPTION
"systemd-analyze verify" doesn't require that the unit file is located
in the systemd load path.

This also fixes false/missing errors because the previous version did not add
`flycheck-buffer-saved-p' to the `:predicate'.