### PR TITLE
Implement a checker for the golang `staticcheck` tool

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -414,6 +414,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
    5. `go-errcheck`
    6. `go-unconvert`
    7. `go-megacheck`
+   8. `go-staticcheck`
 
    .. syntax-checker:: go-gofmt
 
@@ -501,11 +502,27 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Lint code with megacheck_.
 
+      .. note::
+
+         megacheck_ is officially deprecated; it's recommended to switch to staticcheck_.
+
       .. defcustom:: flycheck-go-megacheck-disabled-checkers
 
          A list of checkers to disable when running megacheck_.
 
       .. _megacheck: https://github.com/dominikh/go-tools
+
+   .. syntax-checker:: go-staticcheck
+
+      Perform static analysis and code linting with staticcheck_, the successor to megacheck_.
+
+      .. defcustom:: flycheck-go-version
+
+         staticcheck_ explicitly supports the last two releases of Go, but
+         supports targeting older versions. Go versions should be specified
+         like, "1.6", or, "1.11.4".
+
+      .. _staticcheck: https://staticcheck.io/
 
 .. supported-language:: Groovy
 
@@ -1239,7 +1256,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. defcustom:: flycheck-scheme-chicken-args
 
-	 A list of additional options.
+     A list of additional options.
 
    .. important::
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -190,6 +190,7 @@ attention to case differences."
     go-errcheck
     go-unconvert
     go-megacheck
+    go-staticcheck
     groovy
     haml
     handlebars
@@ -7717,6 +7718,7 @@ See URL `https://golang.org/cmd/gofmt/'."
                   (warning . go-build) (warning . go-test)
                   (warning . go-errcheck)
                   (warning . go-unconvert)
+                  (warning . go-staticcheck)
                   (warning . go-megacheck)))
 
 (flycheck-define-checker go-golint
@@ -7778,7 +7780,17 @@ See URL `https://golang.org/cmd/go/' and URL
                   ;; Fall back if `go build' or `go test' can be used
                   go-errcheck
                   go-unconvert
