### PR TITLE
Fix calling display-error twice after next-error

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4391,6 +4391,8 @@ Intended for use with `next-error-function'."
       (flycheck-jump-to-error err)
     (user-error "No more Flycheck errors")))
 
+(defvar-local flycheck--display-error-caused-by-next-error nil)
+
 (defun flycheck-next-error (&optional n reset)
   "Visit the N-th error from the current point.
 
@@ -4403,7 +4405,8 @@ position."
     ;; Universal prefix argument means reset
     (setq reset t n nil))
   (flycheck-next-error-function n reset)
-  (flycheck-display-error-at-point))
+  (flycheck-display-error-at-point)
+  (setq flycheck--display-error-caused-by-next-error t))
 
 (defun flycheck-previous-error (&optional n)
   "Visit the N-th previous error.
@@ -4946,10 +4949,13 @@ non-nil."
 (defun flycheck-display-error-at-point-soon ()
   "Display the first error message at point in minibuffer delayed."
   (flycheck-cancel-error-display-error-at-point-timer)
-  (when (flycheck-overlays-at (point))
+  (when (and (flycheck-overlays-at (point))
+             (not flycheck--display-error-caused-by-next-error))
     (setq flycheck-display-error-at-point-timer
           (run-at-time flycheck-display-errors-delay nil
-                       'flycheck-display-error-at-point))))
+                       'flycheck-display-error-at-point)))
+  (setq flycheck--display-error-caused-by-next-error nil))
+
 
 
 ;;; Functions to display errors


### PR DESCRIPTION
So, I noticed this bug while working on #1215.  This is a separate PR including just this fix.  I'm reproducing the message to explain the error here:

Since #1042, `flycheck-next-error` is intended to display the errors at point immediately.  However, since `-display-error-at-point-soon` is also on `post-command-hook`, invoking `flycheck-next-error` will actually trigger `-display-errors-function` *twice*.  Here is the timeline of events:
```
flycheck-next-error is called
- triggers display-error-at-point ---> errors are displayed
post-command-hook runs
- triggers display-error-at-point-soon
  - sets a timer for `display-error-at-point`
[0.9 seconds later]
- display-error-at-point is called by the timer ---> errors are displayed
```

For the default behavior of echoing messages in the minibuffer, this is unnoticeable.  For inline error messages (see #1215), this means adding the overlays, then removing and adding them again after 0.9 seconds (the default delay for `-display-error-at-point-soon`).  It might affect other extensions (like [flycheck-pos-tip](https://github.com/flycheck/flycheck-pos-tip)); I have not tested.

I've sketched a fix in the first commit here.  The idea is simple: don't call `display-error-soon` if `next-error` was the last command called.  The implementation relies on setting a flag and clearing it at the end of `post-command-hook`.  Better ideas are welcome.