### PR TITLE
Add informational category (I) to python-pylint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8907,7 +8907,8 @@ See URL `https://www.pylint.org/'."
             (id (one-or-more (not (any ":")))) ":"
             (message) line-end)
    (info line-start (file-name) ":" line ":" column ":"
-         "C:" (id (one-or-more (not (any ":")))) ":"
+         (or "C" "I") ":"
+         (id (one-or-more (not (any ":")))) ":"
          (message) line-end))
   :enabled (lambda ()
              (or (not (flycheck-python-needs-module-p 'python-pylint))


### PR DESCRIPTION
The `python-pylint` checker currently maps messages from `pylint` _categories_ to `flycheck` categories as:
- Error, Fatal  => error
- Warning, Refactor => warning
- Convention => info

`pylint` now also produces messages in another category, "Informational".  This patch maps those to flychecks informational category as well.