### PR TITLE
Add flycheck-eslint-args var

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -624,6 +624,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
          this syntax checker if eslint cannot find a valid configuration file
          for the current buffer.
 
+      .. defcustom:: flycheck-eslint-args
+
+         A list of additional arguments that are passed to eslint.
+
       .. defcustom:: flycheck-eslint-rules-directories
 
          A list of directories with custom rules.

--- a/flycheck.el
+++ b/flycheck.el
@@ -8083,6 +8083,9 @@ See URL `http://www.jshint.com'."
   :modes (js-mode js2-mode js3-mode rjsx-mode)
   :next-checkers ((warning . javascript-jscs)))
 
+(flycheck-def-args-var flycheck-eslint-args javascript-eslint
+  :package-version '(flycheck . "32"))
+
 (flycheck-def-option-var flycheck-eslint-rules-directories nil javascript-eslint
   "A list of directories with custom rules for ESLint.
 
@@ -8109,6 +8112,7 @@ for more information about the custom directories."
 See URL `http://eslint.org/'."
   :command ("eslint" "--format=checkstyle"
             (option-list "--rulesdir" flycheck-eslint-rules-directories)
+            (eval flycheck-eslint-args)
             "--stdin" "--stdin-filename" source-original)
   :standard-input t
   :error-parser flycheck-parse-checkstyle


### PR DESCRIPTION
It can be useful to set custom eslint arguments, for example if I want to see stricter lint rules while editing than what the project currently enforces in `.eslintrc`. `--quiet` or `--maxwarnings` also seem potentially useful. 

Example value of `flycheck-eslint-arg` :
```
("--rule" "no-unused-vars: [2]")
```