### PR TITLE
Use cargo clippy from default toolchain

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9747,7 +9747,7 @@ This syntax checker needs Rust 1.18 or newer.  See URL
   "A Rust syntax checker using clippy.
 
 See URL `https://github.com/rust-lang-nursery/rust-clippy'."
-  :command ("cargo" "+nightly" "clippy" "--message-format=json")
+  :command ("cargo" "clippy" "--message-format=json")
   :error-parser flycheck-parse-cargo-rustc
   :error-filter flycheck-rust-error-filter
   :error-explainer flycheck-rust-error-explainer


### PR DESCRIPTION
Clippy used to be available only on nightly but is now available on stable and beta as well. It's better to allow the user to set their toolchain and use whatever they configured.