### PR TITLE
Add optional column for go-test checker (Go 1.9)

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7588,7 +7588,8 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
             (option-list "-tags=" flycheck-go-build-tags concat)
             "-c" "-o" null-device)
   :error-patterns
-  ((error line-start (file-name) ":" line ": "
+  ((error line-start (file-name) ":" line ":"
+          (optional column ":") " "
           (message (one-or-more not-newline)
                    (zero-or-more "\n\t" (one-or-more not-newline)))
           line-end))


### PR DESCRIPTION
In Go 1.9, `go test -c` adds column in its output, which breaks go-test checker. Adding optional column in `error-patterns` of go-test checker should fix this. 

## `go test -c` output in Go 1.8

```
# github.com/futurenda/errors_test
./errors_test.go:35: undefined: x
```

## `go test -c` output in Go 1.9

```
# github.com/futurenda/errors_test
./errors_test.go:35:3: undefined: x
```