### PR TITLE
Use header-line-format for the Message / Checker column

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3984,8 +3984,7 @@ MESSAGE and CHECKER are displayed in a single column to allow the
 message to stretch arbitrarily far."
   (let ((checker-name (propertize (symbol-name checker)
                                   'face 'flycheck-error-list-checker-name)))
-    (format (propertize "%s (%s)" 'face 'default)
-            message checker-name)))
+    (format "%s (%s)" message checker-name)))
 
 (defconst flycheck-error-list-format
   `[("File" 6)
@@ -4061,7 +4060,8 @@ message to stretch arbitrarily far."
 
 (define-button-type 'flycheck-error-list
   'action #'flycheck-error-list-button-goto-error
-  'help-echo "mouse-2, RET: goto error")
+  'help-echo "mouse-2, RET: goto error"
+  'face nil)
 
 (defun flycheck-error-list-button-goto-error (button)
   "Go to the error at BUTTON."


### PR DESCRIPTION
Fixes #1293

~As outlined in #1293 it would be good to use the `header-line-format` face across the entire tabulated list header. The other columns respect this face and the last one should as well.~

EDIT: I am now only propertizing the checker name, and not the entire column.
