### PR TITLE
Remove google analytics

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,0 +1,8 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+<script type="text/javascript">
+  /* No-op to prevent injected analytics from running */
+  document.createElement = function() {}
+</script>
+{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,4 @@
+# Copyright (C) 2017 Flycheck contributors
 # Copyright (C) 2016 Sebastian Wiesner and Flycheck contributors
 
 # This file is not part of GNU Emacs.
@@ -120,9 +121,6 @@ html_theme_options = {
     'github_type': 'star',
     'github_banner': True,
     'travis_button': False,
-    # Google Analytics ID for our documentation.  On ReadTheDocs it's set via
-    # the Admin interface so we'll skip it here.
-    'analytics_id': 'UA-71100672-2' if not ON_RTD else None,
 }
 html_sidebars = {
     '**': [
@@ -274,7 +272,6 @@ def build_offline_html(app):
         app.info('Building offline documentation without external resources!')
         app.builder.theme_options['github_banner'] = 'false'
         app.builder.theme_options['github_button'] = 'false'
-        app.builder.theme_options['analytics_id'] = None
 
 
 def add_offline_to_context(app, _pagename, _templatename, context, _doctree):


### PR DESCRIPTION
We don't even have access to it, and there's no point in tracking readers of the manual.

Now actually, it seems this is not enough to remove Analytics from the hosted version at readthedocs.  I've built this branch here: http://www.flycheck.org/en/remove-google-analytics/

Analytics are [still included](http://www.flycheck.org/en/remove-google-analytics/_static/readthedocs-dynamic-include.js), only with a *different* analytics code (maybe one for readthedocs directly?)

It seems this is on purpose: rtfd/readthedocs.org/issues/1221.

I've added a second commit that prevents the injected script from loading, so we never hit Google's servers.  I couldn't find any terms of service for readthedocs, so I guess we are not violating any!