### PR TITLE
Don't raise an error an explicitly selected checker cannot be used

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2390,10 +2390,8 @@ otherwise search for the best checker from `flycheck-checkers'.
 Return checker if there is a checker for the current buffer, or
 nil otherwise."
   (if flycheck-checker
-      (if (flycheck-may-use-checker flycheck-checker)
-          flycheck-checker
-        (error "Flycheck cannot use %s in this buffer, type M-x flycheck-verify-setup for more details"
-               flycheck-checker))
+      (when (flycheck-may-use-checker flycheck-checker)
+        flycheck-checker)
     (seq-find #'flycheck-may-use-checker flycheck-checkers)))
 
 (defun flycheck-get-next-checker-for-buffer (checker)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -977,9 +977,9 @@
     (emacs-lisp-mode)
     (flycheck-mode)
     (let* ((flycheck-checker 'sh-bash))
-      (should-error (flycheck-buffer))
+      (flycheck-buffer)
       (should (eq flycheck-checker 'sh-bash))
-      (should (string= flycheck-last-status-change 'errored)))))
+      (should (string= flycheck-last-status-change 'no-checker)))))
 
 (ert-deftest flycheck-checker/usable-checker-is-used ()
   :tags '(selection language-emacs-lisp checker-emacs-lisp-checkdoc)
@@ -1002,9 +1002,9 @@
     (let ((flycheck-disabled-checkers '(emacs-lisp emacs-lisp-checkdoc)))
       (should-not (flycheck-get-checker-for-buffer))
       (let* ((flycheck-checker 'emacs-lisp))
-        (should-error (flycheck-buffer))
+        (flycheck-buffer)
         (should (eq flycheck-checker 'emacs-lisp))
-        (should (string= flycheck-last-status-change 'errored))))))
+        (should (string= flycheck-last-status-change 'no-checker))))))
 
 (ert-deftest flycheck-checker/unregistered-checker-is-used ()
   :tags '(selection language-emacs-lisp checker-emacs-lisp-checkdoc)


### PR DESCRIPTION
Closes GH-1230, which see.

We don't raise an error when no checker can be found anyway.  And we have
`flycheck-verify-setup` to diagnose misconfiguration.