### PR TITLE
Add cargo clippy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
   - Tcl with ``nagelfar`` [GH-1365]
   - CWL with ``schema-salad-tool`` [GH-1361]
   - MarkdownLint CLI with ``markdownlint`` [GH-1366]
+  - Rust with ``rust-clippy`` [GH-1385]
 
 - New features:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1028,21 +1028,27 @@ to view the docstring of the syntax checker.  Likewise, you may use
 .. supported-language:: Rust
 
    Flycheck checks Rust_ with `rust-cargo` in Cargo projects, or `rust`
-   otherwise.
+   otherwise.  For Cargo projects, you can also use the clippy_ linter with
+   `rust-clippy`.
 
    .. _Rust: https://www.rust-lang.org/
+   .. _clippy: https://github.com/rust-lang-nursery/rust-clippy
 
    .. syntax-checker:: rust-cargo
                        rust
+                       rust-clippy
 
       Check syntax and types with the Rust_ compiler.  In a Cargo_ project the
       compiler is invoked through ``cargo check`` to take Cargo dependencies
       into account.
 
+      `rust-clippy` has no configurable options.
+
       .. note::
 
          `rust-cargo` requires Rust 1.17 or newer.
          `rust` requires Rust 1.7 or newer.
+         `rust-clippy` requires the nightly version of Rust.
 
       .. _Cargo: http://doc.crates.io/index.html
 

--- a/test/specs/test-documentation.el
+++ b/test/specs/test-documentation.el
@@ -1,5 +1,6 @@
 ;;; test-documentation.el --- Flycheck Specs: Documentation -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2018 Flycheck contributors
 ;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
@@ -40,12 +41,15 @@
         (let ((match (intern (match-string 1))))
           (cl-pushnew match matches))
         (-when-let (match (match-string 2))
+          (cl-pushnew (intern match) matches))
+        (-when-let (match (match-string 3))
           (cl-pushnew (intern match) matches))))
     matches))
 
 (defconst flycheck/checker-re
   (rx bol "   .. syntax-checker:: " (group (1+ nonl)) "\n"
-      (? "                       " (group (1+ nonl)) eol)))
+      (? "                       " (group (1+ nonl)) "\n")
+      (? "                       " (group (1+ nonl))) eol))
 
 (defconst flycheck/defcustom-re
   (rx bol "      .. defcustom:: " (group (1+ nonl)) "\n"


### PR DESCRIPTION
This adds `clippy` as another checker for rust.  I've picked up #1156, where most of the heavy-lifting had already been done by @dzamlo.

I've tweaked the rust parser to handle a corner case with suggested replacement by Clippy.

Adding a third checker on the same `syntax-checker::` line in `doc/languages.rst` broke the tests, as the regexp did not handle this case.  I've extended it for 3 lines, but... I'm sure there is a more definitive solution waiting to be found ;)

The branch is based on #1381 and #1289, so we should probably merge these before this one.