### PR TITLE
Add a revert function for flycheck-verify-setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 
   - Use option ``flycheck-go-build-tags`` to for ``go-test``,
     ``go-vet`` and ``go-errcheck`` as well.
+  - Add a revert function to ``flycheck-verify-setup``, so hitting
+    ``g`` reloads the buffer.
 
 30 (Oct 12, 2016)
 =================

--- a/flycheck.el
+++ b/flycheck.el
@@ -2146,10 +2146,11 @@ possible problems are shown."
   (let ((buffer (current-buffer))
         ;; Get all checkers that support the current major mode
         (checkers (seq-filter #'flycheck-checker-supports-major-mode-p
-                              flycheck-checkers)))
+                              flycheck-checkers))
+        (help-buffer (get-buffer-create " *Flycheck checkers*")))
 
     ;; Now print all applicable checkers
-    (with-help-window (get-buffer-create " *Flycheck checkers*")
+    (with-help-window help-buffer
       (with-current-buffer standard-output
         (flycheck--verify-print-header "Syntax checkers for buffer " buffer)
         (unless checkers
@@ -2174,7 +2175,12 @@ possible problems are shown."
               (princ "\n"))
             (princ "\nTry adding these syntax checkers to `flycheck-checkers'.\n")))
 
-        (flycheck--verify-print-footer buffer)))))
+        (flycheck--verify-print-footer buffer)))
+
+    (with-current-buffer help-buffer
+      (setq-local revert-buffer-function
+                  (lambda (_ignore-auto _noconfirm)
+                    (with-current-buffer buffer (flycheck-verify-setup)))))))
 
 
 ;;; Predicates for generic syntax checkers


### PR DESCRIPTION
Add a revert function for `flycheck-verify-setup`.

So hitting `g` in this buffer reloads it (respecting the buffer where I launched it from), reflecting the possible changes I made in the setup.  Simplifies troubleshooting as I don't have to switch back and forth between the buffers.