### PR TITLE
Add option `flycheck-jump-to-other-file-immediately`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,7 @@
     This change helps with compiled languages, where an error in another file
     may cause the current file to be considered invalid. [GH-1427]
 
-    The new option ``flycheck-jump-to-other-file-immediately``
+    The new option ``flycheck-jump-to-other-files-immediately``
     controls how eagerly error navigation in the current file jumps to
     the other file containing the error. [GH-1473]
   - Use Emacs' native XML parsing when libXML fails.  This behavior can be

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,10 @@
     instead of ignored.  They can be navigated to from the error list.
     This change helps with compiled languages, where an error in another file
     may cause the current file to be considered invalid. [GH-1427]
+
+    The new option ``flycheck-jump-to-other-file-immediately``
+    controls how eagerly error navigation in the current file jumps to
+    the other file containing the error. [GH-1473]
   - Use Emacs' native XML parsing when libXML fails.  This behavior can be
     changed by customizing ``flycheck-xml-parser`` [GH-1349]
   - Changed parsing of ESLint output from checkstyle XML to JSON [GH-1350]

--- a/flycheck.el
+++ b/flycheck.el
@@ -3885,6 +3885,15 @@ Return the position of the next or previous error overlay, or nil
 if there is none."
   (let ((n (or n 1))
         (pos (if reset (point-min) (point))))
+    ;; When resetting, we may start on an error at `point-min'. In
+    ;; this case, we count it as the first error here; the loops below
+    ;; proceed by skipping the current error, and so don't handle this
+    ;; case. This code applies for example when using
+    ;; `flycheck-first-error' to jump to the first-line overlay in a
+    ;; file that doesn't check due to errors in other files.
+    (when (and reset
+               (get-char-property (point-min) 'flycheck-error))
+      (setq n (1- n)))
     (if (>= n 0)
         ;; Search forwards
         (while (and pos (> n 0))

--- a/flycheck.el
+++ b/flycheck.el
@@ -600,7 +600,7 @@ where variable `flycheck-mode' is already non-nil."
 
 When an error in another file prevents checking the current file,
 Flycheck puts on error overlay on the first line of the current
-file that references the errors in the other file. This option
+file that references the errors in the other file.  This option
 determines how error navigation treats that first-line overlay
 when the cursor is not already on the first line.
 


### PR DESCRIPTION
This options controls whether Flycheck error navigation jumps to other
files immediately when the selected error is in another file. This is
related to PR #1427 that added overlays on the first line of the
current file when errors in other files prevent checking the current
file.

When the new option `flycheck-jump-to-other-files-immediately` is
nil (it defaults to non-nil), error navigation in the current file
moves the cursor to first-line overlay, and then you have to jump
again to actually go to the other file containing the error. The idea
is that it's surprising for Flycheck error navigation to change files,
and stopping on the first-line overlay first makes it less surprising.

There is more context for this commit here:
https://github.com/flycheck/flycheck/pull/1427#issuecomment-390912510.

The current specification for how Flycheck error navigation (`flycheck-{next,previous,first}-error`) works with relation to other-file error overlays is:

- if the cursor is already on an other-file overlay, then that overlay is considered to be the next/previous overlay, and jumping to it jumps to corresponding error in the other file.

- if the cursor is not already on an other-file error overlay, then the next/previous/first overlay is the next/previous in relation to the cursor, or first, respectively. If the overlay determined in this way is an other-file overlay, then what happens when you jump to it is determined by the setting of `flycheck-jump-to-other-files-immediately`: if that setting is non-nil, the default, then jump to the error in the other file; if that setting is nil, then jump to the other-file overlay in the current file.
