### PR TITLE
pug checker: handle more error formats 

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9405,6 +9405,11 @@ See URL `https://pugjs.org/'."
   ((error "Error: " (message) (zero-or-more not-newline) "\n"
           (zero-or-more not-newline) "at "
           (zero-or-more not-newline) " line " line)
+   ;; error when placing anything other than a mixin or
+   ;; block at the top-level of an extended template
+   ;; also unknown filters
+   (error line-start "Error: " (file-name) ":"
+          line ":" column "\n\n" (message) line-end)
    ;; syntax/runtime errors (e.g. type errors, bad indentation, etc.)
    (error line-start
           (optional "Type") "Error: "  (file-name) ":"

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4002,6 +4002,19 @@ Why not:
    "language/pug/pug.pug" 'pug-mode
    '(2 1 error "unexpected token \"indent\"" :checker pug)))
 
+(flycheck-ert-def-checker-test pug pug non-block-or-mixin-at-top-level-of-extended-template-error
+  (flycheck-ert-should-syntax-check
+   "language/pug/foo.pug" 'pug-mode
+   '(9 1
+       error "Only named blocks and mixins can appear at the top level of an extending template"
+       :checker pug)))
+(flycheck-ert-def-checker-test pug pug unknown-filter
+  (flycheck-ert-should-syntax-check
+   "language/pug/foo-unknown-filter.pug" 'pug-mode
+   '(1 1
+       error "unknown filter \":myfilter\""
+       :checker pug)))
+
 (flycheck-ert-def-checker-test pug pug include-extends-error
   (flycheck-ert-should-syntax-check
    "language/pug/pug-extends.pug" 'pug-mode

--- a/test/resources/language/pug/foo-base.pug
+++ b/test/resources/language/pug/foo-base.pug
@@ -1,0 +1,4 @@
+html
+  head
+  body
+    block content

--- a/test/resources/language/pug/foo-unknown-filter.pug
+++ b/test/resources/language/pug/foo-unknown-filter.pug
@@ -1,0 +1,1 @@
+:myfilter

--- a/test/resources/language/pug/foo.pug
+++ b/test/resources/language/pug/foo.pug
@@ -1,0 +1,9 @@
+extends foo-base
+
+block content
+  h1 Hello World
+  h2 Some h2 content
+  h3 Some h3 content
+  h4 Some h4 content
+
+h5 This is going to cause an error


### PR DESCRIPTION
fixes pug checker when you add anything other than a block or mixin at top-level of an extended template and also unknown filter errors.

Fixes #1650 