### PR TITLE
Fix to make error with no line number relevant

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6076,7 +6076,7 @@ otherwise."
             (message (match-string 4 err))
             (id (match-string 5 err)))
         (flycheck-error-new-at
-         (flycheck-string-to-number-safe line)
+         (or (flycheck-string-to-number-safe line) 1)
          (flycheck-string-to-number-safe column)
          level
          (unless (string-empty-p message) message)

--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -74,7 +74,16 @@
         (set-buffer-modified-p t)
         (expect (flycheck-buffer-saved-p) :not :to-be-truthy))
       (expect (spy-calls-count 'file-exists-p) :to-equal 1)
-      (expect (spy-calls-count 'buffer-file-name) :to-equal 1))))
+      (expect (spy-calls-count 'buffer-file-name) :to-equal 1)))
+
+  (describe "flycheck-try-parse-error-with-pattern"
+
+    (it "generates relevant errors even when not matching any line number"
+      (let ((err (flycheck-try-parse-error-with-pattern
+                  "Some error\n"
+                  (cons "^\\(?4:.+\\)\n" 'error)
+                  nil)))
+        (expect (flycheck-relevant-error-p err) :to-be-truthy)))))
 
 
 ;;; test-util.el ends here


### PR DESCRIPTION
When a command checker does not provide any line number for an error, the line is by default set to nil. This makes the error disappear because of `flycheck-relevant-error-p`. This PR makes the default line number to be 1 instead of nil.