### PR TITLE
Make sure that idle timer handlers run in the right buffer

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2744,12 +2744,14 @@ buffer."
           (flycheck-buffer-automatically 'new-line 'force-deferred)
         (setq flycheck-idle-change-timer
               (run-at-time flycheck-idle-change-delay nil
-                           #'flycheck-handle-idle-change))))))
+                           #'flycheck-handle-idle-change (current-buffer)))))))
 
-(defun flycheck-handle-idle-change ()
-  "Handle an expired idle time since the last change."
-  (flycheck-clear-idle-change-timer)
-  (flycheck-buffer-automatically 'idle-change))
+(defun flycheck-handle-idle-change (buffer)
+  "Handle an expired idle timer in BUFFER since the last change."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (flycheck-clear-idle-change-timer)
+      (flycheck-buffer-automatically 'idle-change))))
 
 (defun flycheck-handle-save ()
   "Handle a save of the buffer."


### PR DESCRIPTION
This needs careful review, but at least I have a reasonably simple repro. This problem is the Flycheck side of https://github.com/FStarLang/fstar-mode.el/issues/73 , and it causes Flycheck to repeatedly re-check the same buffer, in a loop.

There's an easy way to see a limited form of this issue; I'll explain how to get the loop after that:

* Create two buffers with Flycheck enabled (say, in Python mode)
* Make a change in one and immediately change to the other (in less `flycheck-idle-change` seconds)
* Observe that Flycheck runs in the current buffer, not in the one that was modified.

This yields a loop when the error parser of a checker creates a buffer in which Flycheck can run:

1. Start a generic check
2. In e.g. the error parser, create a temporary buffer to process the checker's output
3. Put that temporary buffer in a mode that can run Flycheck
4. Make modifications in the temporary buffer

In that scenario, changes in the temporary buffer will cause an idle timer to be registered, and when the idle timer fires Flycheck will run a new check in the *current* buffer (not in the one where the change happened).  This run will cause a new timer to be scheduled, etc.

The fix is to make sure that the timer runs in the right buffer.  WDYT?