### PR TITLE
Parse only JSON output from TSLint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@
   - Add a revert function to ``flycheck-verify-setup``, so hitting
     ``g`` reloads the buffer.
   - Make sure the erlang compiler is only run on compilable files.
+  - ``flycheck-tslint`` does not crash any more on deprecation notices [GH-1174]
 
 30 (Oct 12, 2016)
 =================

--- a/flycheck.el
+++ b/flycheck.el
@@ -5613,7 +5613,7 @@ about TSLint."
                   :filename .name)))
              ;; Don't try to parse empty output as JSON
              (and (not (string-empty-p output))
-                  (json-read-from-string output)))))
+                  (car (flycheck-parse-json output))))))
 
 (defun flycheck-parse-rust-collect-spans (span)
   "Return a list of spans contained in a SPAN object."

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4090,8 +4090,12 @@ Why not:
 (flycheck-ert-def-checker-test typescript-tslint typescript nil
   (flycheck-ert-should-syntax-check
    "language/typescript/sample.ts" 'typescript-mode
+   '(1 10 warning "Unused function: 'invalidAlignment'"
+       :checker typescript-tslint :id "no-unused-variable")
    '(2 3 warning "Forbidden 'var' keyword, use 'let' or 'const' instead"
        :checker typescript-tslint :id "no-var-keyword")
+   '(2 7 warning "Unused variable: 'a'"
+       :checker typescript-tslint :id "no-unused-variable")
    '(3 15 warning "Missing semicolon"
        :checker typescript-tslint :id "semicolon")))
 

--- a/test/resources/language/typescript/tslint.json
+++ b/test/resources/language/typescript/tslint.json
@@ -1,5 +1,7 @@
 {
   "rules": {
+    "no-unused-variable": true,
+    "use-strict": true,
     "no-var-keyword": true,
     "semicolon": true
   }

--- a/test/specs/languages/test-typescript.el
+++ b/test/specs/languages/test-typescript.el
@@ -38,7 +38,23 @@
   \"failure\":\"missing semicolon\",
   \"name\":\"sample.ts\",
   \"ruleName\":\"semicolon\",
-  \"startPosition\":{\"character\":14,\"line\":2,\"position\":76}}]"))
+  \"startPosition\":{\"character\":14,\"line\":2,\"position\":76}}]")
+          (json-with-deprecations "no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
+
+  Could not find implementations for the following rules specified in the configuration:
+      label-undefined
+      no-constructor-vars
+      no-duplicate-key
+      no-unreachable
+      use-strict
+  Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
+  If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.
+
+[{\"endPosition\":{\"character\":25,\"line\":0,\"position\":25},
+ \"failure\":\"unused variable: 'invalidAlignment'\",
+ \"name\":\"sample.ts\",
+ \"ruleName\":\"no-unused-variable\",
+ \"startPosition\":{\"character\":9,\"line\":0,\"position\":9}}]"))
       (it "parses TSLint JSON output"
         (expect (flycheck-parse-tslint json 'checker 'buffer)
                 :to-be-equal-flycheck-errors
@@ -52,6 +68,16 @@
                  (flycheck-error-new-at 3 15 'warning
                                         "missing semicolon"
                                         :id "semicolon"
+                                        :checker 'checker
+                                        :buffer 'buffer
+                                        :filename "sample.ts"))))
+      (it "parses TSLint JSON output with deprecation output"
+        (expect (flycheck-parse-tslint json-with-deprecations 'checker 'buffer)
+                :to-be-equal-flycheck-errors
+                (list
+                 (flycheck-error-new-at 1 10 'warning
+                                        "unused variable: 'invalidAlignment'"
+                                        :id "no-unused-variable"
                                         :checker 'checker
                                         :buffer 'buffer
                                         :filename "sample.ts")))))))


### PR DESCRIPTION
Fixes and closes GH-1174

- Fixed problem using `flycheck-parse-json`.
- Added buttercup test case with deprecation output from TSLint.
- Added deprecated TSLint config options to integration test.

@flycheck/maintainers please review.
