### PR TITLE
Add a check for long lines in `make check`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,7 @@ script:
   case $JOB in
     emacs)
       # Check formatting (our formatting rules don’t work on Emacs 24).
-      # FIXME: this should run on Emacs 26 as well
-      if [[ $EMACS_VERSION == 25.* ]]; then
+      if [[ $EMACS_VERSION != 24.* ]]; then
         docker run --volume "$TRAVIS_BUILD_DIR":/flycheck \
                    --workdir /flycheck \
                    flycheck/emacs-cask:$EMACS_VERSION \

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -57,11 +57,12 @@ Defaults to `error'."
       (let ((conditions
              (if (consp parent)
                  (apply #'append
-                        (mapcar (lambda (parent)
-                                  (cons parent
-                                        (or (get parent 'error-conditions)
-                                            (error "Unknown signal `%s'" parent))))
-                                parent))
+                        (mapcar
+                         (lambda (parent)
+                           (cons parent
+                                 (or (get parent 'error-conditions)
+                                     (error "Unknown signal `%s'" parent))))
+                         parent))
                (cons parent (get parent 'error-conditions)))))
         (put name 'error-conditions
              (delete-dups (copy-sequence (cons name conditions))))
@@ -196,7 +197,8 @@ should use to lookup resource files."
   (let ((tests (ert-select-tests t t)))
     ;; Select all tests
     (unless tests
-      (error "No tests defined.  Call `flycheck-ert-initialize' after defining all tests!"))
+      (error "No tests defined.  \
+Call `flycheck-ert-initialize' after defining all tests!"))
 
     (setq flycheck-ert--resource-directory resource-dir)
 
@@ -257,10 +259,11 @@ case, including assertions and setup code."
        :expected-result ,(or (plist-get keys :expected-result) :passed)
        :tags (append ',(append default-tags language-tags checker-tags)
                      ,(plist-get keys :tags))
-       ,@(mapcar (lambda (c) `(skip-unless
-                               ;; Ignore non-command checkers
-                               (or (not (flycheck-checker-get ',c 'command))
-                                   (executable-find (flycheck-checker-executable ',c)))))
+       ,@(mapcar (lambda (c)
+                   `(skip-unless
+                     ;; Ignore non-command checkers
+                     (or (not (flycheck-checker-get ',c 'command))
+                         (executable-find (flycheck-checker-executable ',c)))))
                  checkers)
        ,@body)))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -8693,8 +8693,10 @@ See URL `https://pugjs.org/'."
           (zero-or-more not-newline) "\n"
           (one-or-more
            (zero-or-more not-newline) "|"
-           (zero-or-more not-newline) "\n") (zero-or-more not-newline) "\n"
-           (message) line-end))
+           (zero-or-more not-newline) "\n")
+          (zero-or-more not-newline) "\n"
+          (message)
+          line-end))
   :modes pug-mode)
 
 (flycheck-define-checker puppet-parser

--- a/flycheck.el
+++ b/flycheck.el
@@ -465,8 +465,9 @@ searches `exec-path'.  You can customize this option to search
 for checkers in other environments such as bundle or NixOS
 sandboxes."
   :group 'flycheck
-  :type '(choice (const :tag "Search executables in `exec-path'" executable-find)
-                 (function :tag "Search executables with a custom function"))
+  :type '(choice
+          (const :tag "Search executables in `exec-path'" executable-find)
+          (function :tag "Search executables with a custom function"))
   :package-version '(flycheck . "0.25")
   :risky t)
 
@@ -1808,7 +1809,8 @@ Signal an error, if any property has an invalid value."
                      (let ((default-directory
                              (flycheck-compute-working-directory symbol)))
                        (funcall enabled)))
