### PR TITLE
GH-1024 - Remove javascript-jscs checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 32-cvs (in development)
 =======================
 
+- **Breaking changes**
+
+  - Remove javascript-jscs checker
+
 - New syntax checkers:
 
   - Jsonnet with ``jsonnet`` [GH-1345]

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -620,7 +620,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 .. supported-language:: Javascript
 
    Flycheck checks Javascript with one of `javascript-eslint` or
-   `javascript-jshint`, and then with `javascript-jscs`.
+   `javascript-jshint`.
 
    Alternatively `javascript-standard` is used instead all of the former ones.
 
@@ -647,12 +647,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Whether to extract Javascript from HTML before linting.
 
       .. syntax-checker-config-file:: flycheck-jshintrc
-
-   .. syntax-checker:: javascript-jscs
-
-      Check code style with `JSCS <http://jscs.info/>`_.
-
-      .. syntax-checker-config-file:: flycheck-jscsrc
 
    .. syntax-checker:: javascript-standard
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -200,7 +200,6 @@ attention to case differences."
     html-tidy
     javascript-eslint
     javascript-jshint
-    javascript-jscs
     javascript-standard
     json-jsonlint
     json-python-json
@@ -8107,8 +8106,7 @@ See URL `http://www.jshint.com'."
   (lambda (errors)
     (flycheck-remove-error-file-names
      "stdin" (flycheck-dequalify-error-ids errors)))
-  :modes (js-mode js2-mode js3-mode rjsx-mode)
-  :next-checkers ((warning . javascript-jscs)))
+  :modes (js-mode js2-mode js3-mode rjsx-mode))
 
 (flycheck-def-option-var flycheck-eslint-rules-directories nil javascript-eslint
   "A list of directories with custom rules for ESLint.
@@ -8157,7 +8155,6 @@ See URL `http://eslint.org/'."
     errors)
   :enabled (lambda () (flycheck-eslint-config-exists-p))
   :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode rjsx-mode)
