### PR TITLE
Added option to follow external sources in shellcheck

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1165,6 +1165,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. defcustom:: flycheck-shellcheck-excluded-warnings
 
          A list of excluded warnings.
+         
+       .. defcustom:: flycheck-shellcheck-follow-sources
+       
+         Allow shellcheck to read sourced files.
 
 .. supported-language:: Slim
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1166,7 +1166,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          A list of excluded warnings.
          
-       .. defcustom:: flycheck-shellcheck-follow-sources
+      .. defcustom:: flycheck-shellcheck-follow-sources
        
          Allow shellcheck to read sourced files.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -9549,7 +9549,7 @@ or added as a shellcheck directive before the source command
 (e.g. # shellcheck source=/full/path/to/file.txt)."
   :type 'boolean
   :safe #'booleanp
-  :package-version '(flycheck . "0.31"))
+  :package-version '(flycheck . "0.21"))
 
 (flycheck-define-checker sh-shellcheck
   "A shell script syntax and style checker using Shellcheck.

--- a/flycheck.el
+++ b/flycheck.el
@@ -9538,6 +9538,19 @@ By default, no warnings are excluded."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.21"))
 
+(flycheck-def-option-var flycheck-shellcheck-follow-sources t sh-shellcheck
+  "Whether to follow external sourced files in scripts.
+
+Shellcheck will follow and parse sourced files so long as
+a pre-runtime resolvable path to the file is present. This
+can either be part of the source command itself
+(e.g. source /full/path/to/file.txt)
+or added as a shellcheck directive before the source command
+(e.g. # shellcheck source=/full/path/to/file.txt)."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "0.31"))
+
 (flycheck-define-checker sh-shellcheck
   "A shell script syntax and style checker using Shellcheck.
 
@@ -9545,6 +9558,7 @@ See URL `https://github.com/koalaman/shellcheck/'."
   :command ("shellcheck"
             "--format" "checkstyle"
             "--shell" (eval (symbol-name sh-shell))
+            (option-flag "--external-sources" flycheck-shellcheck-follow-sources)
             (option "--exclude" flycheck-shellcheck-excluded-warnings list
                     flycheck-option-comma-separated-list)
             "-")

--- a/flycheck.el
+++ b/flycheck.el
@@ -9549,7 +9549,7 @@ or added as a shellcheck directive before the source command
 (e.g. # shellcheck source=/full/path/to/file.txt)."
   :type 'boolean
   :safe #'booleanp
-  :package-version '(flycheck . "0.21"))
+  :package-version '(flycheck . "0.31"))
 
 (flycheck-define-checker sh-shellcheck
   "A shell script syntax and style checker using Shellcheck.


### PR DESCRIPTION
Added the option to follow external sources in Shellcheck as requested in #1011. Created a Flycheck option variable which was mentioned in #1251 and missing from #1254. Fixed from #1255.
