### PR TITLE
Fix flake8 make maint check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 # -*- mode: conf; -*-
 [flake8]
 # Ignore all missing docstrings for now, until we have docstrings everywhere
-ignore = D100,D101,D102,D103,D105
+ignore = D100,D101,D102,D103,D105,D401
 exclude = test/resources
 inline-quotes = '

--- a/maint/requirements.txt
+++ b/maint/requirements.txt
@@ -9,6 +9,3 @@ pep8>=1.7
 pep8-naming>=0.4
 flake8-quotes>=0.8
 flake8_docstrings>=1.0
-# pydocstyle 1.1.0 breaks flake8_docstrings currently, see
-# https://gitlab.com/pycqa/flake8-docstrings/issues/16
-pydocstyle<1.1.0


### PR DESCRIPTION
CI was failing in the LINT build because of updated packages.

This fix is to remove the workaround for pydocstyle.

The latest flake8_docstrings requires pydocstyle 2.0.0, so the workaround
actually breaks our `make -C maint check`.

Besides, the issue with pydocstyle was fixed in 1.1.1.