### PR TITLE
Use `cargo check` for rust-cargo checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 - **Breaking changes**
 
   - Remove javascript-jscs checker
+  - ``rust-cargo`` now requires Rust 1.17 or newer [GH-1289]
+  - Rename ``flycheck-cargo-rustc-args`` to ``flycheck-cargo-check-args``
+    [GH-1289]
+  - ``rust-cargo`` does not use the variable ``flycheck-rust-args`` anymore
+    [GH-1289]
 
 - New syntax checkers:
 
@@ -25,6 +30,7 @@
   - Flycheck will execute ``rubocop`` from directory where ``Gemfile`` is
     located. If ``Gemfile`` does not exist, old behaviour of running command
     from directory where ``.rubocop.yml`` is found will be used [GH-1368]
+  - ``rust-cargo`` now uses ``cargo check`` and ``cargo test`` [GH-1289]
 
 31 (Oct 07, 2017)
 =================

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1019,12 +1019,12 @@ to view the docstring of the syntax checker.  Likewise, you may use
                        rust
 
       Check syntax and types with the Rust_ compiler.  In a Cargo_ project the
-      compiler is invoked through ``cargo rustc`` to take Cargo dependencies
+      compiler is invoked through ``cargo check`` to take Cargo dependencies
       into account.
 
       .. note::
 
-         `rust-cargo` requires Rust 1.15 or newer.
+         `rust-cargo` requires Rust 1.17 or newer.
          `rust` requires Rust 1.7 or newer.
 
       .. _Cargo: http://doc.crates.io/index.html
@@ -1037,11 +1037,13 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. defcustom:: flycheck-rust-args
 
-         A list of additional arguments that are passed to rustc.
+         A list of additional arguments that are passed to rustc.  This option
+         is ignored by `rust-cargo`.
 
-      .. defcustom:: flycheck-cargo-rustc-args
+      .. defcustom:: flycheck-cargo-check-args
 
-         A list of additional arguments passed to the cargo rustc subcommand
+         A list of additional arguments passed to the ``cargo check``
+         subcommand.
 
       .. defcustom:: flycheck-rust-check-tests
 
@@ -1065,7 +1067,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. defcustom:: flycheck-rust-binary-name
 
-         The name of the binary to pass to ``cargo rustc --TARGET-TYPE``, as a
+         The name of the binary to pass to ``cargo check --TARGET-TYPE``, as a
          string.
 
          For `rust-cargo`, always required unless `flycheck-rust-crate-type` is

--- a/flycheck.el
+++ b/flycheck.el
@@ -9211,21 +9211,25 @@ See URL `http://jruby.org/'."
   :modes (enh-ruby-mode ruby-mode)
   :next-checkers ((warning . ruby-rubylint)))
 
-(flycheck-def-args-var flycheck-cargo-rustc-args (rust-cargo)
-  :package-version '(flycheck . "30"))
+(flycheck-def-args-var flycheck-cargo-check-args (rust-cargo)
+  :package-version '(flycheck . "32"))
 
-(flycheck-def-args-var flycheck-rust-args (rust-cargo rust)
+(flycheck-def-args-var flycheck-rust-args (rust)
   :package-version '(flycheck . "0.24"))
 
 (flycheck-def-option-var flycheck-rust-check-tests t (rust-cargo rust)
   "Whether to check test code in Rust.
 
-When non-nil, `rustc' is passed the `--test' flag, which will
-check any code marked with the `#[cfg(test)]' attribute and any
-functions marked with `#[test]'. Otherwise, `rustc' is not passed
-`--test' and test code will not be checked.  Skipping `--test' is
-necessary when using `#![no_std]', because compiling the test
-runner requires `std'."
+For the `rust' checker: When non-nil, `rustc' is passed the
+`--test' flag, which will check any code marked with the
+`#[cfg(test)]' attribute and any functions marked with
+`#[test]'. Otherwise, `rustc' is not passed `--test' and test
+code will not be checked.  Skipping `--test' is necessary when
+using `#![no_std]', because compiling the test runner requires
+`std'.
+
+For the `rust-cargo' checker: When non-nil, calls `cargo test
+--no-run' instead of `cargo check'."
   :type 'boolean
   :safe #'booleanp
   :package-version '("flycheck" . "0.19"))
@@ -9270,7 +9274,7 @@ for the `--crate-type' flag of rustc."
 (make-variable-buffer-local 'flycheck-rust-crate-type)
 
 (flycheck-def-option-var flycheck-rust-binary-name nil rust-cargo
-  "The name of the binary to pass to `cargo rustc --CRATE-TYPE'.
+  "The name of the binary to pass to `cargo check --CRATE-TYPE'.
 
 The value of this variable is a string denoting the name of the
 target to check: usually the name of the crate, or the name of
