### PR TITLE
Quote checkdoc variables in form passed to subprocess

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7182,7 +7182,7 @@ See Info Node `(elisp)Byte Compilation'."
 
 Variables are taken from `flycheck-emacs-lisp-checkdoc-variables'."
   `(progn
-     ,@(seq-map (lambda (opt) `(setq-default ,opt ,(symbol-value opt)))
+     ,@(seq-map (lambda (opt) `(setq-default ,opt ',(symbol-value opt)))
                 (seq-filter #'boundp flycheck-emacs-lisp-checkdoc-variables))))
 
 (flycheck-define-checker emacs-lisp-checkdoc


### PR DESCRIPTION
Prevents invalid function evaluation of list variables like
`checkdoc-symbol-words'.

Fixes error when setting 

```elisp
(setq checkdoc-symbol-words '("top-level")) 
```

which results in:
_Suspicious state from syntax checker emacs-lisp-checkdoc: Flycheck checker emacs-lisp-checkdoc returned non-zero exit code 255\
, but its output contained no errors: Invalid function: "top-level"_ 