### PR TITLE
Allow checker executables to be set to a relative path

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -453,23 +453,38 @@ commands through `bundle exec', `nix-shell' or similar wrappers."
   :package-version '(flycheck . "0.25")
   :risky t)
 
-(defcustom flycheck-executable-find #'executable-find
+(defcustom flycheck-executable-find #'flycheck-default-executable-find
   "Function to search for executables.
 
 The value of this option is a function which is given the name or
 path of an executable and shall return the full path to the
 executable, or nil if the executable does not exit.
 
-The default is the standard `executable-find' function which
-searches `exec-path'.  You can customize this option to search
-for checkers in other environments such as bundle or NixOS
+The default is `flycheck-default-executable-find', which searches
+`exec-path' when given a command name, and resolves paths to
+absolute ones.  You can customize this option to search for
+checkers in other environments such as bundle or NixOS
 sandboxes."
   :group 'flycheck
   :type '(choice
-          (const :tag "Search executables in `exec-path'" executable-find)
+          (const :tag "Search executables in `exec-path'"
+                 flycheck-default-executable-find)
           (function :tag "Search executables with a custom function"))
-  :package-version '(flycheck . "0.25")
+  :package-version '(flycheck . "32")
   :risky t)
+
+(defun flycheck-default-executable-find (executable)
+  "Resolve EXECUTABLE to a full path.
+
+If given just a command name (no directory component), search
+`exec-path' using the standard `executable-find' function;
+otherwise, resolve any relative paths to absolute ones."
+  ;; file-name-directory returns non-nil iff the given path has a
+  ;; directory component.
+  (if (file-name-directory executable)
+      (when (file-executable-p executable)
+        (expand-file-name executable))
+    (executable-find executable)))
 
 (defcustom flycheck-indication-mode 'left-fringe
   "The indication mode for Flycheck errors and warnings.


### PR DESCRIPTION
Hi,

Essentially, my goal is to put `(flycheck-CHECKER-executable . "relative/path/to/checker-script")` in `.dir-locals.el`, include said `checker-script` with the project, and have things "just work".

Below is one way to address this, but I'm open to suggestions.

```
Previously, flycheck-CHECKER-executable could not be set to a relative
path. This is useful when a checker (compatible substitute or wrapper)
is included with the project.

The setting didn't work because the relative path was passed as-is to
executable-find, which returns nil for inputs containing a directory
component.

Address this by introducing flycheck--find-executable, a new function
which checks whether its input has a directory component before
forwarding to executable-find, and update flycheck-executable-find's
default value to point to flycheck--find-executable instead of
executable-find.
```
