### PR TITLE
Pass `-lang en` flag to tidy

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8157,7 +8157,9 @@ See URL `https://github.com/ndmitchell/hlint'."
   "A HTML syntax and style checker using Tidy.
 
 See URL `https://github.com/htacg/tidy-html5'."
-  :command ("tidy" (config-file "-config" flycheck-tidyrc) "-e" "-q")
+  :command ("tidy" (config-file "-config" flycheck-tidyrc)
+            "-lang" "en"
+            "-e" "-q")
   :standard-input t
   :error-patterns
   ((error line-start


### PR DESCRIPTION
Localized error messages also localize the diagnostic
type (e.g. "Warning" becomes "Avertissement" in French), which make them
unparseable by Flycheck.

Forcing English messages makes Flycheck parse the diagnostic correctly,
at the cost of losing the localization.

This is a partial fix for GH-1376.