### PR TITLE
Add an error-explainer for rpm-rpmlint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@
 - New features:
 
   - Add ``flycheck-tslint-args`` to pass additional arguments to tslint [GH-1186]
+  - Add an error explainer to the ``rpm-rpmlint`` checker using
+    ``rpmlint -I`` [GH-1235]
 
 - Improvements:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -8642,6 +8642,13 @@ See URL `https://sourceforge.net/projects/rpmlint/'."
       (unless (flycheck-error-line err)
         (setf (flycheck-error-line err) 1)))
     errors)
+  :error-explainer
+  (lambda (error)
+    (-when-let* ((error-message (flycheck-error-message error))
+                 (message-id (save-match-data (string-match "\\([^ ]+\\)" error-message)
+                                              (match-string 1 error-message))))
+      (with-output-to-string
+        (call-process "rpmlint" nil standard-output nil "-I" message-id))))
   :modes (sh-mode rpm-spec-mode)
   :predicate (lambda () (or (not (eq major-mode 'sh-mode))
                             ;; In `sh-mode', we need the proper shell


### PR DESCRIPTION
rpmlint's warnings/errors are very terse by default. For example, if the file contains the following:

    Source0: foobar.tar.xz

The warning shown by flycheck is:

    invalid-url Source0: foobar.tar.xz

The explainer helps clarify the root cause:

    invalid-url:
    The value should be a valid, public HTTP, HTTPS, or FTP URL.
