### PR TITLE
Add link to emacs-php/phpstan.el (flycheck-phpstan)

### DIFF
--- a/doc/community/extensions.rst
+++ b/doc/community/extensions.rst
@@ -130,6 +130,13 @@ OCaml
 * :flyc:`flycheck-ocaml` (*official*) adds a syntax checker for OCaml using the
   :gh:`Merlin <ocaml/merlin>` backend.
 
+PHP
+---
+
+* :gh:`emacs-php/phpstan.el` adds a PHP static analyzer using PHPStan_.
+
+.. _PHPStan: https://github.com/phpstan/phpstan
+
 Python
 ------
 


### PR DESCRIPTION
I have developed [phpstan.el](https://github.com/emacs-php/phpstan.el) and [flycheck-phpstan](https://melpa.org/#/flycheck-phpstan) package. These are currently working steadily.

------

By the way, I have contributed to PHP checkers in #1045 in the past, I can cooperate with [Language Team](http://www.flycheck.org/en/latest/community/people.html#language-teams) as @flycheck/php.