-  :next-checkers ((warning . javascript-jscs))
   :verify
   (lambda (_)
     (let* ((default-directory
@@ -8168,39 +8165,6 @@ See URL `http://eslint.org/'."
         :label "config file"
         :message (if have-config "found" "missing or incorrect")
         :face (if have-config 'success '(bold error)))))))
-
-(defun flycheck-parse-jscs (output checker buffer)
-  "Parse JSCS OUTPUT from CHECKER and BUFFER.
-
-Like `flycheck-parse-checkstyle', but catches errors about no
-configuration found and prevents to be reported as a suspicious
-error."
-  (if (string-match-p (rx string-start "No configuration found") output)
-      (let ((message "No JSCS configuration found.  Set `flycheck-jscsrc' for JSCS"))
-        (list (flycheck-error-new-at 1 nil 'warning message
-                                     :checker checker
-                                     :buffer buffer
-                                     :filename (buffer-file-name buffer))))
-    (flycheck-parse-checkstyle output checker buffer)))
-
-(flycheck-def-config-file-var flycheck-jscsrc javascript-jscs ".jscsrc"
-  :safe #'stringp
-  :package-version '(flycheck . "0.24"))
-
-(flycheck-define-checker javascript-jscs
-  "A Javascript style checker using JSCS.
-
-See URL `http://www.jscs.info'."
-  :command ("jscs" "--reporter=checkstyle"
-            (config-file "--config" flycheck-jscsrc)
-            "-")
-  :standard-input t
-  :error-parser flycheck-parse-jscs
-  :error-filter (lambda (errors)
-                  (flycheck-remove-error-ids
-                   (flycheck-sanitize-errors
-                    (flycheck-remove-error-file-names "input" errors))))
-  :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode rjsx-mode))
 
 (flycheck-define-checker javascript-standard
   "A Javascript code and style checker for the (Semi-)Standard Style.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3387,20 +3387,18 @@ Why not:
         (js2-mode-show-strict-warnings nil)
         (js3-mode-show-parse-errors nil)
         (flycheck-disabled-checkers
-         '(javascript-jscs javascript-eslint javascript-gjslint)))
+         '(javascript-eslint javascript-gjslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/syntax-error.js" '(js-mode js2-mode js3-mode rjsx-mode)
-     '(3 4 error "Unmatched '('." :checker javascript-jshint :id "E019")
+     '(3 1 error "Unrecoverable syntax error. (75% scanned)." :checker javascript-jshint :id "E041")
      '(3 25 error "Expected an identifier and instead saw ')'."
-         :checker javascript-jshint :id "E030")
-     '(4 1 error "Unrecoverable syntax error. (100% scanned)."
-         :checker javascript-jshint :id "E041"))))
+         :checker javascript-jshint :id "E030"))))
 
 (flycheck-ert-def-checker-test javascript-jshint javascript nil
   :tags '(checkstyle-xml)
   (let ((flycheck-jshintrc "jshintrc")
         (flycheck-disabled-checkers
-         '(javascript-jscs javascript-eslint javascript-gjslint)))
+         '(javascript-eslint javascript-gjslint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
      '(4 9 warning "'foo' is defined but never used." :id "W098"
@@ -3415,61 +3413,13 @@ Why not:
 
 (flycheck-ert-def-checker-test javascript-eslint javascript warning
   :tags '(checkstyle-xml)
-  (let ((flycheck-disabled-checkers '(javascript-jshint javascript-jscs)))
+  (let ((flycheck-disabled-checkers '(javascript-jshint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/warnings.js" flycheck-test-javascript-modes
      '(3 2 warning "Use the function form of 'use strict'." :id "strict"
          :checker javascript-eslint)
      '(4 9 warning "'foo' is assigned a value but never used."
          :id "no-unused-vars" :checker javascript-eslint))))
-
-(flycheck-ert-def-checker-test javascript-jscs javascript nil
-  :tags '(checkstyle-xml)
-  (let ((flycheck-jscsrc "jscsrc")
-        (flycheck-disabled-checkers
-         '(javascript-jshint javascript-eslint)))
-    (flycheck-ert-should-syntax-check
-     "language/javascript/style.js" flycheck-test-javascript-modes
-     '(4 1 error "validateIndentation: Invalid indentation character:"
-         :checker javascript-jscs)
-     '(4 1 error "validateIndentation: Expected indentation of 0 characters"
-         :checker javascript-jscs))))
-
-(flycheck-ert-def-checker-test javascript-jscs javascript no-config
-  :tags '(checkstyle-xml)
-  (let ((flycheck-disabled-checkers
-         '(javascript-jshint javascript-eslint)))
-    (flycheck-ert-should-syntax-check
-     "language/javascript/style.js" flycheck-test-javascript-modes
-     '(1 nil warning "No JSCS configuration found.  Set `flycheck-jscsrc' for JSCS"
-         :checker javascript-jscs))))
-
-(flycheck-ert-def-checker-test (javascript-jshint javascript-jscs)
-    javascript complete-chain
-  :tags '(checkstyle-xml)
-  (let ((flycheck-jshintrc "jshintrc")
-        (flycheck-jscsrc "jscsrc")
-        (flycheck-disabled-checkers '(javascript-eslint javascript-gjslint)))
-    (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" '(js-mode js2-mode js3-mode rjsx-mode)
-     '(4 1 error "validateIndentation: Expected indentation of 0 characters"
-         :checker javascript-jscs)
-     '(4 9 warning "'foo' is defined but never used." :id "W098"
-         :checker javascript-jshint))))
-
-(flycheck-ert-def-checker-test (javascript-eslint javascript-jscs)
-    javascript complete-chain
-  :tags '(checkstyle-xml)
-  (let ((flycheck-jscsrc "jscsrc")
-        (flycheck-disabled-checkers '(javascript-jshint)))
-    (flycheck-ert-should-syntax-check
-     "language/javascript/warnings.js" flycheck-test-javascript-modes
-     '(3 2 warning "Use the function form of 'use strict'." :id "strict"
-         :checker javascript-eslint)
-     '(4 1 error "validateIndentation: Expected indentation of 0 characters"
-         :checker javascript-jscs)
-     '(4 9 warning "'foo' is assigned a value but never used." :id "no-unused-vars"
-         :checker javascript-eslint))))
 
 (flycheck-ert-def-checker-test javascript-standard javascript error
   (let ((flycheck-checker 'javascript-standard))

--- a/test/resources/language/javascript/jscsrc
+++ b/test/resources/language/javascript/jscsrc
@@ -1,3 +1,0 @@
-{
-    "validateIndentation": 2
-}


### PR DESCRIPTION
Fixes and closes GH-1024

- Removed JSCS checker for javascript, related tests and tests related for old JS chain: see GH-1024
- Fixed `jshint` integration test (didn't bother with separate PR for this small change)