### PR TITLE
Prevent `stack` from installing GHC

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7924,7 +7924,9 @@ contains a cabal file."
          "stack.*\\.yaml\\'"))
       (-when-let* ((stack (funcall flycheck-executable-find "stack"))
                    (output (ignore-errors
-                             (process-lines stack "path" "--project-root")))
+                             (process-lines stack
+                                            "--no-install-ghc"
+                                            "path" "--project-root")))
                    (stack-dir (car output)))
         (and (file-directory-p stack-dir) stack-dir))))
     (_
@@ -7938,6 +7940,7 @@ contains a cabal file."
 
 See URL `https://github.com/commercialhaskell/stack'."
   :command ("stack"
+            "--no-install-ghc"
             (option "--stack-yaml" flycheck-ghc-stack-project-file)
             (option-flag "--nix" flycheck-ghc-stack-use-nix)
             "ghc" "--" "-Wall" "-no-link"


### PR DESCRIPTION
This should fix #1417.

Although since we have an `ignore-errors` in there, I'm not sure what happens if `stack` cannot find GHC.  Probably `output` is nil, then we return the location of the cabal file, if any.

Maybe we need to pass `--no-install-ghc` to the `stack` invocation in `haskell-stack-ghc` as well?

WDYT @flycheck/haskell ?