### PR TITLE
prevent redisplaying while recentering the flycheck error list window

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4205,7 +4205,8 @@ ALL-FRAMES specifies the frames to consider, as in
   (dolist (window (flycheck-get-error-list-window-list t))
     (with-selected-window window
       (goto-char pos)
-      (recenter))))
+      (let ((recenter-redisplay nil))
+        (recenter)))))
 
 (defun flycheck-error-list-refresh ()
   "Refresh the current error list.


### PR DESCRIPTION
Currently flycheck will redisplay the entire frame when Emacs is being used in
the terminal and the error list is recentered. This will cause great amount of
flickering specially when I use to C-n to move through a bunch of consecutive
lines with warnings or errors.

I discussed this in a thread on the help-gnu-emacs mailing list [1]. The
current change was suggested on the thread as a workaround. There is also an
open bug [2] to change the default behavior of `recenter' or introduce a new
function that would not redraw the frame.

[1] http://lists.gnu.org/archive/html/help-gnu-emacs/2018-04/msg00326.html
[2] http://debbugs.gnu.org/cgi/bugreport.cgi?bug=31325