### PR TITLE
python-mypy: Add patterns for errors without cols

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9197,10 +9197,10 @@ See URL `http://mypy-lang.org/'."
             (option "--cache-dir" flycheck-python-mypy-cache-dir)
             source-original)
   :error-patterns
-  ((error line-start (file-name) ":" line ":" column ": error:" (message)
-          line-end)
-   (warning line-start (file-name) ":" line ":" column  ": warning:" (message)
-            line-end))
+  ((error line-start (file-name) ":" line (optional ":" column)
+          ": error:" (message) line-end)
+   (warning line-start (file-name) ":" line (optional ":" column)
+            ": warning:" (message) line-end))
   :modes python-mode
   ;; Ensure the file is saved, to work around
   ;; https://github.com/python/mypy/issues/4746.


### PR DESCRIPTION
Even with the --show-columns flag, mypy sometimes doesn't emit columns. We should have patterns for errors/warnings with and without columns so they can still be parsed.