@@ -9320,24 +9324,22 @@ A valid Cargo target type is one of `lib', `bin', `example',
 (flycheck-define-checker rust-cargo
   "A Rust syntax checker using Cargo.
 
-This syntax checker requires Rust 1.15 or newer.  See URL
+This syntax checker requires Rust 1.17 or newer.  See URL
 `https://www.rust-lang.org'."
-  :command ("cargo" "rustc"
+  :command ("cargo"
+            (eval (if flycheck-rust-check-tests
+                      "test"
+                    "check"))
+            (eval (when flycheck-rust-check-tests
+                    "--no-run"))
             (eval (when flycheck-rust-crate-type
                     (concat "--" flycheck-rust-crate-type)))
             ;; All crate targets except "lib" need a binary name
             (eval (when (and flycheck-rust-crate-type
                              (not (string= flycheck-rust-crate-type "lib")))
                     flycheck-rust-binary-name))
-            "--message-format=json"
-            (eval flycheck-cargo-rustc-args)
-            "--"
-            ;; Passing the "--test" flag when the target is a test binary or
-            ;; bench is unnecessary and triggers an error.
-            (eval (when flycheck-rust-check-tests
-                    (unless (member flycheck-rust-crate-type '("test" "bench"))
-                      "--test")))
-            (eval flycheck-rust-args))
+            (eval flycheck-cargo-check-args)
+            "--message-format=json")
   :error-parser flycheck-parse-cargo-rustc
   :error-filter flycheck-rust-error-filter
   :error-explainer flycheck-rust-error-explainer

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4056,6 +4056,19 @@ The manifest path is relative to
        '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(4 17 info "to avoid this warning, consider using `_foo_ex_a_test` instead" :checker rust-cargo :id "unused_variables")))))
 
+(flycheck-ert-def-checker-test rust-cargo rust dev-dependencies
+  (let ((flycheck-disabled-checkers '(rust)))
+    (let ((flycheck-rust-crate-type "lib")
+          (flycheck-rust-check-tests t))
+      (flycheck-ert-cargo-clean "language/rust/dev-deps/Cargo.toml")
+      (flycheck-ert-should-syntax-check
+       "language/rust/dev-deps/src/lib.rs" 'rust-mode
+       '(2 1 warning "unused `#[macro_use]` import" :checker rust-cargo :id "unused_imports")
+       '(2 1 info "#[warn(unused_imports)] on by default" :checker rust-cargo :id "unused_imports")
+       '(8 9 warning "unused variable: `foo`" :checker rust-cargo :id "unused_variables")
+       '(8 9 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
+       '(8 9 info "to avoid this warning, consider using `_foo` instead" :checker rust-cargo :id "unused_variables")))))
+
 (flycheck-ert-def-checker-test rust rust syntax-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check

--- a/test/resources/language/rust/dev-deps/Cargo.lock
+++ b/test/resources/language/rust/dev-deps/Cargo.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = "dev-deps"
+version = "0.1.0"
+dependencies = [
+ "lazy_static 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum lazy_static 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2f61b8421c7a4648c391611625d56fdd5c7567da05af1be655fd8cacc643abb3"

--- a/test/resources/language/rust/dev-deps/Cargo.toml
+++ b/test/resources/language/rust/dev-deps/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dev-deps"
+version = "0.1.0"
+
+[dependencies]
+
+[dev-dependencies]
+lazy_static = "0.2.2"

--- a/test/resources/language/rust/dev-deps/src/lib.rs
+++ b/test/resources/language/rust/dev-deps/src/lib.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
+mod tests {
+  #[test]
+  fn it_works() {
+    let foo = 0;
+  }
+}

--- a/test/resources/language/rust/note-test/Cargo.lock
+++ b/test/resources/language/rust/note-test/Cargo.lock
@@ -1,4 +1,0 @@
-[[package]]
-name = "note-test"
-version = "0.1.0"
-

--- a/test/resources/language/rust/note-test/Cargo.toml
+++ b/test/resources/language/rust/note-test/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "note-test"
-version = "0.1.0"
-authors = ["Wilfred Hughes <me@wilfred.me.uk>"]
-
-[dependencies]
-
-[lib]
-crate-type = ["staticlib"]

--- a/test/resources/language/rust/note-test/src/lib.rs
+++ b/test/resources/language/rust/note-test/src/lib.rs
@@ -1,1 +1,0 @@
-// Deliberately empty file.


### PR DESCRIPTION
Now that `-Z no-trans` is not an option anymore in Rust 1.19, I had to disable the flag.

Unfortunately, that means longer wait time before getting error feedback in Flycheck, and also some unwanted side effects of actually compiling binaries.

Cargo has provided the `cargo check` command for a while now, but I've held onto using it as our main solution because I kept running into issues with it (flycheck/flycheck-rust/issues/51)... but now we have little choice. 

Here is a first implementation of `cargo check` that I made for flycheck/flycheck-rust/issues/55.  I'm using a combination of `cargo check` and `cargo test --no-run` for checking test code as well.

It has the following advantages:
- `cargo check` is the official way to get errors for a project, aside from the still-in-progress RLS.
- It supports arcane project setups that `-Zno-trans` did not.

However, there is one major hurdle right now: `cargo check` and `cargo test --no-run` report warnings only on the *first compilation*.  Subsequent calls do not report warnings (errors are always reported, because the compilation fails).  You would think that's actually not an issue, since we only call `cargo check` on file save, the file is touched, so `cargo check` will always compile and give the warnings.  But when testing, sometimes I see warnings, sometimes I don't.  This is unacceptable, and never happened with `-Zno-trans`.  

It also makes writing tests more cumbersome (I've worked around the lack of warnings by `cargo 
clean`ing the repo before each test).

Note that, without `-Zno-trans`, the *current* checkers (both `rust-cargo` and `rust`) exhibit the same behavior: warnings will only be emitted on the first successful compilation, and Flycheck will sometimes display them, but most likely will just flicker.  So at least, `cargo check` is not worst than what we have *right now*.

Also, we cannot pass arguments to `rustc` anymore.  The variable `flycheck-cargo-rustc-args` is of no use anymore, and `flycheck-rustc-args` will only be used by the plain `rust` checker.  That might break some setups.

TL;DR: For Rust 1.19 and up `cargo check` is the better solution, but overall it's worst than what we had since 1.15, unless we find a solution to the disappearing warnings. 