### PR TITLE
GH-1368 - Run rubocop from ruby project directory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@
   - Use Emacs' native XML parsing when libXML fails.  This behavior can be
     changed by customizing ``flycheck-xml-parser`` [GH-1349]
   - Changed parsing of ESLint output from checkstyle XML to JSON [GH-1350]
+  - Flycheck will execute ``rubocop`` from directory where ``Gemfile`` is
+    located. If ``Gemfile`` does not exist, old behaviour of running command
+    from directory where ``.rubocop.yml`` is found will be used [GH-1368]
 
 31 (Oct 07, 2017)
 =================

--- a/flycheck.el
+++ b/flycheck.el
@@ -9075,6 +9075,14 @@ Requires Sphinx 1.2 or newer.  See URL `http://sphinx-doc.org'."
   :predicate (lambda () (and (flycheck-buffer-saved-p)
                              (flycheck-locate-sphinx-source-directory))))
 
+(defun flycheck-ruby--find-project-root (_checker)
+  "Compute an appropriate working-directory for flycheck-ruby.
+
+This is either a parent directory containing a Gemfile, or nil."
+  (and
+   buffer-file-name
+   (locate-dominating-file buffer-file-name "Gemfile")))
+
 (flycheck-def-config-file-var flycheck-rubocoprc ruby-rubocop ".rubocop.yml"
   :safe #'stringp)
 
@@ -9109,6 +9117,7 @@ See URL `http://batsov.com/rubocop/'."
             ;; from standard input
             "--stdin" source-original)
   :standard-input t
+  :working-directory flycheck-ruby--find-project-root
   :error-patterns
   ((info line-start (file-name) ":" line ":" column ": C: "
          (optional (id (one-or-more (not (any ":")))) ": ") (message) line-end)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3853,8 +3853,10 @@ Why not:
   (flycheck-ert-should-syntax-check
    "language/ruby/syntax-error.rb" 'ruby-mode
    '(5 7 error "unexpected token tCONSTANT (Using Ruby 2.1 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+       :id "Lint/Syntax"
        :checker ruby-rubocop)
    '(5 24 error "unterminated string meets end of file (Using Ruby 2.1 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+       :id "Lint/Syntax"
        :checker ruby-rubocop)))
 
 (flycheck-ert-def-checker-test ruby-rubylint ruby syntax-error


### PR DESCRIPTION
Fixes and closes GH-1368

- Added function to find root of ruby projects by looking for Gemfile. If not found, currently set `default-directory` will be used.
- Rubocop checker will use result from that function for `:working-directory`