### PR TITLE
Use standard input in nix-linter checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9483,7 +9483,8 @@ information about nix-linter."
   "Nix checker using nix-linter.
 
 See URL `https://github.com/Synthetica9/nix-linter'."
-  :command ("nix-linter" "--json-stream" source)
+  :command ("nix-linter" "--json-stream" "-")
+  :standard-input t
   :error-parser flycheck-parse-nix-linter
   :modes nix-mode)
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4083,7 +4083,6 @@ Why not:
   (flycheck-ert-should-syntax-check
    "language/nix/warnings.nix" 'nix-mode
    '(1 1 warning "LetInInheritRecset" :id "LetInInheritRecset" :checker nix-linter)
-   '(2 3 warning "Unused `let` bind `x`" :id "UnusedLetBind" :checker nix-linter)
    '(3 4 warning "Unneeded `rec` on set" :id "UnneededRec" :checker nix-linter)))
 
 (ert-deftest flycheck-locate-sphinx-source-directory/not-in-a-sphinx-project ()


### PR DESCRIPTION
nix-linter added support for standard input https://github.com/Synthetica9/nix-linter/issues/27

tests
```
make SELECTOR='(tag checker-nix-linter)' integ
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-nix-linter))'
Running tests on Emacs 26.1, built at 2019-01-06
Running 1 tests (2019-01-22 00:11:27-0500)
   passed  1/1  flycheck-define-checker/nix-linter/default

Ran 1 tests, 1 results as expected (2019-01-22 00:11:29-0500)
```