### PR TITLE
Add opam checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@
   - VHDL with ``ghdl`` [GH-1160]
   - mypy with ``python-mypy`` [GH-1354]
   - Nix with ``nix-linter`` [GH-1530]
+  - Opam with ``opam lint`` [GH-1532]
 
 - New features:
 

--- a/Cask
+++ b/Cask
@@ -49,6 +49,7 @@
  (depends-on "scss-mode")
  (depends-on "slim-mode")
  (depends-on "systemd")
+ (depends-on "tuareg")
  (depends-on "typescript-mode")
  (depends-on "web-mode")
  (depends-on "yaml-mode")

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -761,6 +761,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _nix-linter: https://github.com/Synthetica9/nix-linter
 
+.. supported-language:: Opam
+
+   .. syntax-checker:: opam
+
+      Check Opam configuration files with `opam lint`_.
+
+      .. _opam lint: https://opam.ocaml.org/doc/man/opam-lint.html
+
 .. supported-language:: Perl
 
    Flycheck checks Perl with `perl` and `perl-perlcritic`.

--- a/flycheck.el
+++ b/flycheck.el
@@ -212,6 +212,7 @@ attention to case differences."
     markdown-mdl
     nix
     nix-linter
+    opam
     perl
     perl-perlcritic
     php
@@ -8599,6 +8600,38 @@ See URL `http://www.lua.org/'."
           (minimal-match (zero-or-more not-newline))
           ": stdin:" line ": " (message) line-end))
   :modes lua-mode)
+
+(flycheck-define-checker opam
+  "A Opam syntax and style checker using opam lint.
+
+See URL `https://opam.ocaml.org/doc/man/opam-lint.html'."
+  :command ("opam" "lint" "-")
+  :standard-input t
+  :error-patterns
+  ((error line-start                    ; syntax error
+          (one-or-more space) "error  " (id ?2)
+          ": File format error"
+          (or (and " at line " line ", column " column ": " (message))
+              (and ": " (message)))
+          line-end)
+   (error line-start
+          (one-or-more space) "error  " (id ?3)
+          (minimal-match (zero-or-more not-newline))
+          "at line " line ", column " column ": " (message)
+          line-end)
+   (error line-start
+          (one-or-more space) "error " (id (one-or-more num))
+          ": " (message (one-or-more not-newline))
+          line-end)
+   (warning line-start
+            (one-or-more space) "warning " (id (one-or-more num))
+            ": " (message)
+            line-end))
+  :error-filter
+  (lambda (errors)
+    (flycheck-increment-error-columns
+     (flycheck-fill-empty-line-numbers errors)))
+  :modes tuareg-opam-mode)
 
 (flycheck-def-option-var flycheck-perl-include-path nil perl
   "A list of include directories for Perl.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3728,6 +3728,20 @@ Why not:
      '(5 nil error "unfinished string near '\"oh no'"
          :checker lua))))
 
+(flycheck-ert-def-checker-test opam opam nil
+  (flycheck-ert-should-syntax-check
+   "language/opam.opam" 'tuareg-opam-mode
+   '(0 nil error "Missing field 'maintainer'"
+       :id "23" :checker opam)
+   '(0 nil warning "Missing field 'authors'"
+       :id "25" :checker opam)
+   '(0 nil warning "Missing field 'homepage'"
+       :id "35" :checker opam)
+   '(0 nil warning "Missing field 'bug-reports'"
+       :id "36" :checker opam)
+   '(2 1 error "Invalid field maintainers"
+       :id "3" :checker opam)))
+
 (flycheck-ert-def-checker-test (perl perl-perlcritic) perl nil
   (flycheck-ert-should-syntax-check
    "language/perl.pl" '(perl-mode cperl-mode)

--- a/test/resources/language/opam.opam
+++ b/test/resources/language/opam.opam
@@ -1,0 +1,2 @@
+opam-version: "2.0"
+maintainers: "John Doe <jdoe@example.com>"


### PR DESCRIPTION
I've added checker for opam files with https://opam.ocaml.org/doc/man/opam-lint.html

tests
```
make SELECTOR='(tag checker-opam)' integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck.el
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-ert.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-opam))'
Running tests on Emacs 26.1, built at 2018-12-19
Running 1 tests (2018-12-28 14:34:23-0500)
   passed  1/1  flycheck-define-checker/opam/default

Ran 1 tests, 1 results as expected (2018-12-28 14:34:25-0500)
```