### PR TITLE
Support mhtml-mode

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8113,7 +8113,7 @@ See URL `https://github.com/htacg/tidy-html5'."
             "line " line
             " column " column
             " - Warning: " (message) line-end))
-  :modes (html-mode nxhtml-mode))
+  :modes (html-mode mhtml-mode nxhtml-mode))
 
 (flycheck-def-config-file-var flycheck-jshintrc javascript-jshint ".jshintrc"
   :safe #'stringp)


### PR DESCRIPTION
Since Emacs 26.1, mhtml-mode is now the default mode for html files, also see https://github.com/emacs-mirror/emacs/blob/766b057e41/etc/NEWS.26#L1052