### PR TITLE
Recognise hpack projects in addition to cabal ones

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
     [GH-1289]
   - ``rust-cargo`` does not use the variable ``flycheck-rust-args`` anymore
     [GH-1289]
+  - Improve detection of default directory for ``haskell-ghc`` to consider
+    ``hpack`` project files [GH-1435]
 
 - New syntax checkers:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7979,7 +7979,7 @@ contains a cabal file."
      (when (buffer-file-name)
        (flycheck--locate-dominating-file-matching
         (file-name-directory (buffer-file-name))
-        ".+\\.cabal\\'")))))
+        "\\.cabal\\'\\|\\`package\\.yaml\\'")))))
 
 (flycheck-define-checker haskell-stack-ghc
   "A Haskell syntax and type checker using `stack ghc'.

--- a/flycheck.el
+++ b/flycheck.el
@@ -7951,7 +7951,7 @@ containing a file that matches REGEXP."
   (locate-dominating-file
    directory
    (lambda (dir)
-     (directory-files dir t regexp t))))
+     (directory-files dir nil regexp t))))
 
 (defun flycheck-haskell--find-default-directory (checker)
   "Come up with a suitable default directory for Haskell to run CHECKER in.


### PR DESCRIPTION
The `flycheck-haskell` project is about to add support for [hpack](https://github.com/sol/hpack)-basked Haskell projects. The difference from standard Haskell projects here is that instead of `.cabal` file a project has `package.yaml` file. Note that while `.cabal` file has different names for different packages, hpack's project file is always named `package.yaml`. Even though `.cabal` and `package.yaml` are frequently both present, in theory users can have only `package.yaml` present. So the proposed change is to recognized `package.yaml` as possible Haskell project file, just as we currently do for `.cabal` files.

The `flycheck-haskel` subproject is about to add similar support (https://github.com/flycheck/flycheck-haskell/issues/85), thus I thought it's a good time to add it to `flycheck` as well.