### PR TITLE
Enhance `verify-setup` buffer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@
     instead of ignored.  They can be navigated to from the error list.
     This change helps with compiled languages, where an error in another file
     may cause the current file to be considered invalid. [GH-1427]
+  - Enhanced the ``flycheck-verify-setup`` to show more clearly which checkers
+    will run in the buffer, and which are misconfigured. [GH-1478]
   - Use Emacs' native XML parsing when libXML fails.  This behavior can be
     changed by customizing ``flycheck-xml-parser`` [GH-1349]
   - Changed parsing of ESLint output from checkstyle XML to JSON [GH-1350]

--- a/doc/user/flycheck-versus-flymake.rst
+++ b/doc/user/flycheck-versus-flymake.rst
@@ -226,8 +226,8 @@ files with PHP CLI first to find syntax errors, then with PHP MessDetector to
 additionally find idiomatic and semantic errors, and eventually with PHP
 CheckStyle to find stylistic errors.  The user will see all errors reported by
 all of these tools in the buffer.  However, if the first checker reported at
-least one error, then the subsequent checkers would not be run (by default; this
-behavior is configurable).
+least one error, then the subsequent checkers would not be run.  This behavior
+is fully configurable; see :ref:`flycheck-checker-chains`.
 
 Errors
 ------

--- a/doc/user/syntax-checkers.rst
+++ b/doc/user/syntax-checkers.rst
@@ -274,3 +274,57 @@ installed into a local ``node_modules`` directory:
 
       :infonode:`(emacs)Directory Variables`
          Information about directory variables.
+
+.. _flycheck-checker-chains:
+
+Configuring checker chains
+==========================
+
+In any given buffer where Flycheck is enabled, only one checker may be run at a
+time.  However, any number of checkers can be run in sequence.  In such a
+sequence, after the first checker has finished running and its errors have been
+reported, the next checker of the sequence runs and its errors are reported,
+etc. until there are no more checkers in the sequence.  This sequence is called
+a *checker chain*.
+
+Some checkers chains are already setup by default in Flycheck: e.g.,
+`emacs-lisp` will be followed by `emacs-lisp-checkdoc`, and `python-mypy` will
+be followed by `python-flake8`.
+
+When defining a checker, you can specify which checkers may run after it by
+setting the ``:next-checkers`` property (see the docstring of
+`flycheck-define-generic-checker`).
+
+For a given checker, several next checkers may be specified.  Flycheck will run
+the first (in order of declaration) whose error level matches (see below) and
+which can be used in the current buffer.
+
+You can also customize the next checker property by calling
+`flycheck-add-next-checker` in your Emacs configuration file.
+
+.. defun:: flycheck-add-next-checker checker next &optional append
+
+   Set *next* to run after *checker*.  Both arguments are syntax checker
+   symbols.
+
+   For example, the following will make `python-pylint` run after
+   `python-flake8`:
+
+   .. code-block:: elisp
+
+      (flycheck-add-next-checker 'python-flake8 'python-pylint)
+
+   *Next* may also be a cons cell ``(level . next-checker)``, where
+   *next-checker* is a symbol denoting the syntax checker to run after
+   *checker*, and *level* is an error level.  The *next-checker* will then only
+   be run if there is no current error whose level is more severe than *level*.
+   If *level* is ``t``, then *next-checker* is run regardless of the current
+   errors.
+
+   For instance, if you wanted to run `python-pylint` only if `python-flake8`
+   produced no errors (only warnings and info diagnostics), then you would
+   rather use:
+
+   .. code-block:: elisp
+
+      (flycheck-add-next-checker 'python-flake8 '(warning . python-pylint))


### PR DESCRIPTION
1.  Separate first checker from other checkers in verify-setup.
      
    This makes it clearer that only one checker can be run, even though
    multiple checkers may be available.

2.  Display next checkers in verify-setup when applicable.

    This makes it easier to debug checker chaining.

Here are some screenshots:

![elisp](https://user-images.githubusercontent.com/340129/41813790-e1204e6c-773c-11e8-9141-4febd799b81b.png)

The checker that will effectively run is the first, and the available checkers for the buffer are below.  Note that the first checker is not repeated in the available checkers.  You can also see the new `next checkers` verification result.

Here is what it looks like with larger chains:

![more-checkers](https://user-images.githubusercontent.com/340129/41813792-e827dd4c-773c-11e8-8ae1-3df42c681031.png)

I've added two checkers `foobar` and `foobar2` for testing.  `foobar` was added as `next-checker` to `c/c++-clang`, and `foobar2` as `next-checker` to `foobar`.  This is all explicitly visible in the screenshot.  The first checker will show the full chain, but the description of `foobar` still shows that `foobar2` comes after it.

And the last example is for a buffer without any checker:

![no-checkers](https://user-images.githubusercontent.com/340129/41813793-e9dce86c-773c-11e8-8c4a-9fb70a4af2e1.png)
