### PR TITLE
Better error for non writable temporary files

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1118,8 +1118,6 @@ Otherwise this function creates a temporary file with
 `flycheck-temp-prefix' and a random suffix.  The path of the file
 is added to `flycheck-temporaries'.
 
-Add the path of the file to `flycheck-temporaries'.
-
 Return the path of the file."
   (let ((tempfile (convert-standard-filename
                    (if filename
@@ -1148,6 +1146,29 @@ Return the path of the file."
         (push tempfile flycheck-temporaries)
         tempfile)
     (flycheck-temp-file-system filename)))
+
+(defun flycheck-temp-directory (checker)
+  "Return the directory where CHECKER writes temporary files.
+
+Return nil if the CHECKER does not write temporary files."
+  (let ((args (flycheck-checker-arguments checker)))
+    (cond
+     ((memq 'source args) temporary-file-directory)
+     ((memq 'source-inplace args)
+      (if buffer-file-name (file-name-directory buffer-file-name)
+        temporary-file-directory))
+     (t nil))))
+
+(defun flycheck-temp-files-writable-p (checker)
+  "Whether CHECKER can write temporary files.
+
+If CHECKER has `source' or `source-inplace' in its `:command',
+return whether flycheck has the permissions to create the
+respective temporary files.
+
+Return t if CHECKER does not use temporary files."
+  (let ((dir (flycheck-temp-directory checker)))
+    (or (not dir) (file-writable-p dir))))
 
 (defun flycheck-save-buffer-to-file (file-name)
   "Save the contents of the current buffer to FILE-NAME."
@@ -4666,6 +4687,7 @@ default `:verify' function of command checkers."
           (plist-put properties :enabled
                      (lambda ()
                        (and (flycheck-find-checker-executable symbol)
+                            (flycheck-temp-files-writable-p symbol)
                             (or (not enabled) (funcall enabled))))))
 
     (apply #'flycheck-define-generic-checker symbol docstring
@@ -5071,7 +5093,13 @@ CHECKER."
             (list (flycheck-verification-result-new
                    :label "configuration file"
                    :message (if path (format "Found at %S" path) "Not found")
-                   :face (if path 'success 'warning))))))))
+                   :face (if path 'success 'warning)))))
+      ,@(when (not (flycheck-temp-files-writable-p checker))
+          (list (flycheck-verification-result-new
+                 :label "temp directory"
+                 :message (format "%s is not writable"
+                                  (flycheck-temp-directory checker))
+                 :face 'error))))))
 
 
 ;;; Process management for command syntax checkers


### PR DESCRIPTION
A proposal to fix #1401.

This disables checker that use `source-inplace` when the temporary file that would be created by `temp-file-name` cannot be written.

It also adds a message in `verify-setup`.  Though I'm not quite happy with how it turns out.  There is not a lot of room for verification result messages (and even less so for labels).  Ideally, I would have liked to write a one-line reason ("need writable permissions on `dir` for writing temporary files) for why the checker has been disabled, and link to (or have some clickable thingy that reveals) a longer explanation of source-inplace.