### PR TITLE
GH-1350 - Change ESLint parsing from XML to JSON

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@
 
   - Use Emacs' native XML parsing when libXML fails.  This behavior can be
     changed by customizing ``flycheck-xml-parser`` [GH-1349]
+  - Changed parsing of ESLint output from checkstyle XML to JSON [GH-1350]
 
 31 (Oct 07, 2017)
 =================

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3405,14 +3405,12 @@ Why not:
          :checker javascript-jshint))))
 
 (flycheck-ert-def-checker-test javascript-eslint javascript error
-  :tags '(checkstyle-xml)
   (let ((flycheck-disabled-checkers '(javascript-jshint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/syntax-error.js" flycheck-test-javascript-modes
      '(3 25 error "Parsing error: Unexpected token )" :checker javascript-eslint))))
 
 (flycheck-ert-def-checker-test javascript-eslint javascript warning
-  :tags '(checkstyle-xml)
   (let ((flycheck-disabled-checkers '(javascript-jshint)))
     (flycheck-ert-should-syntax-check
      "language/javascript/warnings.js" flycheck-test-javascript-modes

--- a/test/specs/languages/test-javascript.el
+++ b/test/specs/languages/test-javascript.el
@@ -1,0 +1,73 @@
+;;; test-javascript.el --- Flycheck Specs: JavaScript      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017 Flycheck contributors
+
+;; Author: Saša Jovanić <info@simplify.ba>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for JavaScript support.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(describe "Language JavaScript"
+  (describe "The ESLint error parser"
+    (let ((json "[{\"filePath\":\"test/resources/language/javascript/syntax-error.js\",
+  \"messages\":[{\"ruleId\":null,\"fatal\":true,\"severity\":2,
+  \"source\":\"if ( /* nothing here */ ) // comment\",
+  \"message\":\"Parsing error: Unexpected token )\",
+  \"line\":3,\"column\":25}],
+  \"errorCount\":1,\"warningCount\":0,\"fixableErrorCount\":0,\"fixableWarningCount\":0,
+  \"source\":\"/** A bad if */\n\nif ( /* nothing here */ ) // comment\n\"}]")
+          (json-without-errors "[{\"filePath\":\"/Users/username/Projects/elisp/flycheck/test/resources/language/javascript/jquery-3.2.1.js\",
+  \"messages\":[],\"errorCount\":0,\"warningCount\":0,\"fixableErrorCount\":0,
+  \"fixableWarningCount\":0}]")
+          (json-with-deprecations "DeprecationWarning: [eslint] The 'ecmaFeatures' config file property is deprecated, and has no effect.\n\n[{\"filePath\":\"test/resources/language/javascript/style.js\",
+  \"messages\":[{\"ruleId\":\"strict\",\"severity\":1,
+  \"message\":\"Use the function form of 'use strict'.\",
+  \"line\":3,\"column\":2,\"nodeType\":\"FunctionExpression\",
+  \"source\":\"(function() {\",\"endLine\":5,\"endColumn\":2}],
+  \"errorCount\":0,\"warningCount\":1,\"fixableErrorCount\":0,\"fixableWarningCount\":0,
+  \"source\":\"/** Tab indentation */\n\n(function() {\n\tvar foo = ['Hello world'];\n}());\n\"}]"))
+      (it "parses ESLint JSON output with errors"
+        (expect (flycheck-parse-eslint json 'checker nil)
+                :to-be-equal-flycheck-errors
+                (list
+                 (flycheck-error-new-at 3 25 'error
+                                        "Parsing error: Unexpected token )"
+                                        :id nil
+                                        :checker 'checker
+                                        :buffer nil
+                                        :filename nil))))
+      (it "parses ESLint JSON output without errors"
+        (expect (flycheck-parse-eslint json-without-errors 'checker 'buffer)
+                :to-be-equal-flycheck-errors ()))
+      (it "parses ESLint JSON output with deprecation warning"
+        (expect (flycheck-parse-eslint json-with-deprecations 'checker nil)
+                :to-be-equal-flycheck-errors
+                (list
+                 (flycheck-error-new-at 3 2 'warning
+                                        "Use the function form of 'use strict'."
+                                        :id "strict"
+                                        :checker 'checker
+                                        :buffer nil
+                                        :filename nil)))))))
+
+;;; test-javascript.el ends here


### PR DESCRIPTION
Fixes and closes GH-1350

- Change ESLint parsing from XML to JSON. 
- Added tests for parser
- Old integration tests just work, I removed `checkstyle-xml` tag.