### PR TITLE
Added ghdl option for setting IEEE library standard.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,8 @@
     ``flycheck-idle-buffer-switch-delay`` and
     ``flycheck-buffer-switch-check-intermediate-buffers`` control the
     functionality [GH-1297]
+  - Add ``flycheck-ghdl-ieee-library`` to select which standard IEEE
+    library to use for ghdl.
 
 - Improvements
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1430,6 +1430,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          The directory to use for the file library.
 
+      .. defcustom:: flycheck-ghdl-ieee-library
+
+         The standard to use for the IEEE library.
+
 .. supported-language:: XML
 
    Flycheck checks XML with `xml-xmlstarlet` or `xml-xmllint`.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10714,7 +10714,7 @@ pass the language standard via the `--std' option."
 (make-variable-buffer-local 'flycheck-ghdl-language-standard)
 
 (flycheck-def-option-var flycheck-ghdl-workdir nil vhdl-ghdl
-  "The directory to use for the file library
+  "The directory to use for the file library.
 
 The value of this variable is either a string with the directory
 to use for the file library, or nil, to use the default value.
@@ -10725,6 +10725,21 @@ When non-nil, pass the directory via the `--workdir' option."
   :package-version '(flycheck . "32"))
 (make-variable-buffer-local 'flycheck-ghdl-workdir)
 
+(flycheck-def-option-var flycheck-ghdl-ieee-library nil vhdl-ghdl
+  "The standard to use for the IEEE library.
+
+The value of this variable is either a string denoting an ieee library
+standard, or nil, to use the default standard.  When non-nil,
+pass the ieee library standard via the `--ieee' option."
+  :type '(choice (const :tag "Default standard" nil)
+                 (const :tag "No IEEE Library" "none")
+                 (const :tag "IEEE standard" "standard")
+                 (const :tag "Synopsys standard" "synopsys")
+                 (const :tag "Mentor standard" "mentor"))
+  :safe #'stringp
+  :package-version '(flycheck . "32"))
+(make-variable-buffer-local 'flycheck-ghdl-ieee-library)
+
 (flycheck-define-checker vhdl-ghdl
   "A VHDL syntax checker using GHDL.
 
@@ -10733,6 +10748,7 @@ See URL `https://github.com/ghdl/ghdl'."
             "-s" ; only do the syntax checking
             (option "--std=" flycheck-ghdl-language-standard concat)
             (option "--workdir=" flycheck-ghdl-workdir concat)
+            (option "--ieee=" flycheck-ghdl-ieee-library concat)
             source)
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": " (message) line-end))


### PR DESCRIPTION
Adds a common option to the syntax checker for VHDL, to specify which IEEE standard library to use. A typcial value is "--ieee=synopsys". I'm not sure if I should set that as the default, or leave it nil.