### PR TITLE
Improve eslint config verification message

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8062,7 +8062,7 @@ for more information about the custom directories."
   :package-version '(flycheck . "29"))
 
 (defun flycheck-eslint-config-exists-p ()
-  "Whether there is an eslint config for the current buffer."
+  "Whether there is a valid eslint config for the current buffer."
   (let* ((executable (flycheck-find-checker-executable 'javascript-eslint))
          (exitcode (and executable (call-process executable nil nil nil
                                                  "--print-config" "."))))
@@ -8104,7 +8104,7 @@ See URL `http://eslint.org/'."
       (list
        (flycheck-verification-result-new
         :label "config file"
-        :message (if have-config "found" "missing")
+        :message (if have-config "found" "missing or incorrect")
         :face (if have-config 'success '(bold error)))))))
 
 (defun flycheck-parse-jscs (output checker buffer)


### PR DESCRIPTION
I had a hard time to find to root cause (syntax error in `.eslintrc` file) of the disabled `flycheck-eslint`, because the flycheck pointed out a `missing` config file.

Current behavior when config is valid:

```
javascript-eslint
-   may enable: yes
-   executable: Found at /usr/bin/eslint
-   config file: found
```
(the config is not only found but also valid!)

Current behavior when config is invalid (missing might be misleading)
```
javascript-eslint
-   may enable: Automatically disabled!
-   executable: Found at /usr/bin/eslint
-   config file: missing
```

Because `eslint` only writes to `stderr` if parsing of the config goes wrong it would be nice to use this information in the verification message:

New behavior when config is invalid

```
javascript-eslint (disabled)
-   may enable: Automatically disabled!
-   executable: Found at /usr/bin/eslint
-   config file: Cannot read config file: /home/juergen/shared/js/bot1/.eslintrc.js
```
