### PR TITLE
Add `flycheck-ghc-stack-project-file' variable for configuring stack project to build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@
   - Add ``flycheck-cppcheck-suppressions-file`` to pass a suppressions
     file to cppcheck [GH-1329]
   - Add ``--force-exclusion`` flag to ``rubocop`` command [GH-1348]
+  - Add ``flycheck-ghc-stack-project-file`` for the
+    ``haskell-stack-ghc`` checker. [GH-1316]
 
 - Improvements
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -571,6 +571,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          Whether to enable Nix support for Stack (only for `haskell-stack-ghc`).
 
+      .. defcustom:: flycheck-ghc-stack-project-file
+
+         Allows to override the default ``stack.yaml`` file for Stack,
+         via ``--stack-yaml`` (only for `haskell-stack-ghc`).
+
       .. defcustom:: flycheck-ghc-package-databases
 
          A list of additional package databases for GHC (only for

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -170,7 +170,7 @@ with VALUE."
   "Determine the absolute file name of a RESOURCE-FILE.
 
 Relative file names are expanded against
-`flycheck-ert-resources-directory'."
+`flycheck-ert--resource-directory'."
   (expand-file-name resource-file flycheck-ert--resource-directory))
 
 (defmacro flycheck-ert-with-resource-buffer (resource-file &rest body)

--- a/flycheck.el
+++ b/flycheck.el
@@ -7793,6 +7793,17 @@ When non-nil, stack will append '--nix' flag to any call."
   :safe #'booleanp
   :package-version '(flycheck . "26"))
 
+(flycheck-def-option-var flycheck-ghc-stack-project-file nil haskell-stack-ghc
+  "Override project stack.yaml file.
+
+The value of this variable is a file path that refers to a yaml
+file for the current stack project. Relative file paths are
+resolved against the checker's working directory. When non-nil,
+stack will get overridden value via `--stack-yaml'."
+  :type 'string
+  :safe #'stringp
+  :package-version '(flycheck . "32"))
+
 (flycheck-def-option-var flycheck-ghc-no-user-package-database nil haskell-ghc
   "Whether to disable the user package database in GHC.
 
@@ -7889,6 +7900,7 @@ contains a cabal file."
 
 See URL `https://github.com/commercialhaskell/stack'."
   :command ("stack"
+            (option "--stack-yaml" flycheck-ghc-stack-project-file)
             (option-flag "--nix" flycheck-ghc-stack-use-nix)
             "ghc" "--" "-Wall" "-no-link"
             "-outputdir" (eval (flycheck-haskell-ghc-cache-directory))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3315,6 +3315,20 @@ Found:
 Why not:
   putStrLn \"hello world\"" :checker haskell-hlint))))
 
+(flycheck-ert-def-checker-test
+    haskell-stack-ghc haskell nonstandard-stack-yaml-file
+  (skip-unless (file-exists-p (getenv "HOME")))
+
+  (let* ((flycheck-disabled-checkers '(haskell-ghc))
+         (proj-dir "language/haskell/stack-project-with-renamed-stack-yaml")
+         (flycheck-ghc-stack-project-file
+          (expand-file-name "stack-nonstandard.yaml"
+                            (flycheck-ert-resource-filename proj-dir))))
+
+    (flycheck-ert-should-syntax-check
+     (concat proj-dir "/src/Foo.hs")
+     'haskell-mode)))
+
 (flycheck-ert-def-checker-test haskell-ghc haskell syntax-error
   (let ((flycheck-disabled-checkers '(haskell-stack-ghc)))
     (flycheck-ert-should-syntax-check
@@ -3336,7 +3350,7 @@ Why not:
   (let ((flycheck-disabled-checkers '(haskell-stack-ghc)))
     (flycheck-ert-should-syntax-check
      "language/haskell/Literate.lhs" 'literate-haskell-mode
-     '(6 1 warning "Top-level binding with no type signature: foo :: forall a. a"
+     '(6 1 warning "Top-level binding with no type signature: foo :: a"
          :id "-Wmissing-signatures"
          :checker haskell-ghc))))
 

--- a/test/resources/language/haskell/.gitignore
+++ b/test/resources/language/haskell/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/test/resources/language/haskell/Warnings.hs
+++ b/test/resources/language/haskell/Warnings.hs
@@ -1,4 +1,4 @@
-module Haskell.Warnings
+module Haskell.Warnings (spam, main)
 where
 
 spam eggs = map lines eggs

--- a/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/src/Foo.hs
+++ b/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/src/Foo.hs
@@ -1,0 +1,5 @@
+module Foo (foo) where
+
+foo :: a -> a
+foo x = x
+

--- a/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/stack-nonstandard.yaml
+++ b/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/stack-nonstandard.yaml
@@ -1,0 +1,4 @@
+resolver: lts-9.0
+
+packages:
+  - "."

--- a/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/stack-project-with-renamed-stack-yaml.cabal
+++ b/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/stack-project-with-renamed-stack-yaml.cabal
@@ -1,0 +1,34 @@
+-- Created     :  24 October 2017
+
+name:
+  stack-project-with-renamed-stack-yaml
+version:
+  0.1.0.0
+license:
+  BSD3
+
+cabal-version:
+  >= 1.16
+build-type:
+  Simple
+
+library
+  exposed-modules:
+    Foo
+  hs-source-dirs:
+    src
+  build-depends:
+    base >= 4.4
+  default-language:
+    Haskell2010
+  ghc-options:
+    -Wall
+    -fwarn-name-shadowing
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -fno-warn-type-defaults
+  if impl(ghc >= 8.0)
+    ghc-options:
+      -Wcompat
+  ghc-prof-options:
+    -fprof-auto

--- a/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/stack.yaml
+++ b/test/resources/language/haskell/stack-project-with-renamed-stack-yaml/stack.yaml
@@ -1,0 +1,4 @@
+resolver: invalid-resolver
+
+packages:
+- "."


### PR DESCRIPTION
This allows users to run checks against custom stack yaml file that flycheck could never guess by itself. Guessing is hard because directory may contain several yaml files from which we'll need to pick
only one.

Fixes https://github.com/flycheck/flycheck-haskell/issues/75.
