### PR TITLE
Fix (most) integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # Directory local variables
 .dir-locals.el
+.vagrant

--- a/Cask
+++ b/Cask
@@ -46,6 +46,7 @@
  (depends-on "scala-mode")
  (depends-on "scss-mode")
  (depends-on "slim-mode")
+ (depends-on "systemd")
  (depends-on "typescript-mode")
  (depends-on "web-mode")
  (depends-on "yaml-mode")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -152,7 +152,8 @@ Vagrant.configure("2") do |config|
                               sass \
                               scss_lint \
                               scss_lint_reporter_checkstyle \
-                              slim
+                              slim \
+                              sqlint
 
     echo "Installing packages from npm..."
     npm install --global --prefix ~/.node_modules coffeelint \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,232 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "terrywang/archlinux"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Need memory to compile Coq!
+    vb.memory = 2048
+    vb.cpus = 2
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+
+  # Make sure keys are up to date before upgrading packages, otherwise PGP
+  # signatures will fail to check
+  config.vm.provision "upgrade",
+                      type: "shell",
+                      privileged: false,
+                      run: "always",
+                      inline: <<-SHELL
+    sudo pacman --noconfirm -Sy
+    sudo pacman --noconfirm --needed -S archlinux-keyring
+    sudo pacman --noconfirm -Su
+  SHELL
+
+  # Get the latest flycheck master
+  config.vm.provision "flycheck",
+                      type: "shell",
+                      privileged: false,
+                      run: "always",
+                      inline: <<-SHELL
+    if [ ! -d flycheck ]; then
+      git clone --depth=1 https://github.com/flycheck/flycheck.git
+    else
+      pushd flycheck
+      git pull
+    fi
+  SHELL
+
+  # The additional packages needed to run the Flycheck integration tests
+  config.vm.provision "flycheck-deps",
+                      type: "shell",
+                      privileged: false,
+                      inline: <<-SHELL
+    echo "Installing packages with pacman..."
+    sudo pacman --noconfirm --needed -S npm \
+                                        jdk8-openjdk \
+                                        gcc-ada \
+                                        asciidoc \
+                                        asciidoctor \
+                                        clang \
+                                        cppcheck \
+                                        coffee-script \
+                                        coq \
+                                        dmd \
+                                        erlang \
+                                        gcc-fortran \
+                                        go \
+                                        groovy \
+                                        ghc \
+                                        haskell-hlint \
+                                        stack \
+                                        tidy \
+                                        perl \
+                                        cpanminus \
+                                        php \
+                                        processing \
+                                        protobuf \
+                                        puppet \
+                                        flake8 \
+                                        python-pylint \
+                                        racket-minimal \
+                                        python-docutils \
+                                        python-sphinx \
+                                        r \
+                                        jruby \
+                                        rustup \
+                                        scala \
+                                        chicken \
+                                        shellcheck \
+                                        xmlstarlet
+    echo "Installing packages from AUR..."
+    yaourt --noconfirm --needed -S cask \
+                                   cfengine \
+                                   luacheck \
+                                   nix \
+                                   phpmd \
+                                   php-pear \
+                                   scalastyle
+                                   # verilator
+
+    echo "Installing packages with gem..."
+    gem install --no-document foodcritic \
+                              haml \
+                              mdl \
+                              puppet-lint \
+                              reek \
+                              rubocop \
+                              ruby-lint \
+                              sass \
+                              scss_lint \
+                              scss_lint_reporter_checkstyle \
+                              slim
+
+    echo "Installing packages from npm..."
+    npm install --global --prefix ~/.node_modules coffeelint \
+                                                  csslint \
+                                                  handlebars \
+                                                  jshint \
+                                                  eslint \
+                                                  jscs \
+                                                  standard \
+                                                  semistandard \
+                                                  jsonlint \
+                                                  less \
+                                                  pug-cli \
+                                                  tslint \
+                                                  typescript \
+                                                  js-yaml
+
+    echo "Installing packages with go get..."
+    go get -u github.com/kisielk/errcheck \
+              github.com/mdempsky/unconvert \
+              github.com/golang/lint/golint
+
+    echo "Installing packages with raco pkg..."
+    raco pkg install --auto --skip-installed compiler-lib
+
+    echo "Installing rust with rustup..."
+    rustup install stable
+    rustup default stable
+
+    echo "Installing GHC for stack..."
+    stack setup
+
+    echo "Installing packages from CPAN..."
+    sudo cpanm Perl::Critic
+    sudo chmod -R a+rX /usr/share/perl5 /usr/lib/perl5
+
+    echo "Installing packages from PEAR..."
+    sudo pear install PHP_CodeSniffer
+    echo 'include_path=".:/usr/share/pear/"' | sudo tee /etc/php/conf.d/pear.ini
+    echo 'extension=iconv.so' | sudo tee /etc/php/conf.d/iconv.ini
+    sudo chmod -R a+rX /usr/share/pear/PHP /etc/php/conf.d
+
+    echo "Installing packages from CRAN..."
+    export R_LIBS_USER=~/R
+    cat <<-EOF > install-packages.R
+      dir.create(Sys.getenv("R_LIBS_USER"), showWarnings = FALSE, recursive = TRUE)
+      install.packages("lintr", Sys.getenv("R_LIBS_USER"), repos="http://cran.case.edu")
+EOF
+    R CMD BATCH install-packages.R
+
+    echo "Installing hadolint..."
+    if [ ! -d hadolint ]; then
+      git clone --depth=1 https://github.com/lukasmartinelli/hadolint
+    else
+      pushd hadolint
+      git pull
+      popd
+    fi
+    pushd hadolint
+    stack setup
+    stack install
+    popd
+  SHELL
+
+  # Add binaries from ad-hoc package managers to PATH
+  config.vm.provision "path-setup",
+                      type: "shell",
+                      privileged: false,
+                      inline: <<-SHELL
+    echo export PATH=$(ruby -e 'print Gem.user_dir')/bin:'$PATH' >> ~/.profile
+    echo export PATH=$HOME/.node_modules/bin:'$PATH' >> ~/.profile
+    echo export PATH=$HOME/go/bin:'$PATH' >> ~/.profile
+    echo export PATH=$HOME/.local/bin:'$PATH' >> ~/.profile
+    echo export R_LIBS_USER=$HOME/R >> ~/.profile
+  SHELL
+
+end

