### PR TITLE
Fix dir local doc of disabled checkers

### DIFF
--- a/doc/user/syntax-checkers.rst
+++ b/doc/user/syntax-checkers.rst
@@ -173,7 +173,7 @@ Internally this command changes the buffer-local `flycheck-disabled-checkers`:
 
 You can also disable syntax checkers per project with directory local variables.
 For instance type :kbd:`M-x add-dir-local-variable RET emacs-lisp-mode RET
-flycheck-disabled-checkers RET emacs-lisp-checkdoc` in your :term:`user emacs
+flycheck-disabled-checkers RET (emacs-lisp-checkdoc)` in your :term:`user emacs
 directory` to disable `emacs-lisp-checkdoc` for all Emacs Lisp files in your
 personal configuration.
 


### PR DESCRIPTION
`flycheck-disabled-checkers` should be a list.

The current version of this doc causes this error when you flycheck an elisp buffer:

```elisp
Debugger entered--Lisp error: (wrong-type-argument listp emacs-lisp-checkdoc)
  signal(wrong-type-argument (listp emacs-lisp-checkdoc))
  flycheck-buffer()
  funcall-interactively(flycheck-buffer)
  call-interactively(flycheck-buffer nil nil)
  command-execute(flycheck-buffer)
```

# Thank you for your contribution!

Thank you for taking the time to submit your changes to Flycheck and help us
making Flycheck better step by step! :+1: :clap:

After you submitted your pull request we will soon review this pull request.  If
you think that we might have missed your pull request please ping us at
`@flycheck/maintainers`.

Meanwhile please take a look at the [Travis CI][] build status of your pull
request which you can see right above the comment input field.  If the build
failed please take a look to see if there were any formatting issues or test
failures.

You may now delete all this text and add a description of your changes.

Thank you for contributing to Flycheck!
