### PR TITLE
WIP pylint: Add support for standard-input t

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9514,9 +9514,10 @@ See URL `https://www.pylint.org/'."
                       "--msg-template={path}:{line}:{column}:{C}:{symbol}:{msg}"
                     "--msg-template={path}:{line}:{column}:{C}:{msg_id}:{msg}"))
             (config-file "--rcfile=" flycheck-pylintrc concat)
-            ;; Need `source-inplace' for relative imports (e.g. `from .foo
-            ;; import bar'), see https://github.com/flycheck/flycheck/issues/280
-            source-inplace)
+            ;; pylint takes the original file name as argument when reading
+            ;; from standard input
+            "--from-stdin" source-original)
+  :standard-input t
   :error-filter
   (lambda (errors)
     (flycheck-sanitize-errors (flycheck-increment-error-columns errors)))


### PR DESCRIPTION
The unreleased pylint 2.4 will contain support for linting
files from stdin (see https://github.com/PyCQA/pylint/pull/2746).

This PR updates the minimum pylint requirement to version 2.4 (requires python3!!).