### PR TITLE
Fix `flycheck-test-with-nav-buffer` not running some tests

### DIFF
--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1885,11 +1885,10 @@ evaluating BODY."
   `(flycheck-ert-with-resource-buffer "language/emacs-lisp/errors-and-warnings.el"
      (emacs-lisp-mode)
      (flycheck-mode)
-     (when ,minimum-level
-       (let ((flycheck-navigation-minimum-level ,minimum-level))
-         (flycheck-ert-buffer-sync)
-         (goto-char (point-min))
-         ,@body))))
+     (let ((flycheck-navigation-minimum-level ,minimum-level))
+       (flycheck-ert-buffer-sync)
+       (goto-char (point-min))
+       ,@body)))
 
 (ert-deftest flycheck-next-error/goes-to-first-error ()
   :tags '(navigation)


### PR DESCRIPTION
Specifically, when `minimum-level` was nil, we did not actually include the
macro body, so we weren't running any `should` assertion.
