### PR TITLE
`rust-cargo` checks tests, examples and benches targets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@
     ``g`` reloads the buffer.
   - Make sure the erlang compiler is only run on compilable files.
   - ``flycheck-tslint`` does not crash any more on deprecation notices [GH-1174]
+  - ``rust-cargo`` now checks integration tests, examples and benchmarks
+    [GH-1206]
+  - ``rust-cargo`` does not use ``flycheck-rust-library-path`` anymore, as
+    dependencies are taken care of by Cargo [GH-1206]
 
 30 (Oct 12, 2016)
 =================

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -970,15 +970,22 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. defcustom:: flycheck-rust-crate-type
 
-         The type of the crate to check, as string for the ``--crate-type``
-         option.
+         For `rust-cargo`, the target type as a string, one of ``lib``, ``bin``,
+         ``example``, ``test`` or ``bench``.  Can also be nil for projects with
+         a single target.
+
+         For `rust`, the type of the crate to check, as a string for the
+         ``--crate-type`` option.
 
       .. defcustom:: flycheck-rust-binary-name
 
-         The name of the binary to pass to ``cargo rustc --bin``, as a string.
+         The name of the binary to pass to ``cargo rustc --TARGET-TYPE``, as a
+         string.
 
-         Only required when `flycheck-rust-crate-type` is ``bin`` and the crate
-         has multiple targets.
+         For `rust-cargo`, always required unless `flycheck-rust-crate-type` is
+         ``lib`` or nil, in which case it is ignored.
+
+         Ignored by `rust`.
 
       .. defcustom:: flycheck-rust-library-path
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3889,7 +3889,20 @@ Why not:
           :checker ruby-jruby))))
 
 (flycheck-ert-def-checker-test rust-cargo rust warning
-  (let ((flycheck-rust-crate-type "bin"))
+  (let ((flycheck-disabled-checkers '(rust))
+        (flycheck-rust-crate-type "bin")
+        (flycheck-rust-binary-name "flycheck-test"))
+    (flycheck-ert-should-syntax-check
+     "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
+     '(3 1 warning "function is never used: `main`, #[warn(dead_code)] on by default"
+         :checker rust-cargo)
+     '(4 9 warning "unused variable: `x`, #[warn(unused_variables)] on by default"
+         :checker rust-cargo))))
+
+(flycheck-ert-def-checker-test rust-cargo rust default-target
+  (let ((flycheck-disabled-checkers '(rust))
+        (flycheck-rust-crate-type nil)
+        (flycheck-rust-binary-name nil))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
      '(3 1 warning "function is never used: `main`, #[warn(dead_code)] on by default"
@@ -3898,7 +3911,8 @@ Why not:
          :checker rust-cargo))))
 
 (flycheck-ert-def-checker-test rust-cargo rust lib-main
-  (let ((flycheck-rust-crate-type "bin")
+  (let ((flycheck-disabled-checkers '(rust))
+        (flycheck-rust-crate-type "bin")
         (flycheck-rust-binary-name "lib-main"))
     (flycheck-ert-should-syntax-check
      "language/rust/lib-main/src/main.rs" 'rust-mode)))
@@ -3911,7 +3925,8 @@ Why not:
                  "language/rust/note-test/Cargo.toml"
                  flycheck-test-resources-directory))
 
-  (let* (flycheck-rust-check-tests)
+  (let ((flycheck-disabled-checkers '(rust))
+        (flycheck-rust-check-tests))
     (flycheck-ert-should-syntax-check
      "language/rust/note-test/src/lib.rs" 'rust-mode
      '(1 1 info "library: util" :checker rust-cargo)
@@ -3928,6 +3943,69 @@ Why not:
      '(1 1 info
          "link against the following native artifacts when linking against this static library"
          :checker rust-cargo))))
+
+(flycheck-ert-def-checker-test rust-cargo rust conventional-layout
+  (let ((flycheck-disabled-checkers '(rust)))
+    (let ((flycheck-rust-crate-type "lib"))
+      (flycheck-ert-should-syntax-check
+       "language/rust/cargo-targets/src/lib.rs" 'rust-mode
+       '(3 1 warning "function is never used: `foo_lib`, #[warn(dead_code)] on by default"
+           :checker rust-cargo)
+       '(6 17 warning "unused variable: `foo_lib_test`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)))
+
+    (let ((flycheck-rust-crate-type "lib"))
+      (flycheck-ert-should-syntax-check
+       "language/rust/cargo-targets/src/a.rs" 'rust-mode
+       '(1 1 warning "function is never used: `foo_a`, #[warn(dead_code)] on by default"
+           :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_a_test`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)))
+
+    (let ((flycheck-rust-crate-type "bin")
+          (flycheck-rust-binary-name "cargo-targets"))
+      (flycheck-ert-should-syntax-check
+       "language/rust/cargo-targets/src/main.rs" 'rust-mode
+       '(1 17 warning "unused variable: `foo_main`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_main_test`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)))
+
+    (let ((flycheck-rust-crate-type "bin")
+          (flycheck-rust-binary-name "a"))
+      (flycheck-ert-should-syntax-check
+       "language/rust/cargo-targets/src/bin/a.rs" 'rust-mode
+       '(1 17 warning "unused variable: `foo_bin_a`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_bin_a_test`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)))
+
+    (let ((flycheck-rust-crate-type "bench")
+          (flycheck-rust-binary-name "a"))
+      (flycheck-ert-should-syntax-check
+       "language/rust/cargo-targets/benches/a.rs" 'rust-mode
+       '(1 17 warning "unused variable: `foo_bench_a`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_bench_a_test`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)))
+
+    (let ((flycheck-rust-crate-type "test")
+          (flycheck-rust-binary-name "a"))
+      (flycheck-ert-should-syntax-check
+       "language/rust/cargo-targets/tests/a.rs" 'rust-mode
+       '(2 16 warning "unused variable: `foo_test_a_test`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)
+       '(4 1 warning "function is never used: `foo_test_a`, #[warn(dead_code)] on by default"
+           :checker rust-cargo)))
+
+    (let ((flycheck-rust-crate-type "example")
+          (flycheck-rust-binary-name "a"))
+      (flycheck-ert-should-syntax-check
+       "language/rust/cargo-targets/examples/a.rs" 'rust-mode
+       '(1 17 warning "unused variable: `foo_ex_a`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_ex_a_test`, #[warn(unused_variables)] on by default"
+           :checker rust-cargo)))))
 
 (flycheck-ert-def-checker-test rust rust syntax-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4011,7 +4011,7 @@ Why not:
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/syntax-error.rs" 'rust-mode
-     '(4 5 error "unresolved name `bla` (unresolved name)" :checker rust :id "E0425"))))
+     '(4 5 error "cannot find value `bla` in this scope (not found in this scope)" :checker rust :id "E0425"))))
 
 (flycheck-ert-def-checker-test rust rust type-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))

--- a/test/resources/language/rust/cargo-targets/Cargo.lock
+++ b/test/resources/language/rust/cargo-targets/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "cargo-targets"
+version = "0.1.0"
+

--- a/test/resources/language/rust/cargo-targets/Cargo.toml
+++ b/test/resources/language/rust/cargo-targets/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "cargo-targets"
+version = "0.1.0"

--- a/test/resources/language/rust/cargo-targets/benches/a.rs
+++ b/test/resources/language/rust/cargo-targets/benches/a.rs
@@ -1,0 +1,4 @@
+fn main() { let foo_bench_a = 0; }
+
+#[test]
+fn test() { let foo_bench_a_test = 0; }

--- a/test/resources/language/rust/cargo-targets/examples/a.rs
+++ b/test/resources/language/rust/cargo-targets/examples/a.rs
@@ -1,0 +1,4 @@
+fn main() { let foo_ex_a = 0; }
+
+#[test]
+fn test() { let foo_ex_a_test = 0; }

--- a/test/resources/language/rust/cargo-targets/src/a.rs
+++ b/test/resources/language/rust/cargo-targets/src/a.rs
@@ -1,0 +1,4 @@
+fn foo_a() {}
+
+#[test]
+fn test() { let foo_a_test = 0; }

--- a/test/resources/language/rust/cargo-targets/src/bin/a.rs
+++ b/test/resources/language/rust/cargo-targets/src/bin/a.rs
@@ -1,0 +1,4 @@
+fn main() { let foo_bin_a = 0; }
+
+#[test]
+fn test() { let foo_bin_a_test = 0; }

--- a/test/resources/language/rust/cargo-targets/src/lib.rs
+++ b/test/resources/language/rust/cargo-targets/src/lib.rs
@@ -1,0 +1,6 @@
+mod a;
+
+fn foo_lib() {}
+
+#[test]
+fn test() { let foo_lib_test = 0; }

--- a/test/resources/language/rust/cargo-targets/src/main.rs
+++ b/test/resources/language/rust/cargo-targets/src/main.rs
@@ -1,0 +1,4 @@
+fn main() { let foo_main = 0; }
+
+#[test]
+fn test() { let foo_main_test = 0; }

--- a/test/resources/language/rust/cargo-targets/tests/a.rs
+++ b/test/resources/language/rust/cargo-targets/tests/a.rs
@@ -1,0 +1,4 @@
+#[test]
+fn foo() { let foo_test_a_test = 0; }
+
+fn foo_test_a() {}


### PR DESCRIPTION
Previously, `rust-cargo` was unable to check integration tests and other
optional Cargo targets.  For a description of the conventional Cargo layout,
see:

http://doc.crates.io/manifest.html#the-project-layout

This commits enhances `rust-cargo` to check all files under the conventional
layout, by using `flycheck-rust-crate-type` as the target type, and
`flycheck-rust-binary-name` as the target name.

In addition, it adds :enabled and :verify properties to `rust-cargo` to ensure
these variables are correctly set, and to inform the user in case they are not.

Integration tests are added to check the support for the full conventional
layout.