### PR TITLE
Add MarkdownLint CLI checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@
   - Jsonnet with ``jsonnet`` [GH-1345]
   - Tcl with ``nagelfar`` [GH-1365]
   - CWL with ``schema-salad-tool`` [GH-1361]
+  - MarkdownLint CLI with ``markdownlint`` [GH-1366]
 
 - New features:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -163,6 +163,7 @@ Vagrant.configure("2") do |config|
                                                   jshint \
                                                   eslint \
                                                   jscs \
+                                                  markdownlint-cli \
                                                   standard \
                                                   semistandard \
                                                   jsonlint \

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -723,6 +723,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: Markdown
 
+   .. syntax-checker:: markdown-markdownlint-cli
+
+      Check Markdown with `markdownlint <https://github.com/igorshubovych/markdownlint-cli>`_.
+
+      .. syntax-checker-config-file:: flycheck-markdown-markdownlint-cli-config
+
+         Path to configuration file.
+
    .. syntax-checker:: markdown-mdl
 
       Check Markdown with `markdownlint <https://github.com/mivok/markdownlint/>`_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -226,6 +226,7 @@ attention to case differences."
     r-lintr
     racket
     rpm-rpmlint
+    markdown-markdownlint-cli
     markdown-mdl
     nix
     rst-sphinx
@@ -8939,6 +8940,28 @@ See URL `https://sourceforge.net/projects/rpmlint/'."
   :predicate (lambda () (or (not (eq major-mode 'sh-mode))
                             ;; In `sh-mode', we need the proper shell
                             (eq sh-shell 'rpm))))
+
+(flycheck-def-config-file-var flycheck-markdown-markdownlint-cli-config
+    markdown-markdownlint-cli nil
+  :safe #'stringp
+  :package-version '(flycheck . "32"))
+
+(flycheck-define-checker markdown-markdownlint-cli
+  "Markdown checker using markdownlint-cli.
+
+See URL `https://github.com/igorshubovych/markdownlint-cli'."
+  :command ("markdownlint"
+            (config-file "--config" flycheck-markdown-markdownlint-cli-config)
+            source)
+  :error-patterns
+  ((error line-start
+          (file-name) ": " line ": " (id (one-or-more (not (any space))))
+          " " (message) line-end))
+  :error-filter
+  (lambda (errors)
+    (flycheck-sanitize-errors
+     (flycheck-remove-error-file-names "(string)" errors)))
+  :modes (markdown-mode gfm-mode))
 
 (flycheck-def-option-var flycheck-markdown-mdl-rules nil markdown-mdl
   "Rules to enable for mdl.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3806,6 +3806,14 @@ Why not:
    )
   )
 
+(flycheck-ert-def-checker-test markdown-markdownlint-cli markdown nil
+  (flycheck-ert-should-syntax-check
+   "language/markdown.md" 'markdown-mode
+   '(1 nil error "First header should be a top level header [Expected: h1; Actual: h2]"
+       :id "MD002/first-header-h1" :checker markdown-markdownlint-cli)
+   '(1 nil error "First line in file should be a top level header [Context: "## Second Header First"]"
+       :id "MD041/first-line-h1" :checker markdown-markdownlint-cli)))
+
 (flycheck-ert-def-checker-test markdown-mdl markdown nil
   (flycheck-ert-should-syntax-check
    "language/markdown.md" 'markdown-mode


### PR DESCRIPTION
Adds support for the MarkdownLint Command Line Interface based on the
Node.js markdownlint package.

 - https://github.com/igorshubovych/markdownlint-cli