### PR TITLE
Changed flycheck-rust-manifest-directory to use 'cargo metadata'

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9480,6 +9480,22 @@ or if the current buffer has no file name."
   (and buffer-file-name
        (locate-dominating-file buffer-file-name "Cargo.toml")))
 
+(defun flycheck-rust-cargo-metadata ()
+  "Run 'cargo metadata' and return the result as parsed JSON object."
+  (with-temp-buffer
+    (call-process "cargo" nil t nil
+                  "metadata" "--no-deps" "--format-version" "1")
+    (goto-char (point-min))
+    (json-read)))
+
+(defun flycheck-rust-cargo-workspace-root ()
+  "Return the path to the workspace root of a Rust Cargo project.
+
+Return nil if the workspace root does not exist (for Rust
+versions inferior to 1.25)."
+  (let-alist (flycheck-rust-cargo-metadata)
+    .workspace_root))
+
 (defun flycheck-rust-cargo-has-command-p (command)
   "Whether Cargo has COMMAND in its list of commands.
 
@@ -9515,7 +9531,15 @@ This syntax checker requires Rust 1.17 or newer.  See URL
             (eval flycheck-cargo-check-args)
             "--message-format=json")
   :error-parser flycheck-parse-cargo-rustc
-  :error-filter flycheck-rust-error-filter
+  :error-filter (lambda (errors)
+                  ;; In Rust 1.25+, filenames are relative to the workspace
+                  ;; root.
+                  (let ((root (flycheck-rust-cargo-workspace-root)))
+                    (seq-do (lambda (err)
+                              (setf (flycheck-error-filename err)
+                                    (expand-file-name
+                                     (flycheck-error-filename err) root)))
+                            (flycheck-rust-error-filter errors))))
   :error-explainer flycheck-rust-error-explainer
   :modes rust-mode
   :predicate flycheck-buffer-saved-p

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3999,7 +3999,6 @@ The manifest path is relative to
      '(3 1 warning "function is never used: `main`" :checker rust-cargo :id "dead_code")
      '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code")
      '(4 9 warning "unused variable: `x`" :checker rust-cargo :id "unused_variables")
