### PR TITLE
Improve haskell default directory detection

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7734,21 +7734,23 @@ contains a cabal file."
   (pcase checker
     (`haskell-stack-ghc
      (or
-      (locate-dominating-file (buffer-file-name) "stack.yaml")
+      (when (buffer-file-name)
+        (locate-dominating-file (buffer-file-name) "stack.yaml"))
       (-when-let* ((stack (funcall flycheck-executable-find "stack"))
                    (output (ignore-errors
                              (process-lines stack "path" "--project-root")))
                    (stack-dir (car output)))
         (and (file-directory-p stack-dir) stack-dir))))
     (_
-     (locate-dominating-file
-      (file-name-directory (buffer-file-name))
-      (lambda (dir)
-        (directory-files dir
-                         nil ;; use full paths
-                         ".+\\.cabal\\'"
-                         t ;; do not sort result
-                         ))))))
+     (when (buffer-file-name)
+       (locate-dominating-file
+        (file-name-directory (buffer-file-name))
+        (lambda (dir)
+          (directory-files dir
+                           nil ;; use full paths
+                           ".+\\.cabal\\'"
+                           t ;; do not sort result
+                           )))))))
 
 (flycheck-define-checker haskell-stack-ghc
   "A Haskell syntax and type checker using `stack ghc'.


### PR DESCRIPTION
I found out that `(buffer-file-name)` can return `nil` for temporary buffers, which leads to errors. Also it seemed like good idea to allow stack files like `stack-7.10.yaml` in addition to just `stack.yaml` for default directory searching purposes.