### PR TITLE
Pass current directory to gosimple

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7587,7 +7587,9 @@ See URL `https://github.com/mdempsky/unconvert'."
 Requires Go 1.6 or newer. See URL `https://github.com/dominikh/go-tools'."
   :command ("gosimple"
             (option-list "-tags=" flycheck-go-build-tags concat)
-            source)
+            ;; Run in current directory to make gosimple aware of symbols
+            ;; declared in other files.
+            ".")
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ": " (message) line-end))
   :modes go-mode)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3197,7 +3197,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (flycheck-ert-with-env
       `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
     (flycheck-ert-should-syntax-check
-     "language/go/src/gosimple/gosimple.go" 'go-mode
+     "language/go/src/gosimple/gosimple1.go" 'go-mode
      '(5 6 warning "should omit values from range; this loop is equivalent to `for range ...` (S1005)"
          :checker go-gosimple))))
 

--- a/test/resources/language/go/src/gosimple/gosimple.go
+++ b/test/resources/language/go/src/gosimple/gosimple.go
@@ -1,7 +1,0 @@
-package main
-
-func main() {
-	xs := []int{1, 2, 3}
-	for _ = range xs {
-	}
-}

--- a/test/resources/language/go/src/gosimple/gosimple1.go
+++ b/test/resources/language/go/src/gosimple/gosimple1.go
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+	// xs is declared in a different file to ensure that test fails if gosimple is called incorrectly
+	for _ = range xs {
+	}
+}

--- a/test/resources/language/go/src/gosimple/gosimple2.go
+++ b/test/resources/language/go/src/gosimple/gosimple2.go
@@ -1,0 +1,3 @@
+package main
+
+var xs = []int{1, 2, 3}


### PR DESCRIPTION
This is necessary to make gosimple aware of symbols declared in other files.
