### PR TITLE
checkdoc: Pass sentence-end-double-space to the subprocess

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6876,7 +6876,8 @@ See Info Node `(elisp)Byte Compilation'."
     checkdoc-package-keywords-flag
     checkdoc-spellcheck-documentation-flag
     checkdoc-verb-check-experimental-flag
-    checkdoc-max-keyref-before-warn)
+    checkdoc-max-keyref-before-warn
+    sentence-end-double-space)
   "Variables inherited by the checkdoc subprocess.")
 
 (defun flycheck-emacs-lisp-checkdoc-variables-form ()

--- a/test/resources/language/emacs-lisp/local-checkdoc-variables.el
+++ b/test/resources/language/emacs-lisp/local-checkdoc-variables.el
@@ -3,7 +3,8 @@
 ;;; Commentary:
 
 ;; Make sure that file-local checkdoc settings are properly propagated to
-;; checkdoc process.
+;; checkdoc process. There's only a single space between these sentences, but we
+;; allow that in this file.
 
 ;;; Code:
 
@@ -17,6 +18,7 @@
 ;; Local Variables:
 ;; checkdoc-arguments-in-order-flag: nil
 ;; checkdoc-verb-check-experimental-flag: nil
+;; sentence-end-double-space: nil
 ;; End:
 
 (provide 'local-checkdoc-variables)

--- a/test/specs/languages/test-emacs-lisp.el
+++ b/test/specs/languages/test-emacs-lisp.el
@@ -48,8 +48,9 @@
               (seq-filter #'flycheck/custom-var-p checkdoc-custom-group))
              (checkdoc-custom-vars (seq-map #'car checkdoc-custom-pairs))
              (checkdoc-relevant-vars
-              (seq-difference checkdoc-custom-vars
-                              flycheck/excluded-checkdoc-vars)))
+              (cons 'sentence-end-double-space
+                    (seq-difference checkdoc-custom-vars
+                                    flycheck/excluded-checkdoc-vars))))
         (expect (seq-sort #'string-lessp flycheck-emacs-lisp-checkdoc-variables)
                 :to-equal
                 (seq-sort #'string-lessp checkdoc-relevant-vars))))))

--- a/test/specs/languages/test-emacs-lisp.el
+++ b/test/specs/languages/test-emacs-lisp.el
@@ -1,4 +1,4 @@
-;;; test-emacs-lisp.el --- Flycheck Specs: Haskell      -*- lexical-binding: t; -*-
+;;; test-emacs-lisp.el --- Flycheck Specs: Emacs Lisp      -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
 


### PR DESCRIPTION
checkdoc respects the value of sentence-end-double space, so pass it along.