### PR TITLE
use erlc on .erl only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@
     ``go-vet`` and ``go-errcheck`` as well.
   - Add a revert function to ``flycheck-verify-setup``, so hitting
     ``g`` reloads the buffer.
+  - Make sure the erlang compiler is only run on compilable files.
 
 30 (Oct 12, 2016)
 =================

--- a/flycheck.el
+++ b/flycheck.el
@@ -6968,7 +6968,7 @@ See URL `http://www.erlang.org/'."
   ((warning line-start (file-name) ":" line ": Warning:" (message) line-end)
    (error line-start (file-name) ":" line ": " (message) line-end))
   :modes erlang-mode
-  :predicate (lambda () (string-suffix-p ".erl" (buffer-file-name))))
+  :enabled (lambda () (string-suffix-p ".erl" (buffer-file-name))))
 
 (flycheck-define-checker eruby-erubis
   "A eRuby syntax checker using the `erubis' command.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6967,7 +6967,8 @@ See URL `http://www.erlang.org/'."
   :error-patterns
   ((warning line-start (file-name) ":" line ": Warning:" (message) line-end)
    (error line-start (file-name) ":" line ": " (message) line-end))
-  :modes erlang-mode)
+  :modes erlang-mode
+  :predicate (lambda () (string-suffix-p ".erl" (buffer-file-name))))
 
 (flycheck-define-checker eruby-erubis
   "A eRuby syntax checker using the `erubis' command.


### PR DESCRIPTION
flycheck (not unreasonably) tries to run all buffers with erlang-mode through the erlang compiler. Alas, it is quite common to have files that use erlang-mode but does not compile (e.g. header and config files).

also see #1198
