### PR TITLE
cargo-rust: remove arguments "-Z no-trans" as they are going away

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9110,7 +9110,7 @@ This syntax checker requires Rust 1.15 or newer.  See URL
                     flycheck-rust-binary-name))
             "--message-format=json"
             (eval flycheck-cargo-rustc-args)
-            "--" "-Z" "no-trans"
+            "--"
             ;; Passing the "--test" flag when the target is a test binary or
             ;; bench is unnecessary and triggers an error.
             (eval (when flycheck-rust-check-tests


### PR DESCRIPTION
The current code generates the following warning when used with
stable rust:
warning: the option `Z` is unstable and should only be used on the
         nightly compiler, but it is currently accepted for backwards
         compatibility; this will soon change, see issue #31847 for
         more details

See also:
- rust-lang/rust#31847
- rust-lang/rust#41751
