### PR TITLE
Remove mentions to the @emacs_flycheck twitter account

### DIFF
--- a/doc/_templates/about.html
+++ b/doc/_templates/about.html
@@ -30,12 +30,6 @@
 
 {% if not flycheck_offline_html %}
 <p>
-    <a href="https://twitter.com/emacs_flycheck" class="twitter-follow-button"
-       data-show-count="false" data-dnt="true">Follow @emacs_flycheck</a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-</p>
-
-<p>
     <a href="https://gitter.im/flycheck/flycheck">
         <img src="https://img.shields.io/gitter/room/flycheck/flycheck.svg?maxAge=2592000" />
     </a>

--- a/doc/community/get-help.rst
+++ b/doc/community/get-help.rst
@@ -4,9 +4,6 @@
  Get help
 ==========
 
-Follow `@emacs_flycheck`_ on Twitter for updates.  Feel free to mention the
-account for questions.
-
 Please ask questions about Flycheck on `Stack Exchange`_ or in our `Gitter
 chat`_.  We try to answer all questions as fast and as precise as possible.
 
@@ -18,4 +15,3 @@ Please follow our :ref:`Code of Conduct <flycheck-conduct>` in all these places.
 
 .. _Stack Exchange: https://emacs.stackexchange.com/questions/tagged/flycheck
 .. _Gitter chat: https://gitter.im/flycheck/flycheck
-.. _@emacs_flycheck: https://twitter.com/emacs_flycheck

--- a/doc/contributor/maintaining.rst
+++ b/doc/contributor/maintaining.rst
@@ -280,13 +280,12 @@ Once the script is completed please
    release.  Don’t forget to add a link to the complete changelog and upload the
    package TAR file.
 2. Enable the new release on the ReadTheDocs `versions dashboard`_.
-3. Announce the new release in our Gitter_ channel, on `emacs_flycheck`_ Twitter
-   and wherever else you see fit.
+3. Announce the new release in our Gitter_ channel, and wherever else you see
+   fit.
 
 .. _release information: https://github.com/flycheck/flycheck/releases
 .. _versions dashboard: https://readthedocs.org/dashboard/flycheck/versions/
 .. _Gitter: https://gitter.im/flycheck/flycheck
-.. _emacs_flycheck: https://twitter.com/emacs_flycheck
 
 New maintainers
 ===============
@@ -302,6 +301,5 @@ Once merged please also
   organisation.  This does not award additional privileges, it's just to support
   ``@flycheck/maintainers`` mentions for the sake of convenience,
 - invite the new maintainer to the internal `Maintainers channel`_ on Gitter,
-- and announce the new maintainer on Flycheck's Twitter account.
 
 .. _Maintainers channel: https://gitter.im/flycheck/maintainers

--- a/maint/release.py
+++ b/maint/release.py
@@ -189,7 +189,7 @@ def main():
 * add information about the release to https://github.com/flycheck/flycheck/releases/edit/{0}
 * upload `dist/flycheck-{0}.tar,
 * enable version {0} on https://readthedocs.org/dashboard/flycheck/versions/, and
-* announce the release in the flycheck/flycheck Gitter channel and the @emacs_flycheck Twitter account.
+* announce the release in the flycheck/flycheck Gitter channel.
 """.format(next_version))       # noqa: E501
 
     except CannotReleaseError as error:


### PR DESCRIPTION
Since the account doesn't exist anymore.

I am fine not having to deal with a twitter account, and don't really see the added value.  But I'm opening as a PR to let others chime in.  If you think we should have a twitter account for Flycheck, then let us know.  