--- a/flycheck.el
+++ b/flycheck.el
@@ -8926,7 +8926,7 @@ See URL `http://jruby.org/'."
   :standard-input t
   :error-patterns
   ((error line-start "SyntaxError in -:" line ": " (message) line-end)
-   (warning line-start "-:" line " warning: " (message) line-end)
+   (warning line-start "-:" line ":" " warning: " (message) line-end)
    (error line-start  "-:" line ": " (message) line-end))
   :modes (enh-ruby-mode ruby-mode)
   :next-checkers ((warning . ruby-rubylint)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2878,14 +2878,8 @@ The term \"1\" has type \"nat\" while it is expected to have type
   :tags '(checkstyle-xml)
   (flycheck-ert-should-syntax-check
    "language/css/syntax-error.css" 'css-mode
-   '(4 16 error "Expected LBRACE at line 4, col 16." :id "ParsingErrors"
-       :checker css-csslint)
-   '(4 16 error "Unexpected token '100%' at line 4, col 16." :id "ParsingErrors"
-       :checker css-csslint)
-   '(4 20 error "Unexpected token ';' at line 4, col 20." :id "ParsingErrors"
-       :checker css-csslint)
-   '(5 1 error "Unexpected token '}' at line 5, col 1." :id "ParsingErrors"
-       :checker css-csslint)))
+   '(4 14 error "Expected a `FUNCTION` or `IDENT` after colon at line 4, col 14."
+       :id "ParsingErrors" :checker css-csslint)))
 
 (ert-deftest flycheck-d-module-re/matches-module-name ()
   :tags '(language-d)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3226,7 +3226,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (let ((flycheck-disabled-checkers '(haskell-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Literate.lhs" 'literate-haskell-mode
-     '(6 1 warning "Top-level binding with no type signature: foo :: forall a. a"
+     '(6 1 warning "Top-level binding with no type signature: foo :: a"
          :id "-Wmissing-signatures"
          :checker haskell-stack-ghc))))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3145,16 +3145,17 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
            :checker go-build)))))
 
 (flycheck-ert-def-checker-test go-build go directory-with-two-packages
-  (flycheck-ert-with-env
-      `(("GOPATH" . ,(flycheck-ert-resource-filename "checkers/go")))
-    (flycheck-ert-should-syntax-check
-     "checkers/go/src/multipkg/a.go" 'go-mode
-     `(1 nil info
-         ,(concat "can't load package: package multipkg: "
-                  "found packages a (a.go) and b (b.go) in "
-                  (flycheck-ert-resource-filename
-                   "checkers/go/src/multipkg"))
-         :checker go-build))))
+  (let ((flycheck-disabled-checkers '(go-errcheck go-unconvert)))
+    (flycheck-ert-with-env
+        `(("GOPATH" . ,(flycheck-ert-resource-filename "checkers/go")))
+      (flycheck-ert-should-syntax-check
+       "checkers/go/src/multipkg/a.go" 'go-mode
+       `(1 nil info
+           ,(concat "can't load package: package multipkg: "
+                    "found packages a (a.go) and b (b.go) in "
+                    (flycheck-ert-resource-filename
+                     "checkers/go/src/multipkg"))
+           :checker go-build)))))
 
 (flycheck-ert-def-checker-test go-test go nil
   (flycheck-ert-with-env
@@ -3178,7 +3179,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (flycheck-ert-with-env
       `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
     (flycheck-ert-should-syntax-check
-     "language/go/unconvert/unconvert.go" 'go-mode
+     "language/go/src/unconvert/unconvert.go" 'go-mode
      '(7 17 warning "unnecessary conversion"
          :checker go-unconvert))))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2746,13 +2746,10 @@ evaluating BODY."
 
 (flycheck-ert-def-checker-test c/c++-clang (c c++) included-file-error
   (let ((flycheck-clang-include-path '("./include"))
-        (flycheck-disabled-checkers '(c/c++-gcc))
-        (include-file (flycheck-ert-resource-filename
-                       "language/c_c++/warning.c")))
+        (flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-ert-should-syntax-check
      "language/c_c++/in-included-file.cpp" 'c++-mode
-     `(3 nil warning ,(format "In include %s" include-file)
-         :checker c/c++-clang))))
+     `(3 nil warning "In include ./warning.c" :checker c/c++-clang))))
 
 (flycheck-ert-def-checker-test c/c++-gcc (c c++) error
   (let ((flycheck-disabled-checkers '(c/c++-clang)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -50,12 +50,13 @@
 (require 'flycheck-ert)
 
 ;; Make a best effort to make Coq Mode available
-(mapc (lambda (dir)
-        (add-to-list 'load-path (expand-file-name "coq/" dir)))
-      '("/usr/share/emacs/site-lisp/"
-        "/usr/local/share/emacs/site-lisp/"))
+;; (mapc (lambda (dir)
+;;         (add-to-list 'load-path (expand-file-name "coq/" dir)))
+;;       '("/usr/share/emacs/site-lisp/"
+;;         "/usr/local/share/emacs/site-lisp/"))
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/")
 
-(autoload 'coq-mode "coq")
+(autoload 'coq-mode "gallina")
 
 ;; Load ESS for R-mode (its autoloads are broken)
 (require 'ess-site nil 'noerror)
@@ -2849,14 +2850,14 @@ evaluating BODY."
          :checker coffee-coffeelint))))
 
 (flycheck-ert-def-checker-test coq coq syntax-error
-  (skip-unless (load "coq" 'noerror 'nomessage))
+  (skip-unless (load "gallina" 'noerror 'nomessage))
   (flycheck-ert-should-syntax-check
    "language/coq/syntax-error.v" 'coq-mode
-   '(6 12 error "'end' expected after [branches] (in [match_constr])."
+   '(6 10 error "\"end\" expected after [branches] (in [match_constr])."
        :checker coq)))
 
 (flycheck-ert-def-checker-test coq coq error
-  (skip-unless (load "coq" 'noerror 'nomessage))
+  (skip-unless (load "gallina" 'noerror 'nomessage))
   (flycheck-ert-should-syntax-check
    "language/coq/error.v" 'coq-mode
    '(7 21 error "In environment
@@ -2864,8 +2865,7 @@ evenb : nat -> bool
 n : nat
 n0 : nat
 n' : nat
-The term \"1\" has type \"nat\" while it is expected to have type
-\"bool\"." :checker coq)))
+The term \"1\" has type \"nat\" while it is expected to have type \"bool\"." :checker coq)))
 
 (flycheck-ert-def-checker-test css-csslint css nil
   :tags '(checkstyle-xml)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2706,11 +2706,12 @@ evaluating BODY."
    '(8  11 warning "unrecognized pragma \"Foo\"" :checker ada-gnat)))
 
 (flycheck-ert-def-checker-test asciidoc asciidoc nil
-  (flycheck-ert-should-syntax-check
-   "language/asciidoc.adoc" 'adoc-mode
-   '(1 nil warning "missing style: [paradef-default]: paragraph" :checker asciidoc)
-   '(3 nil info "old tables syntax" :checker asciidoc)
-   '(11 nil error "[tabledef-default] illegal width=%60%" :checker asciidoc)))
+  (let ((flycheck-disabled-checkers '(asciidoctor)))
+    (flycheck-ert-should-syntax-check
+     "language/asciidoc.adoc" 'adoc-mode
+     '(1 nil warning "missing style: [paradef-default]: paragraph" :checker asciidoc)
+     '(3 nil info "old tables syntax" :checker asciidoc)
+     '(11 nil error "[tabledef-default] illegal width=%60%" :checker asciidoc))))
 
 (flycheck-ert-def-checker-test asciidoctor asciidoc nil
   (flycheck-ert-should-syntax-check

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3801,8 +3801,10 @@ Why not:
 (flycheck-ert-def-checker-test ruby-rubocop ruby syntax-error
   (flycheck-ert-should-syntax-check
    "language/ruby/syntax-error.rb" 'ruby-mode
-   '(5 7 error "unexpected token tCONSTANT (Using Ruby 2.1 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)" :checker ruby-rubocop)
-   '(5 24 error "unterminated string meets end of file (Using Ruby 2.1 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)" :checker ruby-rubocop)))
+   '(5 7 error "unexpected token tCONSTANT (Using Ruby 2.1 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+       :checker ruby-rubocop)
+   '(5 24 error "unterminated string meets end of file (Using Ruby 2.1 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+       :checker ruby-rubocop)))
 
 (flycheck-ert-def-checker-test ruby-rubylint ruby syntax-error
   (ert-skip "Pending: https://github.com/YorickPeterse/ruby-lint/issues/202")

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3791,7 +3791,7 @@ Why not:
    "language/rst/sphinx/index.rst" 'rst-mode
    '(2 nil warning "Title underline too short." :checker rst-sphinx)
    '(9 nil error "Unknown target name: \"cool\"." :checker rst-sphinx)
-   '(9 nil warning "u'envvar' reference target not found: FOO"
+   '(9 nil warning "'envvar' reference target not found: FOO"
        :checker rst-sphinx)))
 
 (flycheck-ert-def-checker-test rst-sphinx rst not-outside-of-a-sphinx-project

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3620,7 +3620,7 @@ Why not:
   (let ((python-indent-guess-indent-offset nil))       ; Silence Python Mode!
     (flycheck-ert-should-syntax-check
      "language/python/syntax-error.py" 'python-mode
-     '(3 13 error "SyntaxError: invalid syntax" :id "E999"
+     '(3 12 error "SyntaxError: invalid syntax" :id "E999"
          :checker python-flake8))))
 
 (flycheck-ert-def-checker-test python-flake8 python nil
@@ -3630,12 +3630,12 @@ Why not:
        :checker python-flake8)
    '(7 1 warning "expected 2 blank lines, found 1" :id "E302"
        :checker python-flake8)
-   '(9 9 info "function name should be lowercase"
-       :checker python-flake8 :id "N802")
    '(12 29 warning "unexpected spaces around keyword / parameter equals"
         :id "E251" :checker python-flake8)
    '(12 31 warning "unexpected spaces around keyword / parameter equals"
         :id "E251" :checker python-flake8)
+   '(21 1 warning "expected 2 blank lines after class or function definition, found 1"
+        :id "E305" :checker python-flake8)
    '(22 1 error "undefined name 'antigravity'" :id "F821"
         :checker python-flake8)))
 
@@ -3644,7 +3644,8 @@ Why not:
         (python-indent-guess-indent-offset nil)) ; Silence Python Mode
     (flycheck-ert-should-syntax-check
      "language/python/syntax-error.py" 'python-mode
-     '(3 1 error "invalid syntax" :id "syntax-error" :checker python-pylint))))
+     '(3 1 error "invalid syntax (<string>, line 3)"
+         :id "syntax-error" :checker python-pylint))))
 
 (flycheck-ert-def-checker-test python-pylint python nil
   (let ((flycheck-disabled-checkers '(python-flake8)))
@@ -3662,18 +3663,12 @@ Why not:
      '(9 5 info "Missing method docstring" :id "missing-docstring" :checker python-pylint)
      '(9 5 warning "Method could be a function" :id "no-self-use"
          :checker python-pylint)
-     '(10 16 warning "Used builtin function 'map'. Using a list comprehension can be clearer."
-          :id "bad-builtin" :checker python-pylint)
      '(12 1 info "No space allowed around keyword argument assignment"
           :id "bad-whitespace" :checker python-pylint)
      '(12 5 info "Missing method docstring" :id "missing-docstring" :checker python-pylint)
      '(12 5 warning "Method could be a function" :id "no-self-use"
           :checker python-pylint)
      '(14 16 error "Module 'sys' has no 'python_version' member" :id "no-member"
