### PR TITLE
flycheck-test: Fix no-child-of-user-emacs-directory test

### DIFF
--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -482,9 +482,10 @@
 
 (ert-deftest flycheck-in-user-emacs-directory-p/no-child-of-user-emacs-directory ()
   :tags '(utility)
-  (should-not (flycheck-in-user-emacs-directory-p
-               (flycheck-ert-resource-filename
-                "language/emacs-lisp/warnings.el"))))
+  (let ((user-emacs-directory "/flycheck-nonexisting"))
+    (should-not (flycheck-in-user-emacs-directory-p
+                 (flycheck-ert-resource-filename
+                  "language/emacs-lisp/warnings.el")))))
 
 (ert-deftest flycheck-in-user-emacs-directory-p/direct-child-of-user-emacs-directory ()
   :tags '(utility)


### PR DESCRIPTION
If the Flycheck repository was cloned in a directory under the user's Emacs directory (`~/.emacs.d`), the test suite (specifically, the `flycheck-in-user-emacs-directory-p/no-child-of-user-emacs-directory` test) would fail. Fix this by temporarily `overriding user-emacs-directory`, as done in the other `flycheck-in-user-emacs-directory-p` tests.
