### PR TITLE
Use standard input in nix checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8739,11 +8739,16 @@ See URL `https://github.com/mivok/markdownlint'."
   "Nix checker using nix-instantiate.
 
 See URL `https://nixos.org/nix/manual/#sec-nix-instantiate'."
-  :command ("nix-instantiate" "--parse" source-inplace)
+  :command ("nix-instantiate" "--parse" "-")
+  :standard-input t
   :error-patterns
   ((error line-start
           "error: " (message) " at " (file-name) ":" line ":" column
           line-end))
+  :error-filter
+  (lambda (errors)
+    (flycheck-sanitize-errors
+     (flycheck-remove-error-file-names "(string)" errors)))
   :modes nix-mode)
 
 (defun flycheck-locate-sphinx-source-directory ()


### PR DESCRIPTION
Hi:

I've changed the nix checker to use standard input

```
make SELECTOR='(tag checker-nix)' integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-buttercup.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-nix))'
Running tests on Emacs 26.0.50, built at 2017-04-19
Running 1 tests (2017-05-02 20:01:27-0500)
   passed  1/1  flycheck-define-checker/nix/default

Ran 1 tests, 1 results as expected (2017-05-02 20:01:28-0500)

```
