### PR TITLE
Add "-" to phpcs arguments.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8507,7 +8507,9 @@ See URL `http://pear.php.net/package/PHP_CodeSniffer/'."
             ;; here, because phpcs really insists to get option and argument as
             ;; a single command line argument :|
             (eval (when (buffer-file-name)
-                    (concat "--stdin-path=" (buffer-file-name)))))
+                    (concat "--stdin-path=" (buffer-file-name))))
+            ;; Read from standard input
+            "-")
   :standard-input t
   :error-parser flycheck-parse-checkstyle
   :error-filter


### PR DESCRIPTION
On PHP_CodeSniffer (phpcs) 3.x or later, "-" must be added as the last argument to wait for STDIN.

https://github.com/squizlabs/PHP_CodeSniffer/blob/master/package.xml#L2237

On Linux, "-" is not necessary for pipe input.
But on Windows, "-" needs to be added to work properly.

Adding "-" has no effect for Linux systems.
For phpcs 2.9 or older, it is just ignored. (https://github.com/squizlabs/PHP_CodeSniffer/blob/2.9/CodeSniffer/CLI.php#L454)
It seems to be safe.

Thanks in advance.
