### PR TITLE
Check Groovy using standard-input.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7738,19 +7738,17 @@ See URL `http://www.groovy-lang.org'."
   :command ("groovy" "-e"
             "import org.codehaus.groovy.control.*
 
-file = new File(args[0])
 unit = new CompilationUnit()
-unit.addSource(file)
+unit.addSource(\"input\", System.in)
 
 try {
     unit.compile(Phases.CONVERSION)
 } catch (MultipleCompilationErrorsException e) {
     e.errorCollector.write(new PrintWriter(System.out, true), null)
-}
-"
-            source)
+}")
+  :standard-input t
   :error-patterns
-  ((error line-start (file-name) ": " line ":" (message)
+  ((error line-start "input: " line ":" (message)
           " @ line " line ", column " column "." line-end))
   :modes groovy-mode)
 


### PR DESCRIPTION
Fixes #1396.

And possibly also provides a workaround for #1395, but I can't verify this till Monday, when I have access to a Windows machine.

Another alternative might be to just use `groovyc`. I know in the original PR which added the Groovy checker ( #716), the author identified that they couldn't use `groovyc` because there was no way to make it stop it syntax checking... but maybe the simplicity of using it is worth the overhead?