-               (lwarn 'flycheck :warning "%S is no valid Flycheck syntax checker.
+               (lwarn 'flycheck
+                      :warning "%S is no valid Flycheck syntax checker.
 Try to reinstall the package defining this syntax checker." symbol)
                nil))))
       (pcase-dolist (`(,prop . ,value)
@@ -1964,7 +1966,8 @@ Pop up a help buffer with the documentation of CHECKER."
           (with-current-buffer standard-output
             (save-excursion
               (re-search-backward "`\\([^`']+\\)'" nil t)
-              (help-xref-button 1 'help-flycheck-checker-def checker filename))))
+              (help-xref-button 1 'help-flycheck-checker-def
+                                checker filename))))
         (princ ".\n\n")
 
         (let ((modes-start (with-current-buffer standard-output (point-max))))
@@ -2132,7 +2135,8 @@ BUFFER is the buffer being verified."
    (with-current-buffer buffer
      ;; Use key binding state in the verified buffer to print the help.
      (substitute-command-keys
-      ".  Use \\[universal-argument] \\[flycheck-disable-checker] to enable disabled checkers.")))
+      ".  Use \\[universal-argument] \\[flycheck-disable-checker] \
+to enable disabled checkers.")))
   (save-excursion
     (let ((end (point)))
       (backward-paragraph)
@@ -2167,10 +2171,12 @@ is applicable from Emacs Lisp code.  Use
         (flycheck--verify-print-header "Syntax checker in buffer " buffer)
         (flycheck--verify-princ-checker checker buffer 'with-mm)
         (if (with-current-buffer buffer (flycheck-may-use-checker checker))
-            (insert (propertize "Flycheck can use this syntax checker for this buffer.\n"
-                                'face 'success))
-          (insert (propertize "Flycheck cannot use this syntax checker for this buffer.\n"
-                              'face 'error)))
+            (insert (propertize
+                     "Flycheck can use this syntax checker for this buffer.\n"
+                     'face 'success))
+          (insert (propertize
+                   "Flycheck cannot use this syntax checker for this buffer.\n"
+                   'face 'error)))
         (insert "\n")
         (flycheck--verify-print-footer buffer)))))
 
@@ -2196,26 +2202,32 @@ possible problems are shown."
       (with-current-buffer standard-output
         (flycheck--verify-print-header "Syntax checkers for buffer " buffer)
         (unless checkers
-          (insert (propertize "There are no syntax checkers for this buffer!\n\n"
-                              'face '(bold error))))
+          (insert (propertize
+                   "There are no syntax checkers for this buffer!\n\n"
+                   'face '(bold error))))
         (dolist (checker checkers)
           (flycheck--verify-princ-checker checker buffer))
 
-        (-when-let (selected-checker (buffer-local-value 'flycheck-checker buffer))
-          (insert (propertize "The following checker is explicitly selected for this buffer:\n\n"
-                              'face 'bold))
+        (-when-let (selected-checker
+                    (buffer-local-value 'flycheck-checker buffer))
+          (insert
+           (propertize
+            "The following checker is explicitly selected for this buffer:\n\n"
+            'face 'bold))
           (flycheck--verify-princ-checker selected-checker buffer 'with-mm))
 
-        (let ((unregistered-checkers (seq-difference (flycheck-defined-checkers)
-                                                     flycheck-checkers)))
+        (let ((unregistered-checkers
+               (seq-difference (flycheck-defined-checkers) flycheck-checkers)))
           (when unregistered-checkers
-            (insert (propertize "\nThe following syntax checkers are not registered:\n\n"
-                                'face '(bold warning)))
+            (insert (propertize
+                     "\nThe following syntax checkers are not registered:\n\n"
+                     'face '(bold warning)))
             (dolist (checker unregistered-checkers)
               (princ "  - ")
               (princ checker)
               (princ "\n"))
-            (princ "\nTry adding these syntax checkers to `flycheck-checkers'.\n")))
+            (princ
+             "\nTry adding these syntax checkers to `flycheck-checkers'.\n")))
 
         (flycheck--verify-print-footer buffer)))
 
