### PR TITLE
Treat 'note' from rustc as info, not error

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5673,6 +5673,7 @@ https://github.com/rust-lang/rust/blob/master/src/libsyntax/json.rs#L67-L139"
             error-level (pcase .level
                           (`"error" 'error)
                           (`"warning" 'warning)
+                          (`"note" 'info)
                           (_ 'error))
             ;; The 'code' field of the diagnostic contains the actual error
             ;; code and an optional explanation that we ignore

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3881,6 +3881,32 @@ Why not:
     (flycheck-ert-should-syntax-check
      "language/rust/lib-main/src/main.rs" 'rust-mode)))
 
+(flycheck-ert-def-checker-test rust-cargo rust notes
+  ;; We only get notes on the first build. Ensure we start from a
+  ;; clean directory each time.
+  (call-process "cargo" nil nil nil "clean" "--manifest-path"
+                (expand-file-name
+                 "language/rust/note-test/Cargo.toml"
+                 flycheck-test-resources-directory))
+
+  (let* (flycheck-rust-check-tests)
+    (flycheck-ert-should-syntax-check
+     "language/rust/note-test/src/lib.rs" 'rust-mode
+     '(1 1 info "library: util" :checker rust-cargo)
+     '(1 1 info "library: rt" :checker rust-cargo)
+     '(1 1 info "library: m" :checker rust-cargo)
+     '(1 1 info "library: c" :checker rust-cargo)
+     '(1 1 info "library: gcc_s" :checker rust-cargo)
+     '(1 1 info "library: pthread" :checker rust-cargo)
+     '(1 1 info "library: rt" :checker rust-cargo)
+     '(1 1 info "library: dl" :checker rust-cargo)
+     '(1 1 info
+         "the order and any duplication can be significant on some platforms, and so may need to be preserved"
+         :checker rust-cargo)
+     '(1 1 info
+         "link against the following native artifacts when linking against this static library"
+         :checker rust-cargo))))
+
 (flycheck-ert-def-checker-test rust rust syntax-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check

--- a/test/resources/language/rust/note-test/Cargo.toml
+++ b/test/resources/language/rust/note-test/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "note-test"
+version = "0.1.0"
+authors = ["Wilfred Hughes <me@wilfred.me.uk>"]
+
+[dependencies]
+
+[lib]
+crate-type = ["staticlib"]

--- a/test/resources/language/rust/note-test/src/lib.rs
+++ b/test/resources/language/rust/note-test/src/lib.rs
@@ -1,0 +1,1 @@
+// Deliberately empty file.


### PR DESCRIPTION
Given a project that is configured as a staticlib:

    [lib]
    crate-type = ["staticlib"]

rustc will output the following errors:

    $ cargo rustc -- --error-format=json
       Compiling foo v0.1.0 (file:///home/wilfred/tmp/foo)
    {"message":"link against the following native artifacts when linking against this static library","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"the order and any duplication can be significant on some platforms, and so may need to be preserved","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: dl","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: rt","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: pthread","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: gcc_s","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: c","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: m","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: rt","code":null,"level":"note","spans":[],"children":[],"rendered":null}
    {"message":"library: util","code":null,"level":"note","spans":[],"children":[],"rendered":null}
        Finished debug [unoptimized + debuginfo] target(s) in 0.17 secs

Previously these would be treated as errors by flycheck.