### PR TITLE
Display errors inline

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -103,11 +103,13 @@ Return the displayed phantom."
     (push (phantom-display msg pos) flycheck-inline--phantoms)))
 
 (defun flycheck-inline-display-messages (errors)
-  "Display ERRORS inline.
+  "Display ERRORS, and all errors from their groups, inline.
 
 ERRORS is a list of `flycheck-error' objects."
   (flycheck-inline-hide-messages)
-  (mapc #'flycheck-inline--display-phantom errors))
+  (mapc #'flycheck-inline--display-phantom
+        (seq-uniq
+         (seq-mapcat #'flycheck-errors-from-group errors))))
 
 (defun flycheck-inline-hide-messages ()
   "Hide all inline messages currently being shown."

--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -1,0 +1,165 @@
+;;; flycheck-inline-.el --- Display Flycheck errors inline -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017 fmdkdd
+
+;; Author: fmdkdd
+;; URL: https://github.com/flycheck/flycheck-inline
+;; Keywords: tools, convenience
+;; Version: 0.1-cvs
+;; Package-Requires: ((emacs "25.1") (flycheck "31"))
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provide an error display function to show Flycheck errors inline, directly
+;; below their location in the buffer.
+
+;;;; Setup
+
+;; (with-eval-after-load 'flycheck
+;;   (flycheck-inline-mode))
+
+;;; Code:
+
+(require 'flycheck)
+
+;;; Displaying line-long overlays (phantoms)
+(defun phantom-display (msg &optional pos)
+  "Display MSG in a phantom directly below POS.
+
+MSG is a string that will be put in a line-long overlay (phantom)
+at the line immediately following POS.  If POS is nil, current
+point is used instead.
+
+Return the displayed phantom."
+  (pcase-let* ((p (or pos (point)))
+               (`(,offset . ,pos-eol)
+                (save-excursion
+                  (goto-char p)
+                  (cons (- p (point-at-bol)) (point-at-eol))))
+               (ov (make-overlay pos-eol (1+ pos-eol)))
+               (str (concat (make-string offset ?\s) msg "\n")))
+    (overlay-put ov 'phantom t)
+    (overlay-put ov 'after-string str)
+    ov))
+
+(defun phantom-delete (phantom)
+  "Delete PHANTOM."
+  (when (overlay-get phantom 'phantom)
+    (delete-overlay phantom)))
+
+
+;;; flycheck-inline mode proper
+(defgroup flycheck-inline nil
+  "Display Flycheck errors inline."
+  :prefix "flycheck-inline-"
+  :group 'flycheck
+  :link '(url-link :tag "Github" "https://github.com/flycheck/flycheck-inline"))
+
+(defface flycheck-inline-error
+  '((t :inherit compilation-error))
+  "Flycheck-inline face for errors."
+  :package-version '(flycheck-inline . "0.1")
+  :group 'flycheck-inline)
+
+(defface flycheck-inline-warning
+  '((t :inherit compilation-warning))
+  "Flycheck-inline face for warnings."
+  :package-version '(flycheck-inline . "0.1")
+  :group 'flycheck-inline)
+
+(defface flycheck-inline-info
+  '((t :inherit compilation-info))
+  "Flycheck-inline face for informational messages."
+  :package-version '(flycheck-inline . "0.1")
+  :group 'flycheck-inline)
+
+(defvar-local flycheck-inline--phantoms nil
+  "Remember which phantoms were added to the buffer.")
+
+(defun flycheck-inline--display-phantom (err)
+  "Display `flycheck-error' ERR in a phantom."
+  (let* ((pos (car (flycheck-error-region-for-mode err 'columns)))
+         (msg (propertize
+               (flycheck-error-message err)
+               'face (pcase (flycheck-error-level err)
+                       (`info 'flycheck-inline-info)
+                       (`warning 'flycheck-inline-warning)
+                       (`error 'flycheck-inline-error)))))
+    (push (phantom-display msg pos) flycheck-inline--phantoms)))
+
+(defun flycheck-inline-display-messages (errors)
+  "Display ERRORS inline.
+
+ERRORS is a list of `flycheck-error' objects."
+  (flycheck-inline-hide-messages)
+  (mapc #'flycheck-inline--display-phantom errors))
+
+(defun flycheck-inline-hide-messages ()
+  "Hide all inline messages currently being shown."
+  (when (not flycheck-display-error-caused-by-next-error)
+    (mapc #'phantom-delete flycheck-inline--phantoms)
+    (setq flycheck-inline--phantoms nil)))
+
+(defvar flycheck-inline-old-display-function nil
+  "The former value of `flycheck-display-errors-function'.")
+
+;;;###autoload
+(define-minor-mode flycheck-inline-mode
+  "A minor mode to show Flycheck error messages line.
+
+When called interactively, toggle `flycheck-inline-mode'.  With
+prefix ARG, enable `flycheck-inline-mode' if ARG is positive,
+otherwise disable it.
+
+When called from Lisp, enable `flycheck-inline-mode' if ARG is
+omitted, nil or positive.  If ARG is `toggle', toggle
+`flycheck-inline-mode'.  Otherwise behave as if called
+interactively.
+
+In `flycheck-inline-mode', show Flycheck error messages inline,
+directly below the error reported location."
+  :global t
+  :group 'flycheck
+  (let ((hooks '(post-command-hook)))
+    (cond
+     ;; Use our display function and remember the old one but only if we haven't
+     ;; yet configured it, to avoid activating twice.
+     ((and flycheck-inline-mode
+           (not (eq flycheck-display-errors-function
+                    #'flycheck-inline-display-messages)))
+      (setq flycheck-inline-old-display-function
+            flycheck-display-errors-function
+            flycheck-display-errors-function
+            #'flycheck-inline-display-messages)
+      (dolist (hook hooks)
+        (add-hook hook #'flycheck-inline-hide-messages)))
+     ;; Reset the display function and remove ourselves from all hooks but only
+     ;; if the mode is still active.
+     ((and (not flycheck-inline-mode)
+           (eq flycheck-display-errors-function
+               #'flycheck-inline-display-messages))
+      (setq flycheck-display-errors-function
+            flycheck-inline-old-display-function
+            flycheck-inline-old-display-function nil)
+      (flycheck-inline-hide-messages)
+      (dolist (hook hooks)
+        (remove-hook hook 'flycheck-inline-hide-messages))))))
+
+(provide 'flycheck-inline)
+
+;;; flycheck-inline.el ends here

--- a/flycheck.el
+++ b/flycheck.el
@@ -2354,6 +2354,7 @@ buffer manually.
 
     (pcase-dolist (`(,hook . ,fn) flycheck-hooks-alist)
       (add-hook hook fn nil 'local))
+    (add-hook 'post-command-hook #'flycheck-clear-display-error-caused-by-next-error t 'local)
 
     (setq flycheck-old-next-error-function (if flycheck-standard-error-navigation
                                                next-error-function
@@ -2366,6 +2367,7 @@ buffer manually.
 
     (pcase-dolist (`(,hook . ,fn) flycheck-hooks-alist)
       (remove-hook hook fn 'local))
+    (remove-hook 'post-command-hook #'flycheck-clear-display-error-caused-by-next-error 'local)
 
     (flycheck-teardown))))
 
@@ -3794,6 +3796,11 @@ Intended for use with `next-error-function'."
         (goto-char pos)
       (user-error "No more Flycheck errors"))))
 
+(defvar-local flycheck-display-error-caused-by-next-error nil)
+
+(defun flycheck-clear-display-error-caused-by-next-error ()
+  (setq flycheck-display-error-caused-by-next-error nil))
+
 (defun flycheck-next-error (&optional n reset)
   "Visit the N-th error from the current point.
 
@@ -3806,7 +3813,8 @@ position."
     ;; Universal prefix argument means reset
     (setq reset t n nil))
   (flycheck-next-error-function n reset)
-  (flycheck-display-error-at-point))
+  (flycheck-display-error-at-point)
+  (setq flycheck-display-error-caused-by-next-error t))
 
 (defun flycheck-previous-error (&optional n)
   "Visit the N-th previous error.
@@ -4312,7 +4320,8 @@ non-nil."
 (defun flycheck-display-error-at-point-soon ()
   "Display the first error message at point in minibuffer delayed."
   (flycheck-cancel-error-display-error-at-point-timer)
-  (when (flycheck-overlays-at (point))
+  (when (and (flycheck-overlays-at (point))
+             (not flycheck-display-error-caused-by-next-error))
     (setq flycheck-display-error-at-point-timer
           (run-at-time flycheck-display-errors-delay nil 'flycheck-display-error-at-point))))
 


### PR DESCRIPTION
**This PR is not intended for merging, just for preview and review**

Here's my implementation proposal for #1210.  There are three parts to it:

1. The `flycheck-inline` global minor mode
2. A fix to `display-error` 
3. Error groups to display related errors

The last part is mostly relevant for Rust.  `flycheck-inline` is intended to work with all checkers, and the fix is optional.

### Flycheck-inline global minor mode
Add `flycheck-inline-mode`, a global minor mode.  When activated, it changes `flycheck-display-errors-function` to `flycheck-inline-display-messages`.  Error messages under point are then displayed inline, just below the line containing the error overlays.  Here's a preview:

![inline simple error](https://cloud.githubusercontent.com/assets/340129/22973560/6e285686-f37e-11e6-9b34-f0773852b196.gif)

If there are 3 errors under point, they will be displayed on three lines, each error on its line.

This functionality is solely contained in `flycheck-inline.el`, which is intended as an extension to flycheck in a separate repository.  I put it in this PR to be able to review it.

The code should be straightforward.  It's mostly the same as `flycheck-pos-tip`, since the functionality is similar.

- Should this extension be hosted under the flycheck organization?  If it should, is `flycheck-inline` alright for the repository name, or is another name more appropriate?

### Fix to `display-error`
Since #1042, `flycheck-next-error` is intended to display the errors at point immediately.  However, since `-display-error-at-point-soon` is also on `post-command-hook`, invoking `flycheck-next-error` will actually trigger `-display-errors-function` *twice*.  Here is the timeline of events:
```
flycheck-next-error is called
- triggers display-error-at-point ---> errors are displayed
post-command-hook runs
- triggers display-error-at-point-soon
  - sets a timer for `display-error-at-point`
[0.9 seconds later]
- display-error-at-point is called by the timer ---> errors are displayed
```


For the default behavior of echoing messages in the minibuffer, this is unnoticeable.  For inline error messages, this means adding the overlays, then removing and adding them again after 0.9 seconds (the default delay for `-display-error-at-point-soon`).

- Is this a bug we want to fix?  Or can the `display-error` functions work around it by being (visually) idempotent?  If we want to fix it, I will open a separate PR for it.
- I've sketched a fix in the first commit here.  The idea is simple: don't call `display-error-soon` if `next-error` was the last command called.  The implementation relies on setting a flag and clearing it at the end of `post-command-hook`.  Better ideas are welcome.

### Error groups
While `flycheck-inline` can work without them, for Rust it makes the most sense to have error groups.  With errors groups, instead of displaying only the errors at point, `flycheck-inline` displays all the errors *from all the groups the errors at point belong to*.  Here is an example using groups:
![inline group error](https://cloud.githubusercontent.com/assets/340129/22973275/4ed3b894-f37d-11e6-94f3-186532896baa.gif)

Here all the errors related to the borrowing error at point are displayed at once.  Note that the errors for the line `let zz = ...` are not displayed.

- Is this a feature we want in flycheck?  I can open a separate PR for error groups, and there we can discuss its merits and implementation, especially with regards to other checkers.



