### PR TITLE
Add ess-r-mode to r-lintr modes

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9095,7 +9095,7 @@ See URL `https://github.com/jimhester/lintr'."
             line-end)
    (error line-start (file-name) ":" line ":" column ": error: " (message)
           line-end))
-  :modes ess-mode
+  :modes (ess-mode ess-r-mode)
   :predicate
   ;; Don't check ESS files which do not contain R, and make sure that lintr is
   ;; actually available


### PR DESCRIPTION
Temporary patch for #1517. Should preserve back compatibility with earlier versions of ESS. In the longer term, a more comprehensive revision of `r-lintr` may be possible (see discussion in #1517).
