### PR TITLE
Call `ansi-color-filter-apply` in nix checker error parser

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -89,6 +89,7 @@
 ;; Tell the byte compiler about autoloaded functions from packages
 (declare-function pkg-info-version-info "pkg-info" (package))
 
+(autoload 'ansi-color-filter-apply "ansi-color")
 
 ;;; Compatibility
 (eval-and-compile
@@ -9217,6 +9218,9 @@ See URL `https://github.com/mivok/markdownlint'."
 See URL `https://nixos.org/nix/manual/#sec-nix-instantiate'."
   :command ("nix-instantiate" "--parse" "-")
   :standard-input t
+  :error-parser
+  (lambda (output checker buffer)
+    (flycheck-parse-with-patterns (ansi-color-filter-apply output) checker buffer))
   :error-patterns
   ((error line-start
           "error: " (message) " at " (file-name) ":" line ":" column


### PR DESCRIPTION
Nix 2.0 outputs ANSI terminal colors, we strip those colors before passing it to the default behavior.

tests:

```
make LANGUAGE=nix integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-buttercup.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (language nix))'
Running tests on Emacs 25.3.1, built at 2018-02-19
Running 1 tests (2018-04-03 09:45:41-0500)
   passed  1/1  flycheck-define-checker/nix/default

Ran 1 tests, 1 results as expected (2018-04-03 09:45:42-0500)

```
