### PR TITLE
Update integration tests for Rust and error groups

### DIFF
--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -1,6 +1,6 @@
 ;;; flycheck-ert.el --- Flycheck: ERT extensions  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2017 Flycheck contributors
+;; Copyright (C) 2017-2018 Flycheck contributors
 ;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
@@ -332,14 +332,27 @@ Raise an assertion error if the buffer is not clear afterwards."
 
 ;;; Test assertions
 
+(defun flycheck-error-without-group (err)
+  "Return a copy ERR with the `group' property set to nil."
+  (let ((copy (copy-flycheck-error err)))
+    (setf (flycheck-error-group copy) nil)
+    copy))
+
 (defun flycheck-ert-should-overlay (error)
   "Test that ERROR has a proper overlay in the current buffer.
 
 ERROR is a Flycheck error object."
-  (let* ((overlay (-first (lambda (ov) (equal (overlay-get ov 'flycheck-error)
-                                              error))
+  (let* ((overlay (-first (lambda (ov)
+                            (equal (flycheck-error-without-group
+                                    (overlay-get ov 'flycheck-error))
+                                   (flycheck-error-without-group error)))
                           (flycheck-overlays-in 0 (+ 1 (buffer-size)))))
-         (region (flycheck-error-region-for-mode error 'symbols))
+         (region
+          ;; Overlays of errors from other files are on the first line
+          (if (flycheck-relevant-error-other-file-p error)
+              (cons (point-min)
+                    (save-excursion (goto-char (point-min)) (point-at-eol)))
+            (flycheck-error-region-for-mode error 'symbols)))
          (level (flycheck-error-level error))
          (category (flycheck-error-level-overlay-category level))
          (face (get category 'face))
@@ -355,7 +368,9 @@ ERROR is a Flycheck error object."
                                       (overlay-get overlay 'before-string))
                    fringe-icon))
     (should (eq (overlay-get overlay 'category) category))
-    (should (equal (overlay-get overlay 'flycheck-error) error))))
+    (should (equal (flycheck-error-without-group (overlay-get overlay
+                                                              'flycheck-error))
+                   (flycheck-error-without-group error)))))
 
 (defun flycheck-ert-should-errors (&rest errors)
   "Test that the current buffers has ERRORS.
@@ -373,7 +388,16 @@ buffer is equal to the number of given ERRORS.  In other words,
 check that the buffer has all ERRORS, and no other errors."
   (let ((expected (mapcar (apply-partially #'apply #'flycheck-error-new-at)
                           errors)))
-    (should (equal expected flycheck-current-errors))
+    (should (equal (mapcar #'flycheck-error-without-group expected)
+                   (mapcar #'flycheck-error-without-group
+                           flycheck-current-errors)))
+    ;; Check that related errors are the same
+    (cl-mapcar (lambda (err1 err2)
+                 (should (equal (mapcar #'flycheck-error-without-group
+                                        (flycheck-related-errors err1 expected))
+                                (mapcar #'flycheck-error-without-group
+                                        (flycheck-related-errors err2)))))
+               expected flycheck-current-errors)
     (mapc #'flycheck-ert-should-overlay expected))
   (should (= (length errors)
              (length (flycheck-overlays-in (point-min) (point-max))))))

--- a/flycheck.el
+++ b/flycheck.el
@@ -3233,16 +3233,17 @@ Return a list of all errors that are relevant for their
 corresponding buffer."
   (seq-filter #'flycheck-relevant-error-p errors))
 
-(defun flycheck-related-errors (err)
+(defun flycheck-related-errors (err &optional error-set)
   "Get all the errors that are in the same group as ERR.
 
-Return a list of all errors (in `flycheck-current-errors') that
-have the same `flycheck-error-group' as ERR, including ERR
-itself."
+Return a list of all errors (from ERROR-SET) that have the same
+`flycheck-error-group' as ERR, including ERR itself.
+
+If ERROR-SET is nil, `flycheck-current-errors' is used instead."
   (-if-let (group (flycheck-error-group err))
       (seq-filter (lambda (e)
                     (eq (flycheck-error-group e) group))
-                  flycheck-current-errors)
+                  (or error-set flycheck-current-errors))
     (list err)))
 
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -9513,10 +9513,17 @@ Relative paths are relative to the file being checked."
 (defun flycheck-rust-error-filter (errors)
   "Filter ERRORS from rustc output that have no explanatory value."
   (seq-remove (lambda (err)
-                (string-match-p
-                 (rx "aborting due to " (optional (one-or-more num) " ")
-                     "previous error")
-                 (flycheck-error-message err)))
+                (or
+                 ;; Macro errors emit a diagnostic in a phony file,
+                 ;; e.g. "<println macros>".
+                 (string-match-p
+                  (rx "macros>" line-end)
+                  (flycheck-error-filename err))
+                 ;; Redundant message giving the number of failed errors
+                 (string-match-p
+                  (rx "aborting due to " (optional (one-or-more num) " ")
+                      "previous error")
+                  (flycheck-error-message err))))
               errors))
 
 (defun flycheck-rust-manifest-directory ()

--- a/flycheck.el
+++ b/flycheck.el
@@ -3240,11 +3240,14 @@ Return a list of all errors (from ERROR-SET) that have the same
 `flycheck-error-group' as ERR, including ERR itself.
 
 If ERROR-SET is nil, `flycheck-current-errors' is used instead."
-  (-if-let (group (flycheck-error-group err))
-      (seq-filter (lambda (e)
-                    (eq (flycheck-error-group e) group))
-                  (or error-set flycheck-current-errors))
-    (list err)))
+  (let ((group (flycheck-error-group err))
+        (checker (flycheck-error-checker err)))
+    (if group
+        (seq-filter (lambda (e)
+                      (and (eq (flycheck-error-checker e) checker)
+                           (eq (flycheck-error-group e) group)))
+                    (or error-set flycheck-current-errors))
+      (list err))))
 
 
 ;;; Status reporting for the current buffer

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4019,7 +4019,12 @@ The manifest path is relative to
         (flycheck-rust-crate-type "bin")
         (flycheck-rust-binary-name "lib-main"))
     (flycheck-ert-should-syntax-check
-     "language/rust/lib-main/src/main.rs" 'rust-mode)))
+     "language/rust/lib-main/src/main.rs" 'rust-mode
+     `(3 12 error "cannot find value `zorglub` in this scope (not found in this scope)"
+         :checker rust-cargo :id "E0425"
+         :filename ,(flycheck-ert-resource-filename "language/rust/lib-main/src/lib.rs")
+         :group 1)
+     )))
 
 (flycheck-ert-def-checker-test rust-cargo rust conventional-layout
   (let ((flycheck-disabled-checkers '(rust)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3997,10 +3997,10 @@ The manifest path is relative to
     (flycheck-ert-cargo-clean "language/rust/flycheck-test/Cargo.toml")
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
-     '(3 1 warning "function is never used: `main`" :checker rust-cargo :id "dead_code")
-     '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code")
-     '(4 9 warning "unused variable: `x`" :checker rust-cargo :id "unused_variables")
-     '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust-cargo :id "unused_variables"))))
+     '(3 1 warning "function is never used: `main`" :checker rust-cargo :id "dead_code" :group 1)
+     '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code" :group 1)
+     '(4 9 warning "unused variable: `x`" :checker rust-cargo :id "unused_variables" :group 2)
+     '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust-cargo :id "unused_variables" :group 2))))
 
 (flycheck-ert-def-checker-test rust-cargo rust default-target
   (let ((flycheck-disabled-checkers '(rust))
@@ -4009,10 +4009,10 @@ The manifest path is relative to
     (flycheck-ert-cargo-clean "language/rust/flycheck-test/Cargo.toml")
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
-     '(3 1 warning "function is never used: `main`" :checker rust-cargo :id "dead_code")
-     '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code")
-     '(4 9 warning "unused variable: `x`" :checker rust-cargo :id "unused_variables")
-     '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust-cargo :id "unused_variables"))))
+     '(3 1 warning "function is never used: `main`" :checker rust-cargo :id "dead_code" :group 1)
+     '(3 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code" :group 1)
+     '(4 9 warning "unused variable: `x`" :checker rust-cargo :id "unused_variables" :group 2)
+     '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust-cargo :id "unused_variables" :group 2))))
 
 (flycheck-ert-def-checker-test rust-cargo rust lib-main
   (let ((flycheck-disabled-checkers '(rust))
@@ -4027,74 +4027,74 @@ The manifest path is relative to
       (flycheck-ert-cargo-clean "language/rust/cargo-targets/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/lib.rs" 'rust-mode
-       '(3 1 warning "function is never used: `foo_lib`" :checker rust-cargo :id "dead_code")
-       '(6 17 warning "unused variable: `foo_lib_test`" :checker rust-cargo  :id "unused_variables")
-       '(6 17 info "to avoid this warning, consider using `_foo_lib_test` instead" :checker rust-cargo :id "unused_variables")))
+       '(3 1 warning "function is never used: `foo_lib`" :checker rust-cargo :id "dead_code" :group 1)
+       '(6 17 warning "unused variable: `foo_lib_test`" :checker rust-cargo  :id "unused_variables" :group 2)
+       '(6 17 info "to avoid this warning, consider using `_foo_lib_test` instead" :checker rust-cargo :id "unused_variables" :group 2)))
 
     (let ((flycheck-rust-crate-type "lib"))
       (flycheck-ert-cargo-clean "language/rust/cargo-targets/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/a.rs" 'rust-mode
-       '(1 1 warning "function is never used: `foo_a`" :checker rust-cargo :id "dead_code")
-       '(1 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code")
-       '(4 17 warning "unused variable: `foo_a_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "to avoid this warning, consider using `_foo_a_test` instead" :checker rust-cargo :id "unused_variables")))
+       '(1 1 warning "function is never used: `foo_a`" :checker rust-cargo :id "dead_code" :group 1)
+       '(1 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code" :group 1)
+       '(4 17 warning "unused variable: `foo_a_test`" :checker rust-cargo :id "unused_variables" :group 2)
+       '(4 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 2)
+       '(4 17 info "to avoid this warning, consider using `_foo_a_test` instead" :checker rust-cargo :id "unused_variables" :group 2)))
 
     (let ((flycheck-rust-crate-type "bin")
           (flycheck-rust-binary-name "cargo-targets"))
       (flycheck-ert-cargo-clean "language/rust/cargo-targets/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/main.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_main`" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "to avoid this warning, consider using `_foo_main` instead" :checker rust-cargo :id "unused_variables")
-       '(4 17 warning "unused variable: `foo_main_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "to avoid this warning, consider using `_foo_main_test` instead" :checker rust-cargo :id "unused_variables")))
+       '(1 17 warning "unused variable: `foo_main`" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "to avoid this warning, consider using `_foo_main` instead" :checker rust-cargo :id "unused_variables" :group 1)
+       '(4 17 warning "unused variable: `foo_main_test`" :checker rust-cargo :id "unused_variables" :group 2)
+       '(4 17 info "to avoid this warning, consider using `_foo_main_test` instead" :checker rust-cargo :id "unused_variables" :group 2)))
 
     (let ((flycheck-rust-crate-type "bin")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-cargo-clean "language/rust/cargo-targets/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/src/bin/a.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_bin_a`" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "to avoid this warning, consider using `_foo_bin_a` instead" :checker rust-cargo :id "unused_variables")
-       '(4 17 warning "unused variable: `foo_bin_a_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "to avoid this warning, consider using `_foo_bin_a_test` instead" :checker rust-cargo :id "unused_variables")))
+       '(1 17 warning "unused variable: `foo_bin_a`" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "to avoid this warning, consider using `_foo_bin_a` instead" :checker rust-cargo :id "unused_variables" :group 1)
+       '(4 17 warning "unused variable: `foo_bin_a_test`" :checker rust-cargo :id "unused_variables" :group 2)
+       '(4 17 info "to avoid this warning, consider using `_foo_bin_a_test` instead" :checker rust-cargo :id "unused_variables" :group 2)))
 
     (let ((flycheck-rust-crate-type "bench")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-cargo-clean "language/rust/cargo-targets/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/benches/a.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_bench_a`" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "to avoid this warning, consider using `_foo_bench_a` instead" :checker rust-cargo :id "unused_variables")
-       '(4 17 warning "unused variable: `foo_bench_a_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "to avoid this warning, consider using `_foo_bench_a_test` instead" :checker rust-cargo :id "unused_variables")))
+       '(1 17 warning "unused variable: `foo_bench_a`" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "to avoid this warning, consider using `_foo_bench_a` instead" :checker rust-cargo :id "unused_variables" :group 1)
+       '(4 17 warning "unused variable: `foo_bench_a_test`" :checker rust-cargo :id "unused_variables" :group 2)
+       '(4 17 info "to avoid this warning, consider using `_foo_bench_a_test` instead" :checker rust-cargo :id "unused_variables" :group 2)))
 
     (let ((flycheck-rust-crate-type "test")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-cargo-clean "language/rust/cargo-targets/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/tests/a.rs" 'rust-mode
-       '(2 16 warning "unused variable: `foo_test_a_test`" :checker rust-cargo :id "unused_variables")
-       '(2 16 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(2 16 info "to avoid this warning, consider using `_foo_test_a_test` instead" :checker rust-cargo :id "unused_variables")
-       '(4 1 warning "function is never used: `foo_test_a`" :checker rust-cargo :id "dead_code")
-       '(4 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code")))
+       '(2 16 warning "unused variable: `foo_test_a_test`" :checker rust-cargo :id "unused_variables" :group 1)
+       '(2 16 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 1)
+       '(2 16 info "to avoid this warning, consider using `_foo_test_a_test` instead" :checker rust-cargo :id "unused_variables" :group 1)
+       '(4 1 warning "function is never used: `foo_test_a`" :checker rust-cargo :id "dead_code" :group 2)
+       '(4 1 info "#[warn(dead_code)] on by default" :checker rust-cargo :id "dead_code" :group 2)))
 
     (let ((flycheck-rust-crate-type "example")
           (flycheck-rust-binary-name "a"))
       (flycheck-ert-cargo-clean "language/rust/cargo-targets/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/cargo-targets/examples/a.rs" 'rust-mode
-       '(1 17 warning "unused variable: `foo_ex_a`" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(1 17 info "to avoid this warning, consider using `_foo_ex_a` instead" :checker rust-cargo :id "unused_variables")
-       '(4 17 warning "unused variable: `foo_ex_a_test`" :checker rust-cargo :id "unused_variables")
-       '(4 17 info "to avoid this warning, consider using `_foo_ex_a_test` instead" :checker rust-cargo :id "unused_variables")))))
+       '(1 17 warning "unused variable: `foo_ex_a`" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 1)
+       '(1 17 info "to avoid this warning, consider using `_foo_ex_a` instead" :checker rust-cargo :id "unused_variables" :group 1)
+       '(4 17 warning "unused variable: `foo_ex_a_test`" :checker rust-cargo :id "unused_variables" :group 2)
+       '(4 17 info "to avoid this warning, consider using `_foo_ex_a_test` instead" :checker rust-cargo :id "unused_variables" :group 2)))))
 
 (flycheck-ert-def-checker-test rust-cargo rust workspace-subcrate
   (let ((flycheck-disabled-checkers '(rust)))
@@ -4103,9 +4103,9 @@ The manifest path is relative to
       (flycheck-ert-cargo-clean "language/rust/workspace/crate1/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/workspace/crate1/src/lib.rs" 'rust-mode
-       '(2 7 warning "unused variable: `a`" :checker rust-cargo :id "unused_variables")
-       '(2 7 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(2 7 info "to avoid this warning, consider using `_a` instead" :checker rust-cargo :id "unused_variables")))))
+       '(2 7 warning "unused variable: `a`" :checker rust-cargo :id "unused_variables" :group 1)
+       '(2 7 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 1)
+       '(2 7 info "to avoid this warning, consider using `_a` instead" :checker rust-cargo :id "unused_variables" :group 1)))))
 
 (flycheck-ert-def-checker-test rust-cargo rust dev-dependencies
   (let ((flycheck-disabled-checkers '(rust)))
@@ -4114,55 +4114,55 @@ The manifest path is relative to
       (flycheck-ert-cargo-clean "language/rust/dev-deps/Cargo.toml")
       (flycheck-ert-should-syntax-check
        "language/rust/dev-deps/src/lib.rs" 'rust-mode
-       '(2 1 warning "unused `#[macro_use]` import" :checker rust-cargo :id "unused_imports")
-       '(2 1 info "#[warn(unused_imports)] on by default" :checker rust-cargo :id "unused_imports")
-       '(8 9 warning "unused variable: `foo`" :checker rust-cargo :id "unused_variables")
-       '(8 9 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables")
-       '(8 9 info "to avoid this warning, consider using `_foo` instead" :checker rust-cargo :id "unused_variables")))))
+       '(2 1 warning "unused `#[macro_use]` import" :checker rust-cargo :id "unused_imports" :group 1)
+       '(2 1 info "#[warn(unused_imports)] on by default" :checker rust-cargo :id "unused_imports" :group 1)
+       '(8 9 warning "unused variable: `foo`" :checker rust-cargo :id "unused_variables" :group 2)
+       '(8 9 info "#[warn(unused_variables)] on by default" :checker rust-cargo :id "unused_variables" :group 2)
+       '(8 9 info "to avoid this warning, consider using `_foo` instead" :checker rust-cargo :id "unused_variables" :group 2)))))
 
 (flycheck-ert-def-checker-test rust rust syntax-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/syntax-error.rs" 'rust-mode
-     '(4 5 error "cannot find value `bla` in this scope (not found in this scope)" :checker rust :id "E0425"))))
+     '(4 5 error "cannot find value `bla` in this scope (not found in this scope)" :checker rust :id "E0425" :group 1))))
 
 (flycheck-ert-def-checker-test rust rust type-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/multiline-error.rs" 'rust-mode
-     '(7 9 error "mismatched types (expected u8, found i8)" :checker rust :id "E0308"))))
+     '(7 9 error "mismatched types (expected u8, found i8)" :checker rust :id "E0308" :group 1))))
 
 (flycheck-ert-def-checker-test rust rust warning
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/warnings.rs" 'rust-mode
-     '(4 9 warning "unused variable: `x`" :checker rust :id "unused_variables")
-     '(4 9 info "#[warn(unused_variables)] on by default" :checker rust :id "unused_variables")
-     '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust :id "unused_variables"))))
+     '(4 9 warning "unused variable: `x`" :checker rust :id "unused_variables" :group 1)
+     '(4 9 info "#[warn(unused_variables)] on by default" :checker rust :id "unused_variables" :group 1)
+     '(4 9 info "to avoid this warning, consider using `_x` instead" :checker rust :id "unused_variables" :group 1))))
 
 (flycheck-ert-def-checker-test rust rust note-and-help
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/note-and-help.rs" 'rust-mode
-     '(11 9 info "value moved here" :checker rust :id "E0382")
-     '(12 9 error "use of moved value: `_x` (value used here after move)" :checker rust :id "E0382")
-     '(12 9 info "move occurs because `_x` has type `NonPOD`, which does not implement the `Copy` trait" :checker rust :id "E0382"))))
+     '(11 9 info "value moved here" :checker rust :id "E0382" :group 1)
+     '(12 9 error "use of moved value: `_x` (value used here after move)" :checker rust :id "E0382" :group 1)
+     '(12 9 info "move occurs because `_x` has type `NonPOD`, which does not implement the `Copy` trait" :checker rust :id "E0382" :group 1))))
 
 (flycheck-ert-def-checker-test rust rust crate-root-not-set
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/importing.rs" 'rust-mode
-     '(1 5 error "failed to resolve. There are too many initial `super`s. (There are too many initial `super`s.)" :checker rust :id "E0433")
-     '(1 5 warning "unused import: `super::imported`" :checker rust :id "unused_imports")
-     '(1 5 info "#[warn(unused_imports)] on by default" :checker rust :id "unused_imports")
-     '(4 24 error "failed to resolve. Use of undeclared type or module `imported` (Use of undeclared type or module `imported`)" :checker rust :id "E0433")
+     '(1 5 error "failed to resolve. There are too many initial `super`s. (There are too many initial `super`s.)" :checker rust :id "E0433" :group 2)
+     '(1 5 warning "unused import: `super::imported`" :checker rust :id "unused_imports" :group 1)
+     '(1 5 info "#[warn(unused_imports)] on by default" :checker rust :id "unused_imports" :group 1)
+     '(4 24 error "failed to resolve. Use of undeclared type or module `imported` (Use of undeclared type or module `imported`)" :checker rust :id "E0433" :group 3)
      )))
 
 (flycheck-ert-def-checker-test rust rust macro-error
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/macro-error.rs" 'rust-mode
-     '(2 3 info "1 positional argument in format string, but no arguments were given" :checker rust))))
+     '(2 3 info "1 positional argument in format string, but no arguments were given" :checker rust :group 1))))
 
 (flycheck-ert-def-checker-test sass sass nil
   (flycheck-ert-should-syntax-check

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1497,6 +1497,19 @@
     (should (equal (error-message-string data)
                    "Wrong type argument: flycheck-error-p, \"foo\""))))
 
+(ert-deftest flycheck-related-errors ()
+  :tags '(error-api)
+  (let ((flycheck-current-errors
+         (list (flycheck-error-new-at 5 7 'error "foo" :checker 'a :group 1)
+               (flycheck-error-new-at 8 9 'error "bar" :checker 'a :group 2)
+               (flycheck-error-new-at 1 4 'error "gul" :checker 'a :group 1)
+               (flycheck-error-new-at 4 5 'error "lag" :checker 'b :group 1))))
+    (should (equal (flycheck-related-errors (nth 0 flycheck-current-errors))
+                   (list (nth 0 flycheck-current-errors)
+                         (nth 2 flycheck-current-errors))))
+    (should (equal (flycheck-related-errors (nth 1 flycheck-current-errors))
+                   (list (nth 1 flycheck-current-errors))))))
+
 
 ;;; Errors in the current buffer
 


### PR DESCRIPTION
See individual commit messages for an overview.

Implementation note: Currently the `group` property, as used by the `rustc` parser is populated with `make-symbol` values.  This makes testing these values difficult using `equal`.  I've worked around the issue by doing the comparison on copies of errors that have `group` set to nil, and added a second check using `flycheck-related-errors`.

The better solution would be to use `group` values that can be checked against in the integration tests.  Or somehow redefine `equal` to optionally disregard the `group` slot.  I'm open to suggestions.