### PR TITLE
Fix spurious reference to 'make test' in docs

### DIFF
--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -89,7 +89,7 @@ Run ``make help`` to see a list of all available targets.  Some common ones are:
 - ``make specs`` runs all Buttercup_ specs for Flycheck.  Set :makevar:`PATTERN`
   to run only specs matching a specific regular expression, e.g. ``make
   PATTERN='^Mode Line' specs`` to run only tests for the mode line.
-- ``make test`` runs all ERT unit tests for Flycheck.  We are phasing ERT out in
+- ``make unit`` runs all ERT unit tests for Flycheck.  We are phasing ERT out in
   favour of Buttercup; no new ERT unit tests will be added and this target will
   eventually be removed.
 - ``make integ`` runs all integration tests for Flycheck syntax checkers.  These


### PR DESCRIPTION
It looks like this was a typo introduced in af30de057cdd17a2898357857597f99428d75118, when the `Makefile` was added.