### PR TITLE
Fix flycheck-default-executable-find to work with exec-suffixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@
   - Add ``flycheck-sh-bash-args`` to pass arguments to ``sh-bash`` [GH-1439].
   - Add ``flychjeck-eslint-args`` to pass arguments to ``javascript-eslint``
     [GH-1360]
+  - Add ``flycheck-default-executable-find``, the new default value for
+    ``flycheck-executable-find``, to allow using relative paths to checkers
+    (set e.g. in file or dir-local variables). [GH-1485]
 
 - Improvements
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -476,15 +476,17 @@ sandboxes."
 (defun flycheck-default-executable-find (executable)
   "Resolve EXECUTABLE to a full path.
 
-If given just a command name (no directory component), search
-`exec-path' using the standard `executable-find' function;
-otherwise, resolve any relative paths to absolute ones."
+Like `executable-find', but supports relative paths.
+
+Attempts invoking `executable-find' first; if that returns nil,
+and EXECUTABLE contains a directory component, expands to a full
+path and tries invoking `executable-find' again."
   ;; file-name-directory returns non-nil iff the given path has a
   ;; directory component.
-  (if (file-name-directory executable)
-      (when (file-executable-p executable)
-        (expand-file-name executable))
-    (executable-find executable)))
+  (or
+   (executable-find executable)
+   (when (file-name-directory executable)
+     (executable-find (expand-file-name executable)))))
 
 (defcustom flycheck-indication-mode 'left-fringe
   "The indication mode for Flycheck errors and warnings.


### PR DESCRIPTION
Change `flycheck-default-executable-find`'s strategy, so that it works on platforms with implicit executable suffixes, such as Win32.

Fixes #1509.