### PR TITLE
 Take into account ruleSeverity for TSLint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,14 +61,17 @@ script:
                    --workdir /flycheck \
                    flycheck/emacs-cask:$EMACS_VERSION \
                    /bin/bash -c "make check"
+      # We use another Cask file for Emacs 24
+      else
+        cp Cask.24 Cask
       fi
       # Compile and run unit tests.
-      # If the unit tests succeed, fetch the all-tools container
-      # and run the integration tests
       docker run --volume "$TRAVIS_BUILD_DIR":/flycheck \
                  --workdir /flycheck \
                  flycheck/emacs-cask:$EMACS_VERSION \
                  /bin/bash -c "make compile && make unit && make specs"
+      # If the unit tests succeed, fetch the all-tools container
+      # and run the integration tests
       docker build --build-arg EMACS_VERSION=$EMACS_VERSION \
                       --tag tools-and-emacs:$EMACS_VERSION \
                       --file=.travis/tools-and-emacs .

--- a/Cask.24
+++ b/Cask.24
@@ -1,0 +1,56 @@
+(source gnu)
+(source melpa)
+
+(package-file "flycheck.el")
+
+(files "flycheck.el" "flycheck-ert.el" "flycheck-buttercup.el")
+
+(development
+ (depends-on "f")                       ; For some maintenance tools
+ (depends-on "buttercup")               ; BDD test framework for Emacs
+ (depends-on "shut-up")                 ; Silence Emacs
+
+ ;; Various modes for use in the unit tests
+ (depends-on "adoc-mode")
+ (depends-on "coffee-mode")
+ (depends-on "cperl-mode")
+ (depends-on "cwl-mode")
+ (depends-on "d-mode")
+ (depends-on "dockerfile-mode")
+ (depends-on "erlang")
+ ;; Latest ess requires `project' from Emacs 25+.
+ ;; (depends-on "ess")
+ (depends-on "geiser")
+ (depends-on "go-mode")
+ (depends-on "groovy-mode")
+ (depends-on "haml-mode")
+ (depends-on "handlebars-mode")
+ (depends-on "haskell-mode")
+ (depends-on "js2-mode")
+ (depends-on "js3-mode")
+ (depends-on "rjsx-mode")
+ (depends-on "json-mode")
+ (depends-on "julia-mode")
+ (depends-on "less-css-mode")
+ (depends-on "lua-mode")
+ (depends-on "markdown-mode")
+ (depends-on "mmm-mode")
+ (depends-on "nix-mode")
+ (depends-on "php-mode")
+ (depends-on "processing-mode")
+ (depends-on "protobuf-mode")
+ (depends-on "pug-mode")
+ (depends-on "puppet-mode")
+ (depends-on "racket-mode")
+ (depends-on "rhtml-mode")
+ (depends-on "rpm-spec-mode")
+ (depends-on "rust-mode")
+ (depends-on "sass-mode")
+ (depends-on "scala-mode")
+ (depends-on "scss-mode")
+ (depends-on "slim-mode")
+ (depends-on "systemd")
+ (depends-on "typescript-mode")
+ (depends-on "web-mode")
+ (depends-on "yaml-mode")
+ )

--- a/flycheck.el
+++ b/flycheck.el
@@ -9099,7 +9099,7 @@ See URL `https://github.com/jimhester/lintr'."
             line-end)
    (error line-start (file-name) ":" line ":" column ": error: " (message)
           line-end))
-  :modes ess-mode
+  :modes (ess-mode ess-r-mode)
   :predicate
   ;; Don't check ESS files which do not contain R, and make sure that lintr is
   ;; actually available

