### PR TITLE
Add 'perl-module-list' option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@
   - Add ``--force-exclusion`` flag to ``rubocop`` command [GH-1348]
   - Add ``flycheck-ghc-stack-project-file`` for the
     ``haskell-stack-ghc`` checker. [GH-1316]
+  - Add ``flycheck-perl-module-list`` to use specified modules when
+    syntax checking code with the ``perl`` checker.
 
 - Improvements
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -762,6 +762,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          A list of include directories, relative to the file being checked.
 
+      .. defcustom:: flycheck-perl-module-list
+
+         A list of module names to implicitly use.
+
    .. syntax-checker:: perl-perlcritic
 
       Lint and check style with `Perl::Critic`_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -8369,12 +8369,22 @@ Relative paths are relative to the file being checked."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.24"))
 
+(flycheck-def-option-var flycheck-perl-module-list nil perl
+  "A list of modules to use for Perl.
+
+The value of this variable is a list of strings, where each
+string is a module to 'use' in Perl."
+  :type '(repeat :tag "Module")
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "32"))
+
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.
 
 See URL `https://www.perl.org'."
   :command ("perl" "-w" "-c"
-            (option-list "-I" flycheck-perl-include-path))
+            (option-list "-I" flycheck-perl-include-path)
+            (option-list "-M" flycheck-perl-module-list concat))
   :standard-input t
   :error-patterns
   ((error line-start (minimal-match (message))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3555,6 +3555,27 @@ Why not:
    '(6 6 error "Glob written as <...> (See page 167 of PBP)"
        :id "BuiltinFunctions::RequireGlobFunction" :checker perl-perlcritic)))
 
+(flycheck-ert-def-checker-test perl perl modules
+  ;; Files that require unlisted modules should fail to check
+  (flycheck-ert-should-syntax-check
+   "language/perl/Script.pl" '(perl-mode cperl-mode)
+   '(3 nil error "Global symbol \"$dependency_a\" requires explicit package name (did you forget to declare \"my $dependency_a\"?)"
+       :checker perl)
+   '(4 nil error "Global symbol \"$dependency_b\" requires explicit package name (did you forget to declare \"my $dependency_b\"?)"
+       :checker perl))
+  ;; Including those modules should allow them to check
+  (let
+      ((flycheck-perl-module-list '("DependencyA")))
+    (flycheck-ert-should-syntax-check
+     "language/perl/Script.pl" '(perl-mode cperl-mode)
+     '(4 nil error "Global symbol \"$dependency_b\" requires explicit package name (did you forget to declare \"my $dependency_b\"?)"
+         :checker perl)))
+  ;; Multiple modules should be allowed
+  (let
+      ((flycheck-perl-module-list '("DependencyA" "DependencyB")))
+    (flycheck-ert-should-syntax-check
+     "language/perl/Script.pl" '(perl-mode cperl-mode))))
+
 (flycheck-ert-def-checker-test php php syntax-error
   (flycheck-ert-should-syntax-check
    "language/php/syntax-error.php" 'php-mode

--- a/test/resources/language/perl/DependencyA.pm
+++ b/test/resources/language/perl/DependencyA.pm
@@ -1,0 +1,9 @@
+package DependencyA;
+
+use parent Exporter;
+
+@EXPORT = qw($dependency_a);
+
+our $dependency_a = 'foo';
+
+1;

--- a/test/resources/language/perl/DependencyB.pm
+++ b/test/resources/language/perl/DependencyB.pm
@@ -1,0 +1,9 @@
+package DependencyB;
+
+use parent Exporter;
+
+@EXPORT = qw($dependency_b);
+
+our $dependency_b = 'bar';
+
+1;

--- a/test/resources/language/perl/Script.pl
+++ b/test/resources/language/perl/Script.pl
@@ -1,0 +1,6 @@
+use strict;
+
+print $dependency_a;
+print $dependency_b;
+
+1;


### PR DESCRIPTION
This just adds the ability to specify perl modules to `use` via the `-M` flag when syntax checking.

I ran `make check unit specs LANGUAGE=perl integ` without errors.
