### PR TITLE
Add --force-exclusion flag to rubocop command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 
   - Add ``flycheck-cppcheck-suppressions-file`` to pass a suppressions
     file to cppcheck [GH-1329]
+  - Add ``--force-exclusion`` flag to ``rubocop`` command [GH-1348]
 
 31 (Oct 07, 2017)
 =================

--- a/flycheck.el
+++ b/flycheck.el
@@ -9082,7 +9082,10 @@ Otherwise report style issues as well."
 You need at least RuboCop 0.34 for this syntax checker.
 
 See URL `http://batsov.com/rubocop/'."
-  :command ("rubocop" "--display-cop-names" "--format" "emacs"
+  :command ("rubocop"
+            "--display-cop-names"
+            "--force-exclusion"
+            "--format" "emacs"
             ;; Explicitly disable caching to prevent Rubocop 0.35.1 and earlier
             ;; from caching standard input.  Later versions of Rubocop
             ;; automatically disable caching with --stdin, see


### PR DESCRIPTION
Fixes and closes GH-1348

Tested manually, works as expected. Didn't wrote any integration test, feels more as testing rubocop output than testing actual integration with flycheck.