### PR TITLE
Allowing shellcheck to follow files (SC1091)

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9486,6 +9486,7 @@ By default, no warnings are excluded."
 
 See URL `https://github.com/koalaman/shellcheck/'."
   :command ("shellcheck"
+            "-x"
             "--format" "checkstyle"
             "--shell" (eval (symbol-name sh-shell))
             (option "--exclude" flycheck-shellcheck-excluded-warnings list


### PR DESCRIPTION
Getting rid of Shellcheck warning SC1091 as documented in https://github.com/koalaman/shellcheck/wiki/SC1091