-     '(4 9 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
      '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust-cargo :id "unused_variables"))))
 
 (flycheck-ert-def-checker-test rust-cargo rust default-target
@@ -4012,7 +4011,6 @@ The manifest path is relative to
      '(3 1 warning "function is never used: `main`" :checker rust-cargo :id "dead_code")
      '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code")
      '(4 9 warning "unused variable: `x`" :checker rust-cargo :id "unused_variables")
-     '(4 9 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
      '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust-cargo :id "unused_variables"))))
 
 (flycheck-ert-def-checker-test rust-cargo rust lib-main
@@ -4029,9 +4027,7 @@ The manifest path is relative to
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/lib.rs" 'rust-mode
        '(3 1 warning "function is never used: `foo_lib`" :checker rust-cargo :id "dead_code")
-       '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code")
        '(6 17 warning "unused variable: `foo_lib_test`" :checker rust-cargo  :id "unused_variables")
-       '(6 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(6 17 info "to avoid this warning, consider using `_foo_lib_test` instead" :checker rust-cargo :id "unused_variables")))
 
     (let ((flycheck-rust-crate-type "lib"))
@@ -4053,7 +4049,6 @@ The manifest path is relative to
        '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(1 17 info "to avoid this warning, consider using `_foo_main` instead" :checker rust-cargo :id "unused_variables")
        '(4 17 warning "unused variable: `foo_main_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(4 17 info "to avoid this warning, consider using `_foo_main_test` instead" :checker rust-cargo :id "unused_variables")))
 
     (let ((flycheck-rust-crate-type "bin")
@@ -4065,7 +4060,6 @@ The manifest path is relative to
        '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(1 17 info "to avoid this warning, consider using `_foo_bin_a` instead" :checker rust-cargo :id "unused_variables")
        '(4 17 warning "unused variable: `foo_bin_a_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(4 17 info "to avoid this warning, consider using `_foo_bin_a_test` instead" :checker rust-cargo :id "unused_variables")))
 
     (let ((flycheck-rust-crate-type "bench")
@@ -4077,7 +4071,6 @@ The manifest path is relative to
        '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(1 17 info "to avoid this warning, consider using `_foo_bench_a` instead" :checker rust-cargo :id "unused_variables")
        '(4 17 warning "unused variable: `foo_bench_a_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(4 17 info "to avoid this warning, consider using `_foo_bench_a_test` instead" :checker rust-cargo :id "unused_variables")))
 
     (let ((flycheck-rust-crate-type "test")
@@ -4100,8 +4093,18 @@ The manifest path is relative to
        '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(1 17 info "to avoid this warning, consider using `_foo_ex_a` instead" :checker rust-cargo :id "unused_variables")
        '(4 17 warning "unused variable: `foo_ex_a_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
        '(4 17 info "to avoid this warning, consider using `_foo_ex_a_test` instead" :checker rust-cargo :id "unused_variables")))))
+
+(flycheck-ert-def-checker-test rust-cargo rust workspace-subcrate
+  (let ((flycheck-disabled-checkers '(rust)))
+    (let ((flycheck-rust-crate-type "lib")
+          (flycheck-rust-check-tests t))
+      (flycheck-ert-cargo-clean "language/rust/workspace/crate1/Cargo.toml")
+      (flycheck-ert-should-syntax-check
+       "language/rust/workspace/crate1/src/lib.rs" 'rust-mode
+       '(2 7 warning "unused variable: `a`" :checker rust-cargo :id "unused_variables")
+       '(2 7 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
+       '(2 7 info "to avoid this warning, consider using `_a` instead" :checker rust-cargo :id "unused_variables")))))
 
 (flycheck-ert-def-checker-test rust-cargo rust dev-dependencies
   (let ((flycheck-disabled-checkers '(rust)))
@@ -4148,7 +4151,11 @@ The manifest path is relative to
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/importing.rs" 'rust-mode
-     '(1 5 error "unresolved import `super` (There are too many initial `super`s.)" :checker rust :id "E0432"))))
+     '(1 5 error "failed to resolve. There are too many initial `super`s. (There are too many initial `super`s.)" :checker rust :id "E0433")
+     '(1 5 warning "unused import: `super::imported`" :checker rust :id "unused_imports")
+     '(1 5 info "#[warn(unused_imports)] on by default" :checker rust :id "unused_imports")
+     '(4 24 error "failed to resolve. Use of undeclared type or module `imported` (Use of undeclared type or module `imported`)" :checker rust :id "E0433")
+     )))
 
 (flycheck-ert-def-checker-test rust rust macro-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))

--- a/test/resources/language/rust/workspace/Cargo.lock
+++ b/test/resources/language/rust/workspace/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "crate1"
+version = "0.1.0"
+

--- a/test/resources/language/rust/workspace/Cargo.toml
+++ b/test/resources/language/rust/workspace/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["crate1"]

--- a/test/resources/language/rust/workspace/crate1/Cargo.toml
+++ b/test/resources/language/rust/workspace/crate1/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "crate1"
+version = "0.1.0"

--- a/test/resources/language/rust/workspace/crate1/src/lib.rs
+++ b/test/resources/language/rust/workspace/crate1/src/lib.rs
@@ -1,0 +1,3 @@
+fn main() {
+  let a = 0;
+}


### PR DESCRIPTION
This commit fixes https://github.com/flycheck/flycheck/issues/1397.
By the recent change of cargo(https://github.com/rust-lang/cargo/pull/4788), flycheck can't detect error files in multi-crate project of Rust.
So I changed to use `workspace_root` in `cargo metadata` 's outputs, as working directory.
If the user's cargo is a bit old and there's no 'workspace_root', `flycheck-rust-manifest-directory` search a directory with `Cargo.toml`, as ever.

I've seen @fmdkdd's comment in https://github.com/rust-lang/cargo/issues/4998, but I wrote this patch just because I need this, so please feel free to abort this PR if you don't like.