-                  go-megacheck))
+                  go-staticcheck
+                  go-megacheck)
+  :verify (lambda (_)
+            (let* ((go (flycheck-checker-executable 'go-vet))
+                   (have-vet (member "vet" (ignore-errors
+                                             (process-lines go "tool")))))
+              (list
+               (flycheck-verification-result-new
+                :label "go tool vet"
+                :message (if have-vet "present" "missing")
+                :face (if have-vet 'success '(bold error)))))))
 
 (flycheck-def-option-var flycheck-go-build-install-deps nil (go-build go-test)
   "Whether to install dependencies in `go build' and `go test'.
@@ -7789,13 +7801,26 @@ while syntax checking."
   :safe #'booleanp
   :package-version '(flycheck . "0.25"))
 
-(flycheck-def-option-var flycheck-go-build-tags nil go-build
+(flycheck-def-option-var flycheck-go-build-tags nil
+                         (go-build go-test go-errcheck
+                                   go-megacheck go-staticcheck)
   "A list of tags for `go build'.
 
 Each item is a string with a tag to be given to `go build'."
   :type '(repeat (string :tag "Tag"))
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.25"))
+
+
+(flycheck-def-option-var flycheck-go-version nil go-staticcheck
+  "The version of go that should be targeted by `staticcheck'.
+
+Should be a string representing a version, like 1.6 or 1.11.4.
+See `https://staticcheck.io/docs/#targeting-go-versions' for
+details."
+  :type 'string
+  :safe #'stringp
+  :package-version '(flycheck . "0.32"))
 
 (flycheck-define-checker go-build
   "A Go syntax and type checker using the `go build' command.
@@ -7835,6 +7860,7 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
                     (not (string-suffix-p "_test.go" (buffer-file-name)))))
   :next-checkers ((warning . go-errcheck)
                   (warning . go-unconvert)
+                  (warning . go-staticcheck)
                   (warning . go-megacheck)))
 
 (flycheck-define-checker go-test
@@ -7857,6 +7883,7 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
                   (string-suffix-p "_test.go" (buffer-file-name))))
   :next-checkers ((warning . go-errcheck)
                   (warning . go-unconvert)
+                  (warning . go-staticcheck)
                   (warning . go-megacheck)))
 
 (flycheck-define-checker go-errcheck
@@ -7886,6 +7913,7 @@ See URL `https://github.com/kisielk/errcheck'."
   :modes go-mode
   :predicate (lambda () (flycheck-buffer-saved-p))
   :next-checkers ((warning . go-unconvert)
+                  (warning . go-staticcheck)
                   (warning . go-megacheck)))
 
 (flycheck-define-checker go-unconvert
@@ -7911,6 +7939,26 @@ Requires Go 1.6 or newer. See URL
                                                     ".enabled=false"))
                           flycheck-go-megacheck-disabled-checkers))
             ;; Run in current directory to make megacheck aware of symbols
+            ;; declared in other files.
+            ".")
+  :error-patterns
+  ((warning line-start (file-name) ":" line ":" column ": " (message) line-end))
+  :modes go-mode)
+
+(flycheck-define-checker go-staticcheck
+  "A Go checker that performs static analysis and linting using
+the `staticcheck' command. `staticcheck' is the successor to
+`megacheck'; while the latter isn't fully deprecated yet, it's
+recommended to migrate to `staticcheck'.
+
+`staticcheck' is explicitly fully compatible with \"the last two
+versions of go\". `staticheck' can target earlier versions (with
+limited features) if `flycheck-go-version' is set. See URL
+`https://staticcheck.io/'."
+  :command ("staticcheck"
+            (option-list "-tags" flycheck-go-build-tags concat)
+            (option "-go" flycheck-go-version)
+            ;; Run in current directory to make staticcheck aware of symbols
             ;; declared in other files.
             ".")
   :error-patterns

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3440,12 +3440,12 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
         `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
       (flycheck-ert-should-syntax-check
        "language/go/src/staticcheck/staticcheck1.go" 'go-mode
-       '(8 6 warning "should omit values from range; this loop is equivalent to `for range ...` (S1005)"
-           :checker go-staticcheck)
-       '(12 21 warning "calling strings.Replace with n == 0 will return no results, did you mean -1? (SA1018)"
-            :checker go-staticcheck)
-       '(16 6 warning "func unused is unused (U1000)"
-            :checker go-staticcheck)))))
+       '(8 6 error "should omit values from range; this loop is equivalent to `for range ...`"
+           :checker go-staticcheck :id "S1005")
+       '(12 21 error "calling strings.Replace with n == 0 will return no results, did you mean -1?"
+            :checker go-staticcheck :id "SA1018")
+       '(16 6 error "func unused is unused"
+            :checker go-staticcheck :id "U1000")))))
 
 (flycheck-ert-def-checker-test groovy groovy syntax-error
   ;; Work around

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3435,7 +3435,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 
 (flycheck-ert-def-checker-test go-staticcheck go nil
   :tags '(language-go external-tool)
-  (let ((flycheck-disabled-checkers '(go-golint go-megacheck)))
+  (let ((flycheck-disabled-checkers '(go-golint go-unconvert)))
     (flycheck-ert-with-env
         `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
       (flycheck-ert-should-syntax-check

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3369,7 +3369,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
            :checker go-build)))))
 
 (flycheck-ert-def-checker-test go-build go directory-with-two-packages
-  (let ((flycheck-disabled-checkers '(go-errcheck go-unconvert go-megacheck)))
+  (let ((flycheck-disabled-checkers '(go-errcheck go-unconvert go-megacheck go-staticcheck)))
     (flycheck-ert-with-env
         `(("GOPATH" . ,(flycheck-ert-resource-filename "checkers/go")))
       (flycheck-ert-should-syntax-check
@@ -3409,7 +3409,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 
 (flycheck-ert-def-checker-test go-megacheck go nil
   :tags '(language-go external-tool)
-  (let ((flycheck-disabled-checkers '(go-golint)))
+  (let ((flycheck-disabled-checkers '(go-golint go-staticcheck)))
     (flycheck-ert-with-env
         `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
       (flycheck-ert-should-syntax-check
@@ -3435,7 +3435,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 
 (flycheck-ert-def-checker-test go-staticcheck go nil
   :tags '(language-go external-tool)
-  (let ((flycheck-disabled-checkers '(go-golint)))
+  (let ((flycheck-disabled-checkers '(go-golint go-megacheck)))
     (flycheck-ert-with-env
         `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
       (flycheck-ert-should-syntax-check

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3433,6 +3433,20 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
          '(12 21 warning "calling strings.Replace with n == 0 will return no results, did you mean -1? (SA1018)"
               :checker go-megacheck))))))
 
+(flycheck-ert-def-checker-test go-staticcheck go nil
+  :tags '(language-go external-tool)
+  (let ((flycheck-disabled-checkers '(go-golint)))
+    (flycheck-ert-with-env
+        `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
+      (flycheck-ert-should-syntax-check
+       "language/go/src/staticcheck/staticcheck1.go" 'go-mode
+       '(8 6 warning "should omit values from range; this loop is equivalent to `for range ...` (S1005)"
+           :checker go-staticcheck)
+       '(12 21 warning "calling strings.Replace with n == 0 will return no results, did you mean -1? (SA1018)"
+            :checker go-staticcheck)
+       '(16 6 warning "func unused is unused (U1000)"
+            :checker go-staticcheck)))))
+
 (flycheck-ert-def-checker-test groovy groovy syntax-error
   ;; Work around
   ;; https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes/issues/11

--- a/test/resources/language/go/src/staticcheck/staticcheck1.go
+++ b/test/resources/language/go/src/staticcheck/staticcheck1.go
@@ -1,0 +1,16 @@
+package main
+
+import "strings"
+
+func main() {
+	// S1005 (gosimple)
+	// xs is declared in a different file to ensure that test fails if megacheck is called incorrectly
+	for _ = range xs {
+	}
+
+	// SA1018 (staticcheck)
+	_ = strings.Replace("foo", "f", "b", 0)
+}
+
+// U1000 (unused)
+func unused() {}

--- a/test/resources/language/go/src/staticcheck/staticcheck2.go
+++ b/test/resources/language/go/src/staticcheck/staticcheck2.go
@@ -1,0 +1,3 @@
+package main
+
+var xs = []int{1, 2, 3}

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -1,0 +1,49 @@
+;;; test-go.el --- Flycheck Specs: Go -*- lexical-binding: t; -*-
+
+(require 'flycheck-buttercup)
+
+(describe "Language Go"
+          (describe "The staticcheck error parser"
+                    (let ((json "
+{
+  \"code\":\"compile\",
+  \"severity\":\"error\",
+  \"location\": {
+    \"file\":\"/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go\",
+    \"line\":4,
+    \"column\":8
+  },
+  \"message\":\"expected ';', found ':'\"}
+{
+  \"code\":\"compile\",
+  \"severity\":\"warning\",
+  \"location\": {
+    \"file\":\"/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go\",
+    \"line\":4,
+    \"column\":2
+  },
+  \"message\":\"undeclared name: Number\"
+}"
+                                ))
+
+                      (it "parses staticcheck JSON output"
+                          (expect (flycheck-parse-go-staticcheck json 'checker 'buffer)
+                                  :to-be-equal-flycheck-errors
+                                  (list
+                                   (flycheck-error-new-at
+                                    4 8 'error
+                                    "expected ';', found ':'"
+                                    :id "compile"
+                                    :checker 'checker
+                                    :buffer 'buffer
+                                    :filename "/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go")
+                                   (flycheck-error-new-at
+                                    4 2 'warning
+                                    "undeclared name: Number"
+                                    :id "compile"
+                                    :checker 'checker
+                                    :buffer 'buffer
+                                    :filename "/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go")
+                                   ))))))
+
+;;; test-go.el ends here

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -3,8 +3,8 @@
 (require 'flycheck-buttercup)
 
 (describe "Language Go"
-          (describe "The staticcheck error parser"
-                    (let ((json "
+  (describe "The staticcheck error parser"
+    (let ((json "
 {
   \"code\":\"compile\",
   \"severity\":\"error\",
@@ -24,26 +24,26 @@
   },
   \"message\":\"undeclared name: Number\"
 }"
-                                ))
+                ))
 
-                      (it "parses staticcheck JSON output"
-                          (expect (flycheck-parse-go-staticcheck json 'checker 'buffer)
-                                  :to-be-equal-flycheck-errors
-                                  (list
-                                   (flycheck-error-new-at
-                                    4 8 'error
-                                    "expected ';', found ':'"
-                                    :id "compile"
-                                    :checker 'checker
-                                    :buffer 'buffer
-                                    :filename "/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go")
-                                   (flycheck-error-new-at
-                                    4 2 'warning
-                                    "undeclared name: Number"
-                                    :id "compile"
-                                    :checker 'checker
-                                    :buffer 'buffer
-                                    :filename "/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go")
-                                   ))))))
+      (it "parses staticcheck JSON output"
+        (expect (flycheck-parse-go-staticcheck json 'checker 'buffer)
+                :to-be-equal-flycheck-errors
+                (list
+                 (flycheck-error-new-at
+                  4 8 'error
+                  "expected ';', found ':'"
+                  :id "compile"
+                  :checker 'checker
+                  :buffer 'buffer
+                  :filename "/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go")
+                 (flycheck-error-new-at
+                  4 2 'warning
+                  "undeclared name: Number"
+                  :id "compile"
+                  :checker 'checker
+                  :buffer 'buffer
+                  :filename "/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go")
+                 ))))))
 
 ;;; test-go.el ends here

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -1,4 +1,10 @@
 ;;; test-go.el --- Flycheck Specs: Go -*- lexical-binding: t; -*-
+;;
+;;; Commentary:
+;;
+;; This file implements buttercup tests for the `go-staticheck' syntax checker.
+;;
+;;; Code:
 
 (require 'flycheck-buttercup)
 


### PR DESCRIPTION
### Commit Message:
This commit implements `go-staticcheck`, a checker wrapping the `staticcheck`
tool. `staticcheck` is the successor to `megacheck`, which is now
deprecated.

This commit includes:

1. A checker definition for `go-staticcheck`.
2. The introduction of a new variable, `flycheck-go-version`, which can be
passed to `staticcheck` to specify the version of the Go compiler to perform
checks compatible with.
3. A test for `staticcheck`.
4. Updates to appropriate documentation.
5. Updates to other Golang syntax checkers to prefer falling back to
`staticcheck` before `megacheck`.

The documentation pass includes:

1. `rst` docs for `go-staticcheck` itself.
2. An update to the documentation for `megacheck`, specifying that it's
deprecated.
3. Documentation for the new `flycheck-go-version` variable.
4. Updating the definition of `flycheck-go-build-tags` to correctly declare the
full list of checkers that can use it.

### A Note about this PR

So! Went to get this tested, and in doing so, discovered a few things. While the specs all pass on my local machine, the integration tests for go... do not. This is because the tests for Go tooling are hardcoded with the `go` binary installed in `/usr/local/bin`; on Fedora, at least, `go` is installed in `/usr/bin`, so those tests fail as well. 

I'm currently testing changes to the [all-tools Dockerfile](https://github.com/flycheck/docker-tools/blob/master/all-tools/Dockerfile); I'll make sure that PR is linked to this one once I've got everything together. My worldview here is that this means the tests on this PR wont pass until my PR is merged in to `docker-tools`, which is fine. 

I'll look in to updating the tests to more flexibly find the `go` binary if I have time!

Thanks for a great tool, y'all, and my complements on _superb_ contributor docs!