-          :checker python-pylint)
-     '(15 1 info "Unnecessary parens after u'print' keyword" :id "superfluous-parens"
-          :checker python-pylint)
-     '(17 1 info "Unnecessary parens after u'print' keyword" :id "superfluous-parens"
           :checker python-pylint)
      '(22 1 error "Undefined variable 'antigravity'" :id "undefined-variable"
           :checker python-pylint))))
@@ -3695,18 +3690,12 @@ Why not:
      '(9 5 info "Missing method docstring" :id "C0111" :checker python-pylint)
      '(9 5 warning "Method could be a function" :id "R0201"
          :checker python-pylint)
-     '(10 16 warning "Used builtin function 'map'. Using a list comprehension can be clearer."
-          :id "W0141" :checker python-pylint)
      '(12 1 info "No space allowed around keyword argument assignment"
           :id "C0326" :checker python-pylint)
      '(12 5 info "Missing method docstring" :id "C0111" :checker python-pylint)
      '(12 5 warning "Method could be a function" :id "R0201"
           :checker python-pylint)
      '(14 16 error "Module 'sys' has no 'python_version' member" :id "E1101"
-          :checker python-pylint)
-     '(15 1 info "Unnecessary parens after u'print' keyword" :id "C0325"
-          :checker python-pylint)
-     '(17 1 info "Unnecessary parens after u'print' keyword" :id "C0325"
           :checker python-pylint)
      '(22 1 error "Undefined variable 'antigravity'" :id "E0602"
           :checker python-pylint))))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3756,7 +3756,8 @@ Why not:
 (flycheck-ert-def-checker-test markdown-mdl markdown nil
   (flycheck-ert-should-syntax-check
    "language/markdown.md" 'markdown-mode
-   '(1 nil error "First header should be a h1 header" :id "MD002" :checker markdown-mdl)))
+   '(1 nil error "First header should be a top level header"
+       :id "MD002" :checker markdown-mdl)))
 
 (flycheck-ert-def-checker-test nix nix nil
   (flycheck-ert-should-syntax-check

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3883,10 +3883,10 @@ Why not:
         (flycheck-rust-binary-name "flycheck-test"))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
-     '(3 1 warning "function is never used: `main`, #[warn(dead_code)] on by default"
-         :checker rust-cargo)
-     '(4 9 warning "unused variable: `x`, #[warn(unused_variables)] on by default"
-         :checker rust-cargo))))
+     '(3 1 warning "function is never used: `main`" :checker rust-cargo)
+     '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo)
+     '(4 9 warning "unused variable: `x`" :checker rust-cargo)
+     '(4 9 info "#[warn(unused_variables)] on by default" :checker rust-cargo))))
 
 (flycheck-ert-def-checker-test rust-cargo rust default-target
   (let ((flycheck-disabled-checkers '(rust))
@@ -3894,10 +3894,10 @@ Why not:
         (flycheck-rust-binary-name nil))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
-     '(3 1 warning "function is never used: `main`, #[warn(dead_code)] on by default"
-         :checker rust-cargo)
-     '(4 9 warning "unused variable: `x`, #[warn(unused_variables)] on by default"
-         :checker rust-cargo))))
+     '(3 1 warning "function is never used: `main`" :checker rust-cargo)
+     '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo)
+     '(4 9 warning "unused variable: `x`" :checker rust-cargo)
+     '(4 9 info "#[warn(unused_variables)] on by default" :checker rust-cargo))))
 
 (flycheck-ert-def-checker-test rust-cargo rust lib-main
   (let ((flycheck-disabled-checkers '(rust))
@@ -3938,63 +3938,63 @@ Why not:
     (let ((flycheck-rust-crate-type "lib"))
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/lib.rs" 'rust-mode
-       '(3 1 warning "function is never used: `foo_lib`, #[warn(dead_code)] on by default"
-           :checker rust-cargo)
-       '(6 17 warning "unused variable: `foo_lib_test`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)))
+       '(3 1 warning "function is never used: `foo_lib`" :checker rust-cargo)
+       '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo)
+       '(6 17 warning "unused variable: `foo_lib_test`" :checker rust-cargo)
+       '(6 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)))
 
     (let ((flycheck-rust-crate-type "lib"))
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/a.rs" 'rust-mode
-       '(1 1 warning "function is never used: `foo_a`, #[warn(dead_code)] on by default"
-           :checker rust-cargo)
-       '(4 17 warning "unused variable: `foo_a_test`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)))
+       '(1 1 warning "function is never used: `foo_a`" :checker rust-cargo)
+       '(1 1 info "#[warn(dead_code)] on by default" :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_a_test`" :checker rust-cargo)
+       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)))
 
     (let ((flycheck-rust-crate-type "bin")
           (flycheck-rust-binary-name "cargo-targets"))
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/main.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_main`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)
-       '(4 17 warning "unused variable: `foo_main_test`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)))
+       '(1 17 warning "unused variable: `foo_main`" :checker rust-cargo)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_main_test`" :checker rust-cargo)
+       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)))
 
     (let ((flycheck-rust-crate-type "bin")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/bin/a.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_bin_a`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)
-       '(4 17 warning "unused variable: `foo_bin_a_test`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)))
+       '(1 17 warning "unused variable: `foo_bin_a`" :checker rust-cargo)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_bin_a_test`" :checker rust-cargo)
+       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)))
 
     (let ((flycheck-rust-crate-type "bench")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/benches/a.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_bench_a`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)
-       '(4 17 warning "unused variable: `foo_bench_a_test`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)))
+       '(1 17 warning "unused variable: `foo_bench_a`" :checker rust-cargo)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_bench_a_test`" :checker rust-cargo)
+       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)))
 
     (let ((flycheck-rust-crate-type "test")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/tests/a.rs" 'rust-mode
-       '(2 16 warning "unused variable: `foo_test_a_test`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)
-       '(4 1 warning "function is never used: `foo_test_a`, #[warn(dead_code)] on by default"
-           :checker rust-cargo)))
+       '(2 16 warning "unused variable: `foo_test_a_test`" :checker rust-cargo)
+       '(2 16 info "#[warn(unused_variables)] on by default" :checker rust-cargo)
+       '(4 1 warning "function is never used: `foo_test_a`" :checker rust-cargo)
+       '(4 1 info "#[warn(dead_code)] on by default" :checker rust-cargo)))
 
     (let ((flycheck-rust-crate-type "example")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/examples/a.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_ex_a`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)
-       '(4 17 warning "unused variable: `foo_ex_a_test`, #[warn(unused_variables)] on by default"
-           :checker rust-cargo)))))
+       '(1 17 warning "unused variable: `foo_ex_a`" :checker rust-cargo)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)
+       '(4 17 warning "unused variable: `foo_ex_a_test`" :checker rust-cargo)
+       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo)))))
 
 (flycheck-ert-def-checker-test rust rust syntax-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
@@ -4012,8 +4012,8 @@ Why not:
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
-     '(4 9 warning "unused variable: `x`, #[warn(unused_variables)] on by default"
-         :checker rust))))
+     '(4 9 warning "unused variable: `x`" :checker rust)
+     '(4 9 info "#[warn(unused_variables)] on by default" :checker rust))))
 
 (flycheck-ert-def-checker-test rust rust note-and-help
   (let ((flycheck-disabled-checkers '(rust-cargo)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3734,6 +3734,7 @@ Why not:
      "language/r.R" 'R-mode
      '(1 28 info "Opening curly braces should never go on their own line and should always be followed by a new line."
          :checker r-lintr)
+     '(1 56 info "Put spaces around all infix operators." :checker r-lintr)
      '(4 6 warning "Do not use absolute paths." :checker r-lintr)
      '(7 5 error "unexpected end of input" :checker r-lintr))))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3517,7 +3517,7 @@ Why not:
 (flycheck-ert-def-checker-test php php syntax-error
   (flycheck-ert-should-syntax-check
    "language/php/syntax-error.php" 'php-mode
-   '(8 nil error "syntax error, unexpected ')', expecting '['" :checker php)))
+   '(8 nil error "Assignments can only happen to writable values" :checker php)))
 
 (flycheck-ert-def-checker-test (php php-phpcs php-phpmd) php nil
   :tags '(phpmd-xml checkstyle-xml)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2824,8 +2824,6 @@ evaluating BODY."
    "language/chef/recipes/error.rb" 'ruby-mode
    '(3 nil error "FC002: Avoid string interpolation where not required"
        :checker chef-foodcritic)
-   '(8 nil error "FC003: Check whether you are running with chef server before using server-specific features"
-       :checker chef-foodcritic)
    '(11 nil error "FC004: Use a service resource to start and stop services"
         :checker chef-foodcritic)))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3321,7 +3321,9 @@ Why not:
   ;; Silence JS2 and JS3 parsers
   (let ((js2-mode-show-parse-errors nil)
         (js2-mode-show-strict-warnings nil)
-        (js3-mode-show-parse-errors nil))
+        (js3-mode-show-parse-errors nil)
+        (flycheck-disabled-checkers
+         '(javascript-jscs javascript-eslint javascript-gjslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/syntax-error.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(3 4 error "Unmatched '('." :checker javascript-jshint :id "E019")
@@ -3333,7 +3335,8 @@ Why not:
 (flycheck-ert-def-checker-test javascript-jshint javascript nil
   :tags '(checkstyle-xml)
   (let ((flycheck-jshintrc "jshintrc")
-        (flycheck-disabled-checkers '(javascript-jscs)))
+        (flycheck-disabled-checkers
+         '(javascript-jscs javascript-eslint javascript-gjslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(4 9 warning "'foo' is defined but never used." :id "W098"
@@ -3353,8 +3356,8 @@ Why not:
      "language/javascript/warnings.js" flycheck-test-javascript-modes
      '(3 2 warning "Use the function form of 'use strict'." :id "strict"
          :checker javascript-eslint)
-     '(4 9 warning "'foo' is defined but never used." :id "no-unused-vars"
-         :checker javascript-eslint))))
+     '(4 9 warning "'foo' is assigned a value but never used."
+         :id "no-unused-vars" :checker javascript-eslint))))
 
 (flycheck-ert-def-checker-test javascript-jscs javascript nil
   :tags '(checkstyle-xml)
@@ -3363,7 +3366,9 @@ Why not:
          '(javascript-jshint javascript-eslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/style.js" flycheck-test-javascript-modes
-     '(4 3 error "Expected indentation of 2 characters"
+     '(4 1 error "validateIndentation: Invalid indentation character:"
+         :checker javascript-jscs)
+     '(4 1 error "validateIndentation: Expected indentation of 0 characters"
          :checker javascript-jscs))))
 
 (flycheck-ert-def-checker-test javascript-jscs javascript no-config
@@ -3379,10 +3384,11 @@ Why not:
     javascript complete-chain
   :tags '(checkstyle-xml)
   (let ((flycheck-jshintrc "jshintrc")
-        (flycheck-jscsrc "jscsrc"))
+        (flycheck-jscsrc "jscsrc")
+        (flycheck-disabled-checkers '(javascript-eslint javascript-gjslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
-     '(4 3 error "Expected indentation of 2 characters"
+     '(4 1 error "validateIndentation: Expected indentation of 0 characters"
          :checker javascript-jscs)
      '(4 9 warning "'foo' is defined but never used." :id "W098"
          :checker javascript-jshint))))
@@ -3394,11 +3400,11 @@ Why not:
         (flycheck-disabled-checkers '(javascript-jshint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/warnings.js" flycheck-test-javascript-modes
-     '(3 2 warning "Use the function form of \"use strict\"." :id "strict"
+     '(3 2 warning "Use the function form of 'use strict'." :id "strict"
          :checker javascript-eslint)
-     '(4 3 error "Expected indentation of 2 characters"
+     '(4 1 error "validateIndentation: Expected indentation of 0 characters"
          :checker javascript-jscs)
-     '(4 9 warning "\"foo\" is defined but never used" :id "no-unused-vars"
+     '(4 9 warning "'foo' is assigned a value but never used." :id "no-unused-vars"
          :checker javascript-eslint))))
 
 (flycheck-ert-def-checker-test javascript-standard javascript error
@@ -3407,9 +3413,11 @@ Why not:
      "language/javascript/style.js" flycheck-test-javascript-modes
      '(3 10 error "Missing space before function parentheses."
          :checker javascript-standard)
-     '(4 2 error "Expected indentation of 2 space characters but found 0."
+     '(4 2 error "Unexpected tab character."
          :checker javascript-standard)
-     '(4 6 error "\"foo\" is defined but never used"
+     '(4 2 error "Expected indentation of 2 spaces but found 1 tab."
+         :checker javascript-standard)
+     '(4 6 error "'foo' is assigned a value but never used."
          :checker javascript-standard)
      '(4 13 error "Strings must use singlequote."
          :checker javascript-standard)
@@ -3425,9 +3433,11 @@ Why not:
      "language/javascript/style.js" flycheck-test-javascript-modes
      '(3 10 error "Missing space before function parentheses."
          :checker javascript-standard)
-     '(4 2 error "Expected indentation of 2 space characters but found 0."
+     '(4 2 error "Unexpected tab character."
          :checker javascript-standard)
-     '(4 6 error "\"foo\" is defined but never used"
+     '(4 2 error "Expected indentation of 2 spaces but found 1 tab."
+         :checker javascript-standard)
+     '(4 6 error "'foo' is assigned a value but never used."
          :checker javascript-standard)
      '(4 13 error "Strings must use singlequote."
          :checker javascript-standard))))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4163,10 +4163,10 @@ Why not:
    "language/slim.slim" 'slim-mode
    `(2 1 error "Unexpected indentation" :checker slim)))
 