@@ -2303,7 +2315,8 @@ Slots:
 (defun flycheck-syntax-check-start (syntax-check callback)
   "Start a SYNTAX-CHECK with CALLBACK."
   (let ((checker (flycheck-syntax-check-checker syntax-check))
-        (default-directory (flycheck-syntax-check-working-directory syntax-check)))
+        (default-directory
+          (flycheck-syntax-check-working-directory syntax-check)))
     (setf (flycheck-syntax-check-context syntax-check)
           (funcall (flycheck-checker-get checker 'start) checker callback))))
 
@@ -2396,9 +2409,10 @@ buffer manually.
     (pcase-dolist (`(,hook . ,fn) flycheck-hooks-alist)
       (add-hook hook fn nil 'local))
 
-    (setq flycheck-old-next-error-function (if flycheck-standard-error-navigation
-                                               next-error-function
-                                             :unset))
+    (setq flycheck-old-next-error-function
+          (if flycheck-standard-error-navigation
+              next-error-function
+            :unset))
     (when flycheck-standard-error-navigation
       (setq next-error-function #'flycheck-next-error-function)))
    (t
@@ -2473,7 +2487,8 @@ the syntax checker to the buffer-local value of
 With non-nil ENABLE or with prefix arg, prompt for a disabled
 syntax checker and re-enable it by removing it from the
 buffer-local value of `flycheck-disabled-checkers'."
-  (declare (interactive-only "Directly set `flycheck-disabled-checkers' instead"))
+  (declare
+   (interactive-only "Directly set `flycheck-disabled-checkers' instead"))
   (interactive
    (let* ((enable current-prefix-arg)
           (candidates (if enable flycheck-disabled-checkers flycheck-checkers))
@@ -2509,11 +2524,12 @@ Set `flycheck-current-syntax-check' accordingly."
   ;; Allocate the current syntax check *before* starting it.  This allows for
   ;; synchronous checks, which call the status callback immediately in their
   ;; start function.
-  (let* ((check (flycheck-syntax-check-new
-                 :buffer (current-buffer)
-                 :checker checker
-                 :context nil
-                 :working-directory (flycheck-compute-working-directory checker)))
+  (let* ((check
+          (flycheck-syntax-check-new
+           :buffer (current-buffer)
+           :checker checker
+           :context nil
+           :working-directory (flycheck-compute-working-directory checker)))
          (callback (flycheck-buffer-status-callback check)))
     (setq flycheck-current-syntax-check check)
     (flycheck-report-status 'running)
@@ -2907,11 +2923,12 @@ variables of Flycheck."
 ;;; Errors from syntax checks
 (cl-defstruct (flycheck-error
                (:constructor flycheck-error-new)
-               (:constructor flycheck-error-new-at (line column
-                                                         &optional level message
-                                                         &key checker id group
-                                                         (filename (buffer-file-name))
-                                                         (buffer (current-buffer)))))
+               (:constructor flycheck-error-new-at
+                             (line column
+                                   &optional level message
+                                   &key checker id group
+                                   (filename (buffer-file-name))
+                                   (buffer (current-buffer)))))
   "Structure representing an error reported by a syntax checker.
 Slots:
 
@@ -3091,7 +3108,8 @@ non-whitespace character of the error line, if ERR has no error column."
   (let ((id (flycheck-error-id err))
         (filename (flycheck-error-filename err)))
     (concat (when (and filename (not (equal filename (buffer-file-name))))
-              (format "In \"%s\":\n" (file-relative-name filename default-directory)))
+              (format "In \"%s\":\n"
+                      (file-relative-name filename default-directory)))
             (flycheck-error-message err)
             (when id
               (format " [%s]" id)))))
@@ -3744,7 +3762,8 @@ Return the created overlay."
                 (if (flycheck-relevant-error-other-file-p err)
                     ;; Display overlays for other-file errors on the first line
                     (cons (point-min)
-                          (save-excursion (goto-char (point-min)) (point-at-eol)))
+                          (save-excursion (goto-char (point-min))
+                                          (point-at-eol)))
                   (flycheck-error-region-for-mode
                    err (or flycheck-highlighting-mode 'lines))))
                (overlay (make-overlay beg end))
@@ -3990,7 +4009,8 @@ message to stretch arbitrarily far."
    flycheck-error-list-padding)
   "Amount of space to use in `flycheck-flush-multiline-message'.")
 
-(define-derived-mode flycheck-error-list-mode tabulated-list-mode "Flycheck errors"
+(define-derived-mode flycheck-error-list-mode tabulated-list-mode
+  "Flycheck errors"
   "Major mode for listing Flycheck errors.
 
 \\{flycheck-error-list-mode-map}"
@@ -4099,7 +4119,8 @@ Return a list with the contents of the table cell."
          (id (flycheck-error-id error))
          (id-str (if id (format "%s" id) ""))
          (checker (flycheck-error-checker error))
-         (msg-and-checker (flycheck-error-list-make-last-column flushed-msg checker))
+         (msg-and-checker
+          (flycheck-error-list-make-last-column flushed-msg checker))
          (explainer (flycheck-checker-get checker 'error-explainer)))
     (list error
           (vector (flycheck-error-list-make-cell
@@ -4113,7 +4134,8 @@ Return a list with the contents of the table cell."
                    column 'flycheck-error-list-column-number)
                   (flycheck-error-list-make-cell
                    (symbol-name (flycheck-error-level error)) level-face)
-                  ;; Error ID use a different face when an error-explainer is present
+                  ;; Error ID use a different face when an error-explainer is
+                  ;; present
                   (flycheck-error-list-make-cell
                    id-str (if explainer 'flycheck-error-list-id-with-explainer
                             'flycheck-error-list-id)
@@ -4385,9 +4407,9 @@ non-nil."
                     (setq min-point (min min-point beg)
                           max-point (max max-point beg))
                     (let ((ov (make-overlay beg
-                                            ;; Extend overlay to the beginning of
-                                            ;; the next line, to highlight the
-                                            ;; whole line
+                                            ;; Extend overlay to the beginning
+                                            ;; of the next line, to highlight
+                                            ;; the whole line
                                             (or end (point-max)))))
                       (push ov flycheck-error-list-highlight-overlays)
                       (setf (overlay-get ov 'flycheck-error-highlight-overlay)
@@ -4455,7 +4477,8 @@ non-nil."
   (flycheck-cancel-error-display-error-at-point-timer)
   (when (flycheck-overlays-at (point))
     (setq flycheck-display-error-at-point-timer
-          (run-at-time flycheck-display-errors-delay nil 'flycheck-display-error-at-point))))
+          (run-at-time flycheck-display-errors-delay nil
+                       'flycheck-display-error-at-point))))
 
 
 ;;; Functions to display errors
@@ -5071,7 +5094,8 @@ and rely on Emacs' own buffering and chunking."
           (process-put process 'flycheck-checker checker)
           (process-put process 'flycheck-callback callback)
           (process-put process 'flycheck-buffer (current-buffer))
-          ;; The default directory is bound in the `flycheck-syntax-check-start' function.
+          ;; The default directory is bound in the `flycheck-syntax-check-start'
+          ;; function.
           (process-put process 'flycheck-working-directory default-directory)
           ;; Track the temporaries created by argument substitution in the
           ;; process itself, to get rid of the global state ASAP.
@@ -5125,7 +5149,8 @@ and rely on Emacs' own buffering and chunking."
           (fill-region-as-paragraph doc-start (point-max)))))
     (princ "\n")
     (when option-vars
-      (princ "\n  This syntax checker can be configured with these options:\n\n")
+      (princ
+       "\n  This syntax checker can be configured with these options:\n\n")
       (dolist (var option-vars)
         (princ (format "     * `%s'\n" var))))))
 
@@ -5515,11 +5540,12 @@ shell execution."
   ;; does not properly quote shell arguments, and actually breaks for special
   ;; characters.  See https://github.com/flycheck/flycheck/pull/522
   (let* ((args (apply #'append
-                      (seq-map (lambda (arg)
-                                 (if (memq arg '(source source-inplace source-original))
-                                     (list (buffer-file-name))
-                                   (flycheck-substitute-argument arg checker)))
-                               (flycheck-checker-arguments checker))))
+                      (seq-map
+                       (lambda (arg)
+                         (if (memq arg '(source source-inplace source-original))
+                             (list (buffer-file-name))
+                           (flycheck-substitute-argument arg checker)))
+                       (flycheck-checker-arguments checker))))
          (command (mapconcat
                    #'shell-quote-argument
                    (funcall flycheck-command-wrapper-function
@@ -5713,7 +5739,8 @@ about Cppcheck."
                                  nil
                                  level
                                  ;; cppcheck return newline characters as "\012"
-                                 (replace-regexp-in-string "\\\\012" "\n" message)
+                                 (replace-regexp-in-string "\\\\012" "\n"
+                                                           message)
                                  :id id
                                  :checker checker
                                  :buffer buffer
@@ -5989,9 +6016,8 @@ The expected format for OUTPUT is a mix of plain text lines and
 JSON lines.  This function ignores the plain text lines and
 parses only JSON lines.  Each JSON line is expected to be a JSON
 object that represents a message from Cargo.  The format of
-messages emitted by Cargo is described there:
-
-https://github.com/rust-lang/cargo/blob/master/src/cargo/util/machine_message.rs#L20-L31"
+messages emitted by Cargo is described in cargo's
+machine_message.rs at URL `https://git.io/vh24R'."
   (let ((errors))
     (dolist (msg (flycheck-parse-json output))
       (let-alist msg
@@ -6193,7 +6219,8 @@ Uses the GNAT compiler from GCC.  See URL
          ": note: " (message) line-end)
    (warning line-start (file-name) ":" line ":" column
             ": warning: " (message) line-end)
-   (error line-start (file-name) ":" line ":" column ;no specific error prefix in Ada
+   ;; no specific error prefix in Ada
+   (error line-start (file-name) ":" line ":" column
           ": " (message) line-end))
   :modes ada-mode)
 
@@ -6674,7 +6701,8 @@ See URL `http://cppcheck.sourceforge.net/'."
             (option-list "-I" flycheck-cppcheck-include-path)
             (option-list "--std=" flycheck-cppcheck-standards concat)
             (option-list "--suppress=" flycheck-cppcheck-suppressions concat)
-            (option "--suppressions-list=" flycheck-cppcheck-suppressions-file concat)
+            (option "--suppressions-list="
+                    flycheck-cppcheck-suppressions-file concat)
             "-x" (eval
                   (pcase major-mode
                     (`c++-mode "c++")
@@ -6924,8 +6952,8 @@ See URL `http://stylelint.io/'."
 (flycheck-def-option-var flycheck-cwl-schema-path nil cwl
   "A path for the schema file for Common Workflow Language.
 
-The value of this variable is a string that denotes a path for the schema file of
-Common Workflow Language."
+The value of this variable is a string that denotes a path for
+the schema file of Common Workflow Language."
   :type 'string
   :safe #'stringp)
 
@@ -7422,7 +7450,8 @@ Relative paths are relative to the file being checked."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.20"))
 
-(flycheck-def-option-var flycheck-gfortran-language-standard "f95" fortran-gfortran
+(flycheck-def-option-var flycheck-gfortran-language-standard "f95"
+                         fortran-gfortran
   "The language standard to use in GFortran.
 
 The value of this variable is either a string denoting a language
@@ -7489,9 +7518,10 @@ Uses GCC's Fortran compiler gfortran.  See URL
   :command ("gfortran"
             "-fsyntax-only"
             "-fshow-column"
-            "-fno-diagnostics-show-caret" ; Do not visually indicate the source location
-            "-fno-diagnostics-show-option" ; Do not show the corresponding
-                                        ; warning group
+            ;; Do not visually indicate the source location
+            "-fno-diagnostics-show-caret"
+            ;; Do not show the corresponding warning group
+            "-fno-diagnostics-show-option"
             ;; Fortran has similar include processing as C/C++
             "-iquote" (eval (flycheck-c/c++-quoted-include-directory))
             (option "-std=" flycheck-gfortran-language-standard concat)
@@ -7518,7 +7548,8 @@ See URL `https://golang.org/cmd/gofmt/'."
   :command ("gofmt")
   :standard-input t
   :error-patterns
-  ((error line-start "<standard input>:" line ":" column ": " (message) line-end))
+  ((error line-start "<standard input>:" line ":" column ": "
+          (message) line-end))
   :modes go-mode
   :next-checkers ((warning . go-golint)
                   ;; Fall back, if go-golint doesn't exist
@@ -7570,7 +7601,8 @@ This option requires Go 1.6 or newer."
                  (const :tag "Check for shadowed variables" t)
                  (const :tag "Strictly check for shadowed variables" strict)))
 
-(flycheck-def-option-var flycheck-go-megacheck-disabled-checkers nil go-megacheck
+(flycheck-def-option-var flycheck-go-megacheck-disabled-checkers nil
+                         go-megacheck
   "A list of checkers to disable when running `megacheck'.
 
 The value of this variable is a list of strings, where each
@@ -8622,8 +8654,10 @@ See URL `http://proselint.com/'."
 See URL `https://developers.google.com/protocol-buffers/'."
   :command ("protoc" "--error_format" "gcc"
             (eval (concat "--java_out=" (flycheck-temp-dir-system)))
-            ;; Add the file directory of protobuf path to resolve import directives
-            (eval (concat "--proto_path=" (file-name-directory (buffer-file-name))))
+            ;; Add the file directory of protobuf path to resolve import
+            ;; directives
+            (eval (concat "--proto_path="
+                          (file-name-directory (buffer-file-name))))
             source-inplace)
   :error-patterns
   ((info line-start (file-name) ":" line ":" column
@@ -8649,7 +8683,8 @@ See URL `https://pugjs.org/'."
           (zero-or-more not-newline) " line " line)
    ;; syntax/runtime errors (e.g. type errors, bad indentation, etc.)
    (error line-start
-          (optional "Type") "Error: "  (file-name) ":" line (optional ":" column)
+          (optional "Type") "Error: "  (file-name) ":"
+          line (optional ":" column)
           (zero-or-more not-newline) "\n"
           (one-or-more (or (zero-or-more not-newline) "|"
                            (zero-or-more not-newline) "\n")
@@ -8976,7 +9011,8 @@ See URL `http://mypy-lang.org/'."
   ((error line-start (file-name) ":" line ": error:" (message) line-end)
    (warning line-start (file-name) ":" line ": warning:" (message) line-end))
   :modes python-mode
-  ;; Ensure the file is saved, to work around https://github.com/python/mypy/issues/4746.
+  ;; Ensure the file is saved, to work around
+  ;; https://github.com/python/mypy/issues/4746.
   :predicate flycheck-buffer-saved-p
   :next-checkers '(t . python-flake8))
 
@@ -9007,7 +9043,8 @@ expression, which selects linters for lintr."
                     "--slave" "--restore" "--no-save" "-e"
                     "library('lintr')")
       (goto-char (point-min))
-      (not (re-search-forward "there is no package called 'lintr'" nil 'no-error)))))
+      (not (re-search-forward "there is no package called 'lintr'"
+                              nil 'no-error)))))
 
 (flycheck-define-checker r-lintr
   "An R style and syntax checker using the lintr package.
@@ -9128,8 +9165,9 @@ See URL `https://sourceforge.net/projects/rpmlint/'."
   :error-explainer
   (lambda (error)
     (-when-let* ((error-message (flycheck-error-message error))
-                 (message-id (save-match-data (string-match "\\([^ ]+\\)" error-message)
-                                              (match-string 1 error-message))))
+                 (message-id (save-match-data
+                               (string-match "\\([^ ]+\\)" error-message)
+                               (match-string 1 error-message))))
       (with-output-to-string
         (call-process "rpmlint" nil standard-output nil "-I" message-id))))
   :modes (sh-mode rpm-spec-mode)
@@ -9518,21 +9556,22 @@ Relative paths are relative to the file being checked."
 
 (defun flycheck-rust-error-filter (errors)
   "Filter ERRORS from rustc output that have no explanatory value."
-  (seq-remove (lambda (err)
-                (or
-                 ;; Macro errors emit a diagnostic in a phony file,
-                 ;; e.g. "<println macros>".
-                 (string-match-p
-                  (rx "macros>" line-end)
-                  (flycheck-error-filename err))
-                 ;; Redundant message giving the number of failed errors
-                 (string-match-p
-                  (rx (or (: "aborting due to " (optional (one-or-more num) " ")
-                             "previous error")
-                          (: "For more information about this error, try `rustc --explain "
-                             (one-or-more alnum) "`.")))
-                  (flycheck-error-message err))))
-              errors))
+  (seq-remove
+   (lambda (err)
+     (or
+      ;; Macro errors emit a diagnostic in a phony file,
+      ;; e.g. "<println macros>".
+      (string-match-p
+       (rx "macros>" line-end)
+       (flycheck-error-filename err))
+      ;; Redundant message giving the number of failed errors
+      (string-match-p
+       (rx (or (: "aborting due to " (optional (one-or-more num) " ")
+                  "previous error")
+               (: "For more information about this error, try `rustc --explain "
+                  (one-or-more alnum) "`.")))
+       (flycheck-error-message err))))
+   errors))
 
 (defun flycheck-rust-manifest-directory ()
   "Return the nearest directory holding the Cargo manifest.
@@ -9626,7 +9665,8 @@ This syntax checker requires Rust 1.17 or newer.  See URL
              :label "Crate type"
              :message (if valid-crate-type
                           (format "%s" flycheck-rust-crate-type)
-                        (format "%s (invalid, should be one of 'lib', 'bin', 'test', 'example' or 'bench')"
+                        (format "%s (invalid, should be one of 'lib', 'bin', \
+'test', 'example' or 'bench')"
                                 flycheck-rust-crate-type))
              :face (if valid-crate-type 'success '(bold error)))
             (flycheck-verification-result-new
@@ -9739,7 +9779,8 @@ See URL `http://sass-lang.com'."
             line-end))
   :modes sass-mode)
 
-(flycheck-def-config-file-var flycheck-sass-lintrc sass/scss-sass-lint ".sass-lint.yml"
+(flycheck-def-config-file-var flycheck-sass-lintrc sass/scss-sass-lint
+                              ".sass-lint.yml"
   :safe #'stringp
   :package-version '(flycheck . "30"))
 
@@ -9907,27 +9948,28 @@ See URL `https://github.com/brigade/scss-lint'."
   ;; Flycheck error.
   :error-parser flycheck-parse-scss-lint
   :modes scss-mode
-  :verify (lambda (checker)
-            (let* ((executable (flycheck-find-checker-executable checker))
-                   (reporter-missing
-                    (and executable
-                         (with-temp-buffer
-                           (call-process executable nil t nil
-                                         "--require=scss_lint_reporter_checkstyle")
-                           (goto-char (point-min))
-                           (re-search-forward
-                            flycheck-scss-lint-checkstyle-re
-                            nil 'no-error)))))
-              (when executable
-                (list
-                 (flycheck-verification-result-new
-                  :label "checkstyle reporter"
-                  :message (if reporter-missing
-                               "scss_lint_reporter_checkstyle missing"
-                             "present")
-                  :face (if reporter-missing
-                            '(bold error)
-                          'success)))))))
+  :verify
+  (lambda (checker)
+    (let* ((executable (flycheck-find-checker-executable checker))
+           (reporter-missing
+            (and executable
+                 (with-temp-buffer
+                   (call-process executable nil t nil
+                                 "--require=scss_lint_reporter_checkstyle")
+                   (goto-char (point-min))
+                   (re-search-forward
+                    flycheck-scss-lint-checkstyle-re
+                    nil 'no-error)))))
+      (when executable
+        (list
+         (flycheck-verification-result-new
+          :label "checkstyle reporter"
+          :message (if reporter-missing
+                       "scss_lint_reporter_checkstyle missing"
+                     "present")
+          :face (if reporter-missing
+                    '(bold error)
+                  'success)))))))
 
 (flycheck-define-checker scss-stylelint
   "A SCSS syntax and style checker using stylelint.
@@ -10078,7 +10120,8 @@ See URL `https://github.com/koalaman/shellcheck/'."
   :command ("shellcheck"
             "--format" "checkstyle"
             "--shell" (eval (symbol-name sh-shell))
-            (option-flag "--external-sources" flycheck-shellcheck-follow-sources)
+            (option-flag "--external-sources"
+                         flycheck-shellcheck-follow-sources)
             (option "--exclude" flycheck-shellcheck-excluded-warnings list
                     flycheck-option-comma-separated-list)
             "-")
@@ -10145,7 +10188,8 @@ See URL `https://github.com/purcell/sqlint'."
 (flycheck-define-checker systemd-analyze
   "A systemd unit checker using systemd-analyze(1).
 
-See URL `https://www.freedesktop.org/software/systemd/man/systemd-analyze.html'."
+See URL
+`https://www.freedesktop.org/software/systemd/man/systemd-analyze.html'."
   :command ("systemd-analyze" "verify" source)
   :error-patterns
   ((error line-start "[" (file-name) ":" line "] " (message) line-end))

--- a/test/init.el
+++ b/test/init.el
@@ -58,7 +58,8 @@ in this file."
   (setq package-user-dir (expand-file-name "init-elpa" (file-name-directory
                                                         flycheck/init-file))
         package-check-signature nil)
-  (add-to-list 'package-archives '("MELPA" . "https://stable.melpa.org/packages/"))
+  (add-to-list 'package-archives
+               '("MELPA" . "https://stable.melpa.org/packages/"))
 
   (package-initialize)
 
@@ -84,8 +85,8 @@ in this file."
   (ido-mode t)
   (setq ido-enable-flex-matching t)
 
-  ;; Get rid of all the silly UI clutter of a default Emacs session and opt out of
-  ;; all the stupid startup and license messages
+  ;; Get rid of all the silly UI clutter of a default Emacs session and opt out
+  ;; of all the stupid startup and license messages
   (tool-bar-mode -1)
   (blink-cursor-mode -1)
   (setq ring-bell-function #'ignore
@@ -109,15 +110,15 @@ in this file."
                       (save-excursion
                         (goto-char (point-min))
                         (search-forward "an-info-here")
-                        (list (flycheck-error-new-at (line-number-at-pos)
-                                                     10 'info "An info here"
-                                                     :checker checker)
-                              (flycheck-error-new-at (+ 1 (line-number-at-pos))
-                                                     10 'warning "A warning here"
-                                                     :checker checker)
-                              (flycheck-error-new-at (+ 2 (line-number-at-pos))
-                                                     10 'error "A error here"
-                                                     :checker checker)))))
+                        (list (flycheck-error-new-at
+                               (line-number-at-pos) 10 'info
+                               "An info here" :checker checker)
+                              (flycheck-error-new-at
+                               (+ 1 (line-number-at-pos)) 10 'warning
+                               "A warning here" :checker checker)
+                              (flycheck-error-new-at
+                               (+ 2 (line-number-at-pos)) 10 'error
+                               "A error here" :checker checker)))))
     :modes 'emacs-lisp-mode))
 
 (defun flycheck-prepare-screenshot (&optional hide-cursor)

--- a/test/specs/test-documentation.el
+++ b/test/specs/test-documentation.el
@@ -72,8 +72,8 @@
                   :to-equal nil)))
 
       (describe "Options"
-        (let ((documented-options (flycheck/collect-matches flycheck/defcustom-re
-                                                            languages))
+        (let ((documented-options
+               (flycheck/collect-matches flycheck/defcustom-re languages))
               (all-options (seq-mapcat (lambda (c)
                                          (flycheck-checker-get c 'option-vars))
                                        flycheck-checkers)))

--- a/test/specs/test-error-filters.el
+++ b/test/specs/test-error-filters.el
@@ -52,10 +52,11 @@
   (describe "flycheck-remove-error-file-names"
 
     (it "removes the given filename from errors"
-      (let ((errors (list
-                     (flycheck-error-new-at 1 1 'error "foo" :filename "hello")
-                     (flycheck-error-new-at 2 2 'warning "bar" :filename "world")
-                     (flycheck-error-new-at 3 3 'info "spam"))))
+      (let ((errors
+             (list
+              (flycheck-error-new-at 1 1 'error "foo" :filename "hello")
+              (flycheck-error-new-at 2 2 'warning "bar" :filename "world")
+              (flycheck-error-new-at 3 3 'info "spam"))))
         (expect (flycheck-remove-error-file-names "world" errors)
                 :to-be-equal-flycheck-errors
                 (list
@@ -89,14 +90,17 @@
   (describe "flycheck-fold-include-levels"
     (it "skips over intermittent errors"
       ;; See https://github.com/flycheck/flycheck/pull/783
-      (let ((errors (list (flycheck-error-new-at 1 0 'error "In file included from"
-                                                 :filename "foo.cpp")
-                          (flycheck-error-new-at 6 11 'error "b is not a member of hi"
-                                                 :filename "foo.cpp")
-                          (flycheck-error-new-at 5 20 'note "in definition of macro CHECK"
-                                                 :filename "foo.h")
-                          (flycheck-error-new-at 8 5 'error "xx was not declared in this scope"
-                                                 :filename "foo.cpp"))))
+      (let ((errors
+             (list (flycheck-error-new-at 1 0 'error "In file included from"
+                                          :filename "foo.cpp")
+                   (flycheck-error-new-at 6 11 'error "b is not a member of hi"
+                                          :filename "foo.cpp")
+                   (flycheck-error-new-at 5 20 'note
+                                          "in definition of macro CHECK"
+                                          :filename "foo.h")
+                   (flycheck-error-new-at 8 5 'error
+                                          "xx was not declared in this scope"
+                                          :filename "foo.cpp"))))
         (expect
          (flycheck-fold-include-levels errors "In file included from")
          :to-be-equal-flycheck-errors
@@ -106,7 +110,8 @@
                                       :filename "foo.cpp")
                (flycheck-error-new-at 5 20 'note "in definition of macro CHECK"
                                       :filename "foo.h")
-               (flycheck-error-new-at 8 5 'error "xx was not declared in this scope"
+               (flycheck-error-new-at 8 5 'error
+                                      "xx was not declared in this scope"
                                       :filename "foo.cpp"))))))
 
   (describe "flycheck-collapse-error-message-whitespace"
@@ -120,8 +125,9 @@
 
   (describe "flycheck-dequalify-error-ids"
     (it "removes all nested qualifiers"
-      (let ((errors (list (flycheck-error-new-at 1 2 nil nil :id "foo.bar")
-                          (flycheck-error-new-at 1 2 nil nil :id "Spam.With.Eggs"))))
+      (let ((errors
+             (list (flycheck-error-new-at 1 2 nil nil :id "foo.bar")
+                   (flycheck-error-new-at 1 2 nil nil :id "Spam.With.Eggs"))))
         (expect (flycheck-dequalify-error-ids errors)
                 :to-be-equal-flycheck-errors
                 (list (flycheck-error-new-at 1 2 nil nil :id "bar")


### PR DESCRIPTION
We did not check that previously on CI, now we do.

Of course, we now have over a hundred lines longer than 80 characters (a number we can still change).

There may be a better way to check for long lines than rolling our own function.  I thought about using `whitespace-mode` which highlights long lines in a custom face, but seeing as I wanted to make some exceptions (e.g., for the first line of a package), I wrote the code directly.

Before merging, we should make sure that the long lines *can* be made shorter.  For example, the first line of `flycheck-format.el`  is too long, but I don't think we can split it without breaking the lexical-binding setting.   I've added an exception to the first line of files in this commit.

In `flycheck.el`, we have the `Package-Requires` line that is too long.  Can we split that?  Or do we need an exception?

We can also raise the max length to 100 to catch overly long lines.  In this case, we mostly have long lines in `flycheck-test.el` which I think should be splitteable without exceptions.
