### PR TITLE
 Clean "stdin" filename from flake8 errors

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8448,7 +8448,6 @@ Requires Flake8 3.0 or newer. See URL
 `https://flake8.readthedocs.io/'."
   :command ("flake8"
             "--format=default"
-            "--stdin-display-name" source-original
             (config-file "--config" flycheck-flake8rc)
             (option "--max-complexity" flycheck-flake8-maximum-complexity nil
                     flycheck-option-int)
@@ -8458,11 +8457,10 @@ Requires Flake8 3.0 or newer. See URL
   :standard-input t
   :error-filter (lambda (errors)
                   (let ((errors (flycheck-sanitize-errors errors)))
-                    (seq-do #'flycheck-flake8-fix-error-level errors)
-                    errors))
+                    (seq-map #'flycheck-flake8-fix-error-level errors)))
   :error-patterns
   ((warning line-start
-            (file-name) ":" line ":" (optional column ":") " "
+            "stdin:" line ":" (optional column ":") " "
             (id (one-or-more (any alpha)) (one-or-more digit)) " "
             (message (one-or-more not-newline))
             line-end))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3629,7 +3629,7 @@ Why not:
   (let ((python-indent-guess-indent-offset nil))       ; Silence Python Mode!
     (flycheck-ert-should-syntax-check
      "language/python/syntax-error.py" 'python-mode
-     '(3 13 error "SyntaxError: invalid syntax" :id "E999"
+     '(3 12 error "SyntaxError: invalid syntax" :id "E999"
          :checker python-flake8))))
 
 (flycheck-ert-def-checker-test python-flake8 python nil
@@ -3645,6 +3645,8 @@ Why not:
         :id "E251" :checker python-flake8)
    '(12 31 warning "unexpected spaces around keyword / parameter equals"
         :id "E251" :checker python-flake8)
+   '(21 1 warning "expected 2 blank lines after class or function definition, found 1"
+        :id "E305" :checker python-flake8)
    '(22 1 error "undefined name 'antigravity'" :id "F821"
         :checker python-flake8)))
 


### PR DESCRIPTION
flake8 checker fails when a buffer doesn't have a `buffer-file-name`.

Also, I've update the flake8 tests, to work with flake8 v3.3.0:

```
make SELECTOR='(tag checker-python-flake8)' integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-buttercup.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-python-flake8))'
Running tests on Emacs 26.0.50.3, built at 2017-02-09
Running 2 tests (2017-02-10 17:13:12-0500)
   passed  1/2  flycheck-define-checker/python-flake8/default
   passed  2/2  flycheck-define-checker/python-flake8/syntax-error

Ran 2 tests, 2 results as expected (2017-02-10 17:13:15-0500)
```
