### PR TITLE
Fix rustc checker creating stray binaries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
   - Remove ``javascript-jscs`` checker
   - Remove ``elixir-dogma`` checker [GH-1450]
   - ``rust-cargo`` now requires Rust 1.17 or newer [GH-1289]
+  - ``rust`` now requires 1.18 or newer [GH-1501]
   - Rename ``flycheck-cargo-rustc-args`` to ``flycheck-cargo-check-args``
     [GH-1289]
   - ``rust-cargo`` does not use the variable ``flycheck-rust-args`` anymore

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1069,7 +1069,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. note::
 
          `rust-cargo` requires Rust 1.17 or newer.
-         `rust` requires Rust 1.7 or newer.
+         `rust` requires Rust 1.18 or newer.
          `rust-clippy` requires the nightly version of Rust.
 
       .. _Cargo: http://doc.crates.io/index.html

--- a/flycheck.el
+++ b/flycheck.el
@@ -9708,10 +9708,11 @@ This syntax checker requires Rust 1.17 or newer.  See URL
 (flycheck-define-checker rust
   "A Rust syntax checker using Rust compiler.
 
-This syntax checker needs Rust 1.7 or newer.  See URL
+This syntax checker needs Rust 1.18 or newer.  See URL
 `https://www.rust-lang.org'."
   :command ("rustc"
             (option "--crate-type" flycheck-rust-crate-type)
+            "--emit=mir" "-o" "/dev/null" ; avoid creating binaries
             "--error-format=json"
             (option-flag "--test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path concat)


### PR DESCRIPTION
This fix will prevent us from getting some linker errors, but most of
the time when editing we are interested in type/parse errors.

Closes GH-1497, which see.