### PR TITLE
Cache stable Emacs binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ matrix:
 cache:
   - pip
   - directories:
-      - .cask/
+      # Cache stable Emacs binaries
+      - "$HOME/emacs/"
+      # Cache Flycheck dependencies
+      - ".cask/"
+      # Cache Cask bootstrap dependencies
+      - "$HOME/.emacs.d/.cask"
 env:
   matrix:
     - EMACS_VERSION=24.4


### PR DESCRIPTION
Following changes in flycheck/emacs-travis, we can now cache the Emacs stable
build after the ./configure step.  This shaves off ~1min on each build.

In addition to caching dependencies from Cask, we did not previously cache
bootstrapping packages used by Cask itself.  Doing that shaves another 30sec off
the build.