### PR TITLE
Add link to flycheck-pycheckers

### DIFF
--- a/doc/community/extensions.rst
+++ b/doc/community/extensions.rst
@@ -132,6 +132,7 @@ Python
 ------
 
 * :gh:`Wilfred/flycheck-pyflakes` adds a Python syntax checker using Pyflakes.
+* :gh:`msherry/flycheck-pycheckers` adds a checker for Python that can run multiple syntax checkers simultaneously (Pyflakes, PEP8, mypy2/3, etc.).
 
 .. _Pyflakes: https://github.com/PyCQA/pyflakes
 


### PR DESCRIPTION
`flycheck-pycheckers` enables the user to run multiple syntax checkers simultaneously on Python code, including support for pyflakes, pep8, flake8, pylint, and mypy.

Each checker can be turned on and off individually, and checking can be controlled by individual (per-checker) config files like `.pylintrc`, as well as a unified file (`.pycheckers`).