### PR TITLE
Remove javascript-gjslint checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - **Breaking changes**
 
   - ``rust-cargo`` now requires Rust 1.15 or newer [GH-1201]
+  - Remove javascript-gjslint checker
 
 - New syntax checkers:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -569,8 +569,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: Javascript
 
-   Flycheck checks Javascript with one of `javascript-eslint`,
-   `javascript-jshint` or `javascript-gjslint`, and then with `javascript-jscs`.
+   Flycheck checks Javascript with one of `javascript-eslint` or
+   `javascript-jshint`, and then with `javascript-jscs`.
 
    Alternatively `javascript-standard` is used instead all of the former ones.
 
@@ -597,14 +597,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Whether to extract Javascript from HTML before linting.
 
       .. syntax-checker-config-file:: flycheck-jshintrc
-
-   .. syntax-checker:: javascript-gjslint
-
-      Lint with `Closure Linter`_.
-
-      .. _Closure Linter: https://developers.google.com/closure/utilities
-
-      .. syntax-checker-config-file:: flycheck-gjslintrc
 
    .. syntax-checker:: javascript-jscs
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -195,7 +195,6 @@ attention to case differences."
     html-tidy
     javascript-eslint
     javascript-jshint
-    javascript-gjslint
     javascript-jscs
     javascript-standard
     json-jsonlint
@@ -7777,22 +7776,6 @@ See URL `https://github.com/eslint/eslint'."
         :label "config file"
         :message (if have-config "found" "missing")
         :face (if have-config 'success '(bold error)))))))
-
-(flycheck-def-config-file-var flycheck-gjslintrc javascript-gjslint ".gjslintrc"
-  :safe #'stringp)
-
-(flycheck-define-checker javascript-gjslint
-  "A Javascript syntax and style checker using Closure Linter.
-
-See URL `https://developers.google.com/closure/utilities'."
-  :command ("gjslint" "--unix_mode"
-            (config-file "--flagfile" flycheck-gjslintrc)
-            source)
-  :error-patterns ((warning
-                    line-start (file-name) ":" line ":("
-                    (id (one-or-more digit)) ") " (message) line-end))
-  :modes (js-mode js2-mode js3-mode rjsx-mode)
-  :next-checkers ((warning . javascript-jscs)))
 
 (defun flycheck-parse-jscs (output checker buffer)
   "Parse JSCS OUTPUT from CHECKER and BUFFER.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3364,21 +3364,11 @@ Why not:
      '(4 9 warning "'foo' is defined but never used." :id "no-unused-vars"
          :checker javascript-eslint))))
 
-(flycheck-ert-def-checker-test javascript-gjslint javascript nil
-  (let ((flycheck-disabled-checkers
-         '(javascript-jshint javascript-eslint javascript-jscs)))
-    (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
-     '(4 nil warning "Single-quoted string preferred over double-quoted string."
-         :id "0131" :checker javascript-gjslint)
-     '(4 nil warning "Extra space before \"]\""
-         :id "0001" :checker javascript-gjslint))))
-
 (flycheck-ert-def-checker-test javascript-jscs javascript nil
   :tags '(checkstyle-xml)
   (let ((flycheck-jscsrc "jscsrc")
         (flycheck-disabled-checkers
-         '(javascript-jshint javascript-eslint javascript-gjslint)))
+         '(javascript-jshint javascript-eslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/style.js" flycheck-test-javascript-modes
      '(4 3 error "Expected indentation of 2 characters"
@@ -3387,7 +3377,7 @@ Why not:
 (flycheck-ert-def-checker-test javascript-jscs javascript no-config
   :tags '(checkstyle-xml)
   (let ((flycheck-disabled-checkers
-         '(javascript-jshint javascript-eslint javascript-gjslint)))
+         '(javascript-jshint javascript-eslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/style.js" flycheck-test-javascript-modes
      '(1 nil warning "No JSCS configuration found.  Set `flycheck-jscsrc' for JSCS"
@@ -3418,20 +3408,6 @@ Why not:
          :checker javascript-jscs)
      '(4 9 warning "\"foo\" is defined but never used" :id "no-unused-vars"
          :checker javascript-eslint))))
-
-(flycheck-ert-def-checker-test (javascript-gjslint javascript-jscs)
-    javascript complete-chain
-  :tags '(checkstyle-xml)
-  (let ((flycheck-jscsrc "jscsrc")
-        (flycheck-disabled-checkers '(javascript-jshint javascript-eslint)))
-    (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
-     '(4 nil warning "Single-quoted string preferred over double-quoted string."
-         :id "0131" :checker javascript-gjslint)
-     '(4 nil warning "Extra space before \"]\""
-         :id "0001" :checker javascript-gjslint)
-     '(4 3 error "Expected indentation of 2 characters"
-         :checker javascript-jscs))))
 
 (flycheck-ert-def-checker-test javascript-standard javascript error
   (let ((flycheck-checker 'javascript-standard))


### PR DESCRIPTION
The linter is deprecated, as explained [there](https://developers.google.com/closure/utilities/).

However, the page also mentions that you can pass a flag to the Closure compiler to get lints.  I haven't tested it, but maybe we could adapt the checker to work with that instead.

I have no experience with either, so I'll let @flycheck/javascript chime in.