### PR TITLE
Add the ability to group related errors

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5702,6 +5702,7 @@ https://github.com/rust-lang/rust/blob/master/src/libsyntax/json.rs#L67-L139"
         (primary-filename)
         (primary-line)
         (primary-column)
+        (group (make-symbol "group"))
         (spans)
         (children)
         (errors))
@@ -5761,7 +5762,8 @@ https://github.com/rust-lang/rust/blob/master/src/libsyntax/json.rs#L67-L139"
           :id error-code
           :checker checker
           :buffer buffer
-          :filename .file_name)
+          :filename .file_name
+          :group group)
          errors)))
 
     ;; Then we turn children messages into flycheck errors pointing to the
@@ -5778,7 +5780,8 @@ https://github.com/rust-lang/rust/blob/master/src/libsyntax/json.rs#L67-L139"
           :id error-code
           :checker checker
           :buffer buffer
-          :filename primary-filename)
+          :filename primary-filename
+          :group group)
          errors)))
 
     ;; If there are no spans, the error is not associated with a specific
@@ -5793,7 +5796,8 @@ https://github.com/rust-lang/rust/blob/master/src/libsyntax/json.rs#L67-L139"
              error-message
              :id error-code
              :checker checker
-             :buffer buffer)
+             :buffer buffer
+             :group group)
             errors))
     (nreverse errors)))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -2894,8 +2894,11 @@ Slots:
      columns must be adjusted for Flycheck, see
      `flycheck-increment-error-columns'.
 
+`message' (optional)
+     The error message as a string, if any.
+
 `level'
-     The error level, as either `warning' or `error'.
+     The error level, as either `info', `warning' or `error'.
 
 `id' (optional)
      An ID identifying the kind of error."


### PR DESCRIPTION
The use case is mainly for some Rust errors, like lifetime and borrowing errors,
where multiple individual errors are actually part of the same "diagnostic" for
only one issue.  Here is an example of rustc output:

```
error[E0382]: use of moved value: `x`
 --> main.rs:9:7
  |
8 |   let y = x;          // note: x's lifetime ends here
  |       - value moved here
9 |   let z = x;          // error: can no longer move x
  |       ^ value used here after move
  |
  = note: move occurs because `x` has type `NonPOD`, which does not implement the `Copy` trait
```

In the JSON output parsed by Flycheck, this one diagnostic corresponds to three
errors and one note, all of which are turned into individual flycheck-error
objects.  Consequently, the relationship between these errors is lost, and this
could confuse users not familiar with these kinds of errors.

To preserve the relationship between errors, this commit adds a `group` property
to flycheck-error objects.  Checkers should use the same `group` value for
related errors.

This commits also adds a function to get related errors,
`flycheck-errors-from-group`.  This allows extensions to display related errors
as they see fit.