### PR TITLE
Update copyright years and maintainers for relevant files

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,2 @@
-Clément Pit--Claudel <hidden@example.com> (@cpitclaudel)
+Clément Pit-Claudel <hidden@example.com> (@cpitclaudel)
 fmdkdd <hidden@example.com> (@fmdkdd)

--- a/doc/community/people.rst
+++ b/doc/community/people.rst
@@ -12,7 +12,7 @@ Teams
 Maintainers
 -----------
 
-* **Clément Pit--Claudel** (:gh:`cpitclaudel`, owner)
+* **Clément Pit-Claudel** (:gh:`cpitclaudel`, owner)
 * **fmdkdd** (:gh:`fmdkdd`, owner)
 
 We maintain Flycheck and all official extensions within the `Flycheck
@@ -165,7 +165,7 @@ to Flycheck:
 * Alex Reed (:gh:`acr4`)
 * Atila Neves (:gh:`atilaneves`)
 * Bozhidar Batsov (:gh:`bbatsov`)
-* Clément Pit--Claudel (:gh:`cpitclaudel`, maintainer, owner)
+* Clément Pit-Claudel (:gh:`cpitclaudel`, maintainer, owner)
 * Cristian Capdevila (:gh:`capdevc`)
 * Damon Haley (:gh:`dhaley`)
 * David Caldwell (:gh:`caldwell`)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,7 @@ extensions = [
 
 # Project metadata
 project = 'Flycheck'
-copyright = ' 2014-2016, Sebastian Wiesner and Flycheck contributors'
+copyright = ' 2014-2017, Sebastian Wiesner and Flycheck contributors'
 author = 'Sebastian Wiesner'
 
 

--- a/flycheck-buttercup.el
+++ b/flycheck-buttercup.el
@@ -1,8 +1,11 @@
 ;;; flycheck-buttercup.el --- Flycheck: Extensions to Buttercup -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
+;; Maintainer: Clément Pit-Claudel <clement.pitclaudel@live.com>
+;;             fmdkdd <fmdkdd@gmail.com>
 ;; Keywords: lisp, tools
 
 ;; This file is not part of GNU Emacs.

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -1,9 +1,11 @@
 ;;; flycheck-ert.el --- Flycheck: ERT extensions  -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
-;; Maintainer: Sebastian Wiesner <swiesner@lunaryorn.com>
+;; Maintainer: Clément Pit-Claudel <clement.pitclaudel@live.com>
+;;             fmdkdd <fmdkdd@gmail.com>
 ;; URL: https://github.com/flycheck/flycheck
 
 ;; This file is not part of GNU Emacs.

--- a/flycheck.el
+++ b/flycheck.el
@@ -1,11 +1,12 @@
 ;;; flycheck.el --- On-the-fly syntax checking -*- lexical-binding: t; -*-
 
-;; Copyright (c) 2012-2016 Sebastian Wiesner and Flycheck contributors
+;; Copyright (C) 2017 Flycheck contributors
+;; Copyright (C) 2012-2016 Sebastian Wiesner and Flycheck contributors
 ;; Copyright (C) 2013, 2014 Free Software Foundation, Inc.
 ;;
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
-;; Maintainer: Sebastian Wiesner <swiesner@lunaryorn.com>
-;;             Clément Pit--Claudel <clement.pitclaudel@live.com>
+;; Maintainer: Clément Pit-Claudel <clement.pitclaudel@live.com>
+;;             fmdkdd <fmdkdd@gmail.com>
 ;; URL: http://www.flycheck.org
 ;; Keywords: convenience, languages, tools
 ;; Version: 31-cvs

--- a/maint/release.py
+++ b/maint/release.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright (C) 2017 Flycheck contributors
 # Copyright (C) 2016 Sebastian Wiesner and Flycheck contributors
 
 # This file is not part of GNU Emacs.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1,9 +1,11 @@
 ;;; flycheck-test.el --- Flycheck: Unit test suite   -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
-;; Maintainer: Sebastian Wiesner <swiesner@lunaryorn.com>
+;; Maintainer: Clément Pit-Claudel <clement.pitclaudel@live.com>
+;;             fmdkdd <fmdkdd@gmail.com>
 ;; URL: https://github.com/flycheck/flycheck
 
 ;; This file is not part of GNU Emacs.

--- a/test/init.el
+++ b/test/init.el
@@ -1,9 +1,11 @@
 ;;; init.el --- Flycheck: Init file for testing      -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2015-2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
-;; Maintainer: Sebastian Wiesner <swiesner@lunaryorn.com>
+;; Maintainer: Clément Pit-Claudel <clement.pitclaudel@live.com>
+;;             fmdkdd <fmdkdd@gmail.com>
 ;; URL: https://www.flycheck.org
 
 ;; This file is not part of GNU Emacs.

--- a/test/run.el
+++ b/test/run.el
@@ -1,9 +1,11 @@
 ;;; run.el --- Flycheck: Test runner    -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2014-2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
-;; Maintainer: Sebastian Wiesner <swiesner@lunaryorn.com>
+;; Maintainer: Clément Pit-Claudel <clement.pitclaudel@live.com>
+;;             fmdkdd <fmdkdd@gmail.com>
 ;; URL: https://www.flycheck.org
 
 ;; This file is not part of GNU Emacs.

--- a/test/specs/languages/test-emacs-lisp.el
+++ b/test/specs/languages/test-emacs-lisp.el
@@ -1,5 +1,6 @@
 ;;; test-emacs-lisp.el --- Flycheck Specs: Emacs Lisp      -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Clément Pit-Claudel <clement.pitclaudel@live.com>

--- a/test/specs/languages/test-ruby.el
+++ b/test/specs/languages/test-ruby.el
@@ -1,5 +1,6 @@
 ;;; test-typescript.el --- Flycheck Specs: Ruby      -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Saša Jovanić <sasa@simplify.ba>

--- a/test/specs/languages/test-typescript.el
+++ b/test/specs/languages/test-typescript.el
@@ -1,5 +1,6 @@
 ;;; test-typescript.el --- Flycheck Specs: TypeScript      -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2017 Flycheck contributors
 ;; Copyright (C) 2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Saša Jovanić <info@simplify.ba>


### PR DESCRIPTION
All files that have been updated in 2017 now have an updated copyright notice.
The manual is a special case: it bears a single copyright notice at the bottom,
so this mark applies to all its pages.

Elisp packages containing the 'Maintainer' field have been updated.  Though,
another solution would be to replace them by a "see the MAINTAINERS file".

Better start using that `copyright-update` function in `before-save-hook` now.
