### PR TITLE
Add ember-template-lint to the syntax checkers

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -346,10 +346,12 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: Ember Templates
 
-   .. syntax-checker:: ember-template-lint
+   .. syntax-checker:: ember-template
 
       Check your Ember templates with
       `ember-template-lint <https://github.com/ember-template-lint/ember-template-lint>`_ 
+
+      .. syntax-checker-config-file:: flycheck-ember-template-lintrc
 
 .. supported-language:: Erlang
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -344,6 +344,13 @@ to view the docstring of the syntax checker.  Likewise, you may use
       :infonode:`(elisp)Library Headers`
          Information about library headers for Emacs Lisp files.
 
+.. supported-language:: Ember Templates
+
+   .. syntax-checker:: ember-template-lint
+
+      Check your Ember templates with
+      `ember-template-lint <https://github.com/ember-template-lint/ember-template-lint>`_ 
+
 .. supported-language:: Erlang
 
    Flycheck checks Erlang with `erlang-rebar3` in rebar projects and

--- a/flycheck.el
+++ b/flycheck.el
@@ -178,7 +178,7 @@ attention to case differences."
     dockerfile-hadolint
     emacs-lisp
     emacs-lisp-checkdoc
-    ember-template-lint
+    ember-template
     erlang-rebar3
     erlang
     eruby-erubis
@@ -7362,12 +7362,12 @@ The checker runs `checkdoc-current-buffer'."
   (setf (car (flycheck-checker-get checker 'command))
         flycheck-this-emacs-executable))
 
-(defun flycheck-ember-template-lint--check-for-config (&rest _ignored)
+(defun flycheck-ember-template--check-for-config (&rest _ignored)
   "Check the required config file is available up the file system."
   (and buffer-file-name
        (locate-dominating-file buffer-file-name ".template-lintrc.js")))
 
-(defun flycheck-ember-template-lint--parse-error (output checker buffer)
+(defun flycheck-ember-template--parse-error (output checker buffer)
   "Parse Ember-template-lint errors/warnings from JSON OUTPUT.
 CHECKER and BUFFER denote the CHECKER that returned OUTPUT and
 the BUFFER that was checked respectively."
@@ -7387,14 +7387,23 @@ the BUFFER that was checked respectively."
                :filename (buffer-file-name buffer))))
           (cdr (car (car (flycheck-parse-json output))))))
 
-(flycheck-define-checker ember-template-lint
+(flycheck-def-config-file-var flycheck-ember-template-lintrc
+    ember-template
+    ".template-lintrc.js"
+  :type 'string
+  :safe #'stringp)
+
+(flycheck-define-checker ember-template
   "An Ember template checker using ember-template-lint."
-  :command ("ember-template-lint" source "--json")
+  :command ("ember-template-lint"
+            (config-file "--config-path" flycheck-ember-template-lintrc)
+            "--stdin-filename" source-original
+            "--json")
   :standard-input t
-  :error-parser flycheck-ember-template-lint--parse-error
+  :error-parser flycheck-ember-template--parse-error
   :modes web-mode
-  :enabled flycheck-ember-template-lint--check-for-config
-  :working-directory flycheck-ember-template-lint--check-for-config)
+  :enabled flycheck-ember-template--check-for-config
+  :working-directory flycheck-ember-template--check-for-config)
 
 (flycheck-def-option-var flycheck-erlang-include-path nil erlang
   "A list of include directories for Erlang.

--- a/flycheck.el
+++ b/flycheck.el
@@ -7397,7 +7397,7 @@ the BUFFER that was checked respectively."
   "An Ember template checker using ember-template-lint."
   :command ("ember-template-lint"
             (config-file "--config-path" flycheck-ember-template-lintrc)
-            "--stdin-filename" source-original
+            "--filename" source-original
             "--json")
   :standard-input t
   :error-parser flycheck-ember-template--parse-error

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3105,6 +3105,16 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
     (flycheck-ert-should-syntax-check
      "language/emacs-lisp/check-declare-warnings.el" 'emacs-lisp-mode)))
 
+(flycheck-ert-def-checker-test ember-template ember-template error
+  (flycheck-ert-should-syntax-check
+   "language/ember-template-lint/ember-template-lint/error.hbs" 'web-mode
+   '(2 16 error "Incorrect indentation for `<span>` beginning at L2:C16. Expected `<span>` to be at an indentation of 2 but was found at 16." :id "block-indentation" :checker ember-template)))
+
+(flycheck-ert-def-checker-test ember-template ember-template warning
+  (flycheck-ert-should-syntax-check
+   "language/ember-template-lint/ember-template-lint/warning.hbs" 'web-mode
+   '(1 nil warning "Non-translated string used" :id "no-bare-strings" :checker ember-template)))
+
 (flycheck-ert-def-checker-test erlang erlang error
   (shut-up
     (flycheck-ert-should-syntax-check

--- a/test/resources/language/ember-template-lint/ember-template-lint/.template-lintrc.js
+++ b/test/resources/language/ember-template-lint/ember-template-lint/.template-lintrc.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+'use strict'
+
+module.exports = {
+  extends: 'recommended',
+  rules: {
+    'no-bare-strings': true
+  },
+  pending: ['warning']
+}

--- a/test/resources/language/ember-template-lint/ember-template-lint/error.hbs
+++ b/test/resources/language/ember-template-lint/ember-template-lint/error.hbs
@@ -1,0 +1,3 @@
+<div>
+                <span></span>
+</div>

--- a/test/resources/language/ember-template-lint/ember-template-lint/warning.hbs
+++ b/test/resources/language/ember-template-lint/ember-template-lint/warning.hbs
@@ -1,0 +1,1 @@
+This file only emits a warning because it has been marked as "pending" in the configuration file.


### PR DESCRIPTION
See https://github.com/ember-template-lint/ember-template-lint

It has been introduced in the default toolset of Ember in the latest releases (ember-cli 3.5, IIRC).

---

heavily inspired by https://pastebin.com/8iBaMrpj