### PR TITLE
Add proselint checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@
   - Ruby with ``reek`` [GH-1244]
   - Go with ``megacheck`` [GH-1290]
   - LLVM IR with ``llc`` [GH-1302]
+  - Text prose with ``proselint`` [GH-1304]
 
 - New features:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1217,6 +1217,12 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _systemd-analyze: https://www.freedesktop.org/software/systemd/man/systemd-analyze.html
 
+.. supported-language:: Text
+
+   .. syntax-checker:: proselint
+
+      Check text prose with `Proselint <http://proselint.com/>`_.
+
 .. supported-language:: TeX/LaTeX
 
    Flycheck checks TeX and LaTeX with either `tex-chktex` or `tex-lacheck`.

--- a/flycheck.el
+++ b/flycheck.el
@@ -214,6 +214,7 @@ attention to case differences."
     php-phpmd
     php-phpcs
     processing
+    proselint
     protobuf-protoc
     pug
     puppet-parser
@@ -8446,6 +8447,40 @@ See https://github.com/processing/processing/wiki/Command-Line"
   :modes processing-mode
   ;; This syntax checker needs a file name
   :predicate (lambda () (buffer-file-name)))
+
+(defun flycheck-proselint-parse-errors (output checker buffer)
+  "Parse proselint json output errors from OUTPUT.
+
+CHECKER and BUFFER denoted the CHECKER that returned OUTPUT and
+the BUFFER that was checked respectively.
+
+See URL `http://proselint.com/' for more information about proselint."
+  (mapcar (lambda (err)
+            (let-alist err
+              (flycheck-error-new-at
+               .line
+               .column
+               (pcase .severity
+                 (`"suggestion" 'info)
+                 (`"warning"    'warning)
+                 (`"error"      'error)
+                 ;; Default to error
+                 (_             'error))
+               .message
+               :id .check
+               :buffer buffer
+               :checker checker)))
+          (let-alist (car (flycheck-parse-json output))
+            .data.errors)))
+
+(flycheck-define-checker proselint
+  "Flycheck checker using Proselint.
+
+See URL `http://proselint.com/'."
+  :command ("proselint" "--json" "-")
+  :standard-input t
+  :error-parser flycheck-proselint-parse-errors
+  :modes (text-mode markdown-mode gfm-mode))
 
 (flycheck-define-checker protobuf-protoc
   "A protobuf syntax checker using the protoc compiler.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3626,17 +3626,22 @@ Why not:
         :id "Generic.PHP.LowerCaseConstant.Found" :checker php-phpcs)))
 
 (flycheck-ert-def-checker-test proselint (text markdown) nil
-  (flycheck-ert-should-syntax-check
-   "language/text.txt" 'text-mode
-   '(1 7 warning "Substitute 'damn' every time you're inclined to write 'very;' your editor will delete it and the writing will be just as it should be."
-       :id "weasel_words.very"
-       :checker proselint)
-   '(2 4 warning "Redundancy. Use 'associate' instead of 'associate together'."
-       :id "redundancy.garner"
-       :checker proselint)
-   '(3 5 warning "Gender bias. Use 'lawyer' instead of 'lady lawyer'."
-       :id "sexism.misc"
-       :checker proselint)))
+  ;; Unset LC_ALL which is set to LC_ALL=C for other checkers in ./run.el,
+  ;; because Click, used by ProseLint, when running with python 3 will refuse to
+  ;; work unless an Unicode locale is exported. See:
+  ;; http://click.pocoo.org/5/python3/#python-3-surrogate-handling
+  (flycheck-ert-with-env '(("LC_ALL" . nil))
+    (flycheck-ert-should-syntax-check
+     "language/text.txt" 'text-mode
+     '(1 7 warning "Substitute 'damn' every time you're inclined to write 'very;' your editor will delete it and the writing will be just as it should be."
+         :id "weasel_words.very"
+         :checker proselint)
+     '(2 4 warning "Redundancy. Use 'associate' instead of 'associate together'."
+         :id "redundancy.garner"
+         :checker proselint)
+     '(3 5 warning "Gender bias. Use 'lawyer' instead of 'lady lawyer'."
+         :id "sexism.misc"
+         :checker proselint))))
 
 (flycheck-ert-def-checker-test processing processing syntax-error
   (flycheck-ert-should-syntax-check

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3625,6 +3625,19 @@ Why not:
    '(26 12 error "TRUE, FALSE and NULL must be lowercase; expected \"false\" but found \"FALSE\""
         :id "Generic.PHP.LowerCaseConstant.Found" :checker php-phpcs)))
 
+(flycheck-ert-def-checker-test proselint (text markdown) nil
+  (flycheck-ert-should-syntax-check
+   "language/text.txt" 'text-mode
+   '(1 7 warning "Substitute 'damn' every time you're inclined to write 'very;' your editor will delete it and the writing will be just as it should be."
+       :id "weasel_words.very"
+       :checker proselint)
+   '(2 4 warning "Redundancy. Use 'associate' instead of 'associate together'."
+       :id "redundancy.garner"
+       :checker proselint)
+   '(3 5 warning "Gender bias. Use 'lawyer' instead of 'lady lawyer'."
+       :id "sexism.misc"
+       :checker proselint)))
+
 (flycheck-ert-def-checker-test processing processing syntax-error
   (flycheck-ert-should-syntax-check
    "language/processing/syntax_error/syntax_error.pde" 'processing-mode

--- a/test/resources/language/text.txt
+++ b/test/resources/language/text.txt
@@ -1,0 +1,3 @@
+he is very smart
+we associate together
+The lady lawyer handled my case.


### PR DESCRIPTION
Hi:

This is a rebase of #939

Minor changes with respect to #939:

+ Use standard input
+ Added `gfm-mode` to `:modes`
+ Replaced `json-read-from-string` with `flycheck-parse-json`

Related:
+ https://github.com/melpa/melpa/pull/4938