### PR TITLE
Add Emacs Lisp other initialization option.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6761,7 +6761,8 @@ This variable has no effect, if
 
 (defun flycheck-emacs-lisp-feature-requires (value)
   "Option VALUE filter for `flycheck-def-option-var'."
-  (mapconcat (lambda (feature) (format "(require '%s)" feature)) value " "))
+  (when value
+    (mapconcat (lambda (feature) (format "(require '%s)" feature)) value " ")))
 
 (flycheck-define-checker emacs-lisp
   "An Emacs Lisp syntax checker using the Emacs Lisp Byte compiler.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6775,7 +6775,7 @@ See Info Node `(elisp)Byte Compilation'."
                     flycheck-option-emacs-lisp-package-user-dir)
             (option "--eval" flycheck-emacs-lisp-initialize-packages nil
                     flycheck-option-emacs-lisp-package-initialize)
-            (option "--eval" flycheck-emacs-lisp-other-initialization
+            (option "--eval" flycheck-emacs-lisp-other-initialization nil
                     flycheck-sexp-to-string)
             "--eval" (eval flycheck-emacs-lisp-check-form)
             "--"

--- a/flycheck.el
+++ b/flycheck.el
@@ -6752,14 +6752,16 @@ This variable has no effect, if
     (when value
       (flycheck-sexp-to-string `(setq package-user-dir ,value)))))
 
-(flycheck-def-option-var flycheck-emacs-lisp-other-initialization
+(flycheck-def-option-var flycheck-emacs-lisp-require-features
     nil emacs-lisp
-  "Other initialization to perform before byte-compiling.
-
-This can be set to any form to evaluate."
-  :type 'sexp
+  "List of features to require before checking."
+  :type '(repeat (string :tag "Feature to require"))
   :risky t
   :package-version '(flycheck . "0.14"))
+
+(defun flycheck-emacs-lisp-feature-requires (value)
+  "Option VALUE filter for `flycheck-def-option-var'."
+  (mapconcat (lambda (feature) (format "(require '%s)" feature)) value " "))
 
 (flycheck-define-checker emacs-lisp
   "An Emacs Lisp syntax checker using the Emacs Lisp Byte compiler.
@@ -6775,8 +6777,8 @@ See Info Node `(elisp)Byte Compilation'."
                     flycheck-option-emacs-lisp-package-user-dir)
             (option "--eval" flycheck-emacs-lisp-initialize-packages nil
                     flycheck-option-emacs-lisp-package-initialize)
-            (option "--eval" flycheck-emacs-lisp-other-initialization nil
-                    flycheck-sexp-to-string)
+            (option "--eval" flycheck-emacs-lisp-require-features nil
+                    flycheck-emacs-lisp-feature-requires)
             "--eval" (eval flycheck-emacs-lisp-check-form)
             "--"
             source-inplace)

--- a/flycheck.el
+++ b/flycheck.el
@@ -6752,6 +6752,15 @@ This variable has no effect, if
     (when value
       (flycheck-sexp-to-string `(setq package-user-dir ,value)))))
 
+(flycheck-def-option-var flycheck-emacs-lisp-other-initialization
+    nil emacs-lisp
+  "Other initialization to perform before byte-compiling.
+
+This can be set to any form to evaluate."
+  :type 'sexp
+  :risky t
+  :package-version '(flycheck . "0.14"))
+
 (flycheck-define-checker emacs-lisp
   "An Emacs Lisp syntax checker using the Emacs Lisp Byte compiler.
 
@@ -6766,6 +6775,8 @@ See Info Node `(elisp)Byte Compilation'."
                     flycheck-option-emacs-lisp-package-user-dir)
             (option "--eval" flycheck-emacs-lisp-initialize-packages nil
                     flycheck-option-emacs-lisp-package-initialize)
+            (option "--eval" flycheck-emacs-lisp-other-initialization
+                    flycheck-sexp-to-string)
             "--eval" (eval flycheck-emacs-lisp-check-form)
             "--"
             source-inplace)


### PR DESCRIPTION
This adds a simple option to the emacs-lisp checker to have flycheck evaluate an arbitrary piece of code before checking a file.  I use it to (require 'my-globals).