--- a/flycheck.el
+++ b/flycheck.el
@@ -9751,7 +9751,7 @@ This syntax checker needs Rust 1.18 or newer.  See URL
   "A Rust syntax checker using clippy.
 
 See URL `https://github.com/rust-lang-nursery/rust-clippy'."
-  :command ("cargo" "+nightly" "clippy" "--message-format=json")
+  :command ("cargo" "clippy" "--message-format=json")
   :error-parser flycheck-parse-cargo-rustc
   :error-filter flycheck-rust-error-filter
   :error-explainer flycheck-rust-error-explainer

--- a/flycheck.el
+++ b/flycheck.el
@@ -5841,7 +5841,12 @@ about TSLint."
                  (flycheck-error-new-at
                   (+ 1 .startPosition.line)
                   (+ 1 .startPosition.character)
-                  'warning .failure
+                  (pcase .ruleSeverity
+                    (`"ERROR"   'error)
+                    (`"WARNING" 'warning)
+                    ;; Default to error
+                    (_          'error))
+                  .failure
                   :id .ruleName
                   :checker checker
                   :buffer buffer

--- a/flycheck.el
+++ b/flycheck.el
@@ -5842,10 +5842,9 @@ about TSLint."
                   (+ 1 .startPosition.line)
                   (+ 1 .startPosition.character)
                   (pcase .ruleSeverity
-                    (`"ERROR"   'error)
-                    (`"WARNING" 'warning)
-                    ;; Default to error
-                    (_          'error))
+                    ("ERROR"   'error)
+                    ("WARNING" 'warning)
+                    (_          'warning))
                   .failure
                   :id .ruleName
                   :checker checker

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2983,7 +2983,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 (flycheck-ert-def-checker-test dockerfile-hadolint dockerfile error
   (flycheck-ert-should-syntax-check
    "language/dockerfile/Dockerfile.error" 'dockerfile-mode
-   '(2 1 error "unexpected 'I' expecting '#', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, end of input, or the rest of a new line followed by the next instruction"
+   '(2 1 error "unexpected 'I' expecting '#', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, end of input, or whitespace"
        :checker dockerfile-hadolint)))
 
 (flycheck-ert-def-checker-test dockerfile-hadolint dockerfile warnings
@@ -4229,7 +4229,8 @@ The manifest path is relative to
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/macro-error.rs" 'rust-mode
-     '(2 3 info "1 positional argument in format string, but no arguments were given" :checker rust :group 1))))
+     '(2 3 info "1 positional argument in format string, but no arguments were given" :checker rust :group 1)
+     '(2 13 error "1 positional argument in format string, but no arguments were given" :checker rust :group 1))))
 
 (flycheck-ert-def-checker-test sass sass nil
   (let ((flycheck-disabled-checkers '(sass/scss-sass-lint)))

--- a/test/specs/languages/test-typescript.el
+++ b/test/specs/languages/test-typescript.el
@@ -42,7 +42,7 @@
   \"ruleName\":\"semicolon\",
   \"ruleSeverity\":\"WARNING\",
   \"startPosition\":{\"character\":14,\"line\":2,\"position\":76}}]")
-          (json-with-deprecations "no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
+          (json-with-unknown-severity "no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
 
   Could not find implementations for the following rules specified in the configuration:
       label-undefined
@@ -75,11 +75,11 @@
                                         :checker 'checker
                                         :buffer 'buffer
                                         :filename "sample.ts"))))
-      (it "parses TSLint JSON output with deprecation output"
-        (expect (flycheck-parse-tslint json-with-deprecations 'checker 'buffer)
+      (it "parses TSLint JSON output with unknown severity"
+          (expect (flycheck-parse-tslint json-with-unknown-severity 'checker 'buffer)
                 :to-be-equal-flycheck-errors
                 (list
-                 (flycheck-error-new-at 1 10 'error
+                 (flycheck-error-new-at 1 10 'warning
                                         "unused variable: 'invalidAlignment'"
                                         :id "no-unused-variable"
                                         :checker 'checker

--- a/test/specs/languages/test-typescript.el
+++ b/test/specs/languages/test-typescript.el
@@ -34,11 +34,13 @@
   \"failure\":\"unused variable: 'invalidAlignment'\",
   \"name\":\"sample.ts\",
   \"ruleName\":\"no-unused-variable\",
+  \"ruleSeverity\":\"ERROR\",
   \"startPosition\":{\"character\":9,\"line\":0,\"position\":9}},
  {\"endPosition\":{\"character\":14,\"line\":2,\"position\":76},
   \"failure\":\"missing semicolon\",
   \"name\":\"sample.ts\",
   \"ruleName\":\"semicolon\",
+  \"ruleSeverity\":\"WARNING\",
   \"startPosition\":{\"character\":14,\"line\":2,\"position\":76}}]")
           (json-with-deprecations "no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
 
@@ -55,12 +57,13 @@
  \"failure\":\"unused variable: 'invalidAlignment'\",
  \"name\":\"sample.ts\",
  \"ruleName\":\"no-unused-variable\",
+ \"ruleSeverity\":\"XXX\",
  \"startPosition\":{\"character\":9,\"line\":0,\"position\":9}}]"))
       (it "parses TSLint JSON output"
         (expect (flycheck-parse-tslint json 'checker 'buffer)
                 :to-be-equal-flycheck-errors
                 (list
-                 (flycheck-error-new-at 1 10 'warning
+                 (flycheck-error-new-at 1 10 'error
                                         "unused variable: 'invalidAlignment'"
                                         :id "no-unused-variable"
                                         :checker 'checker
@@ -76,7 +79,7 @@
         (expect (flycheck-parse-tslint json-with-deprecations 'checker 'buffer)
                 :to-be-equal-flycheck-errors
                 (list
-                 (flycheck-error-new-at 1 10 'warning
+                 (flycheck-error-new-at 1 10 'error
                                         "unused variable: 'invalidAlignment'"
                                         :id "no-unused-variable"
                                         :checker 'checker


### PR DESCRIPTION
All rules from TSLint where generating warnings in flycheck. I added the *ruleSeverity* parsing to *level* so TSLint errors generate flycheck errors instead of warnings