### PR TITLE
Hadolint has a new home

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -212,7 +212,7 @@ EOF
 
     echo "Installing hadolint..."
     if [ ! -d hadolint ]; then
-      git clone --depth=1 https://github.com/lukasmartinelli/hadolint
+      git clone --depth=1 https://github.com/hadolint/hadolint
     else
       pushd hadolint
       git pull

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -295,7 +295,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check syntax and code style with hadolint_
 
-      .. _hadolint: http://hadolint.lukasmartinelli.ch/
+      .. _hadolint: https://github.com/hadolint/hadolint
 
 .. supported-language:: Emacs Lisp
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7000,7 +7000,7 @@ Requires DMD 2.066 or newer.  See URL `http://dlang.org/'."
 (flycheck-define-checker dockerfile-hadolint
   "A Dockerfile syntax checker using the hadolint.
 
-See URL `http://hadolint.lukasmartinelli.ch/'."
+See URL `http://github.com/hadolint/hadolint/'."
   :command ("hadolint" "-")
   :standard-input t
   :error-patterns


### PR DESCRIPTION
Hadolint development was moved to an organization in github, and the code
has been improved since. flycheck should take advantage of this