### PR TITLE
Change source to source-inplace for TSLint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10150,7 +10150,7 @@ See URL `https://github.com/palantir/tslint'."
             (config-file "--config" flycheck-typescript-tslint-config)
             (option "--rules-dir" flycheck-typescript-tslint-rulesdir)
             (eval flycheck-tslint-args)
-            source)
+            source-inplace)
   :error-parser flycheck-parse-tslint
   :modes (typescript-mode))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4327,13 +4327,11 @@ The manifest path is relative to
 (flycheck-ert-def-checker-test typescript-tslint typescript nil
   (flycheck-ert-should-syntax-check
    "language/typescript/sample.ts" 'typescript-mode
-   '(1 10 warning "Unused function: 'invalidAlignment'"
-       :checker typescript-tslint :id "no-unused-variable")
-   '(2 3 warning "Forbidden 'var' keyword, use 'let' or 'const' instead"
+   '(2 23 warning "Module 'chai' is not listed as dependency in package.json"
+       :checker typescript-tslint :id "no-implicit-dependencies")
+   '(5 3 warning "Forbidden 'var' keyword, use 'let' or 'const' instead"
        :checker typescript-tslint :id "no-var-keyword")
-   '(2 7 warning "Unused variable: 'a'"
-       :checker typescript-tslint :id "no-unused-variable")
-   '(3 15 warning "Missing semicolon"
+   '(6 15 warning "Missing semicolon"
        :checker typescript-tslint :id "semicolon")))
 
 (flycheck-ert-def-checker-test verilog-verilator verilog error

--- a/test/resources/language/typescript/package.json
+++ b/test/resources/language/typescript/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "mocha": "^3.0.0"
+  }
+}

--- a/test/resources/language/typescript/sample.ts
+++ b/test/resources/language/typescript/sample.ts
@@ -1,3 +1,6 @@
+import * as mocha from 'mocha';
+import * as chai from 'chai';
+
 function invalidAlignment() {
   var a:string = "test string";
   alert('Hi!')

--- a/test/resources/language/typescript/tslint.json
+++ b/test/resources/language/typescript/tslint.json
@@ -1,8 +1,7 @@
 {
   "rules": {
-    "no-unused-variable": true,
-    "use-strict": true,
     "no-var-keyword": true,
-    "semicolon": true
+    "semicolon": true,
+    "no-implicit-dependencies": [true, "dev"]
   }
 }


### PR DESCRIPTION
Fixes and closes GH-1420

- Changes `source` to `source-inplace` in `tslint` command. This way `tslint` can locate `package.json`.
- Added rule `no-implicit-dependencies` into test `tslintrc.json` and `package.json` to test this.
- Removed `use-strict` rule because it does not exist in `tslint` any more.
- Removed rule `no-unused-variable` because this now in `tslint` also requires `tsconfig.json`.