-(flycheck-ert-def-checker-test sqllint sql nil
+(flycheck-ert-def-checker-test sqlint sql nil
   (flycheck-ert-should-syntax-check
    "language/sql.sql" 'sql-mode
-   `(1 15 error "unterminated quoted string at or near \"';\n  \" (scan.l:1087)"
+   `(1 15 error "unterminated quoted string at or near \"';\n  \""
        :checker sql-sqlint)))
 
 (flycheck-ert-def-checker-test systemd-analyze systemd nil


### PR DESCRIPTION
I was bugged out by the fact we never actually run the whole integration test suite anywhere.  So I built a VM using Vagrant and added all the external tools.  Finding which tools and how to install them was a chore, but it all stands neatly in a single Vagrantfile.

I've fixed 31 failing tests (see other commits in PR).  2 tests are still failing and I'm not sure if that's due to upstream bugs or obsolete tests.

- `go-build/missing-package` fails because `go build` ignores the GOPATH environment variable
- `ruby-rubylint/syntax-error` fails with a backtrace from `rubylint`

Are @flycheck/go and @flycheck/ruby able to reproduce the failures above?

6 tests are still skipped:
- 2 tests due to `javascript-gjslint` being uninstalled.  As far as I can tell, `gjslint` is deprecated and unvailable from the URL in the checker docstring.  The page suggests to use lints from the Closure compiler instead.
- 2 tests due to `verilog-verilator` being uninstalled.  It's available in Arch AUR, but fails to build due to an upstream bug.
- 1 test due to `rpm-rpmlint` being uninstalled.  I found a github repo, but I'm missing the rpm python bindings.
- 1 `puppet` test which is intended to skip for puppet <= 4.0

@flycheck/javascript: should we drop the gjslint checker?  Or should we change it to use Closure compiler?  Or is everyone using eslint these days? 

If you have Vagrant and VirtualBox installed, using the VM to run the full suite is as simple as:
```
cd flycheck
vagrant up
vagrant ssh --command 'cd /vagrant; make integ'
```
**Warning**: provisioning the VM for the first time takes around 1 hour.  After that, booting should only take a few seconds.  Though since it's an Arch system, I've set it up to upgrade at boot, and that can take some time if you seldom use it.  Also, right now, it sits at 15Gb on my drive.

I'm by no means an expert in Vagrant or setting up VMs.  I just looked up enough info to make it work.  Here are some things I'm not sure about:
- Coq takes a bunch of time (and RAM!) to compile.  The website does not seem to provide Linux binaries :(
- There are 3 different versions of GHC installed (7.10, 8.01, 8.02).  One used by stack, one used by hadolint, one used by the `haskell-ghc` tests.
- Ideally Travis should run the integration tests, but due to the time it takes to install all the tools, I'm not sure it's worth it to tear it down/bring it up on each pull request.  That's why I'm pushing the Vagrantfile, so at least anyone willing can use it.

Should help with #1163.