### PR TITLE
change 'go tool vet' to 'go vet'

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -431,10 +431,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          A list of print-like functions to check calls for format string problems.
 
-      .. defcustom:: flycheck-go-vet-shadow
-
-         Whether to check for shadowed variables, in Go 1.6 or newer.
-
       .. defcustom:: flycheck-go-build-tags
 
          A list of build tags.

--- a/flycheck.el
+++ b/flycheck.el
@@ -7769,31 +7769,16 @@ See URL `https://golang.org/cmd/go/' and URL
   :command ("go" "vet"
             (option "-printf.funcs=" flycheck-go-vet-print-functions concat
                     flycheck-option-comma-separated-list)
-            ;; (option-flag "-shadow" flycheck-go-vet-shadow) ;; DEPRECATED
-            ;; (option-list "-tags=" flycheck-go-build-tags concat) ;; DEPRECATED
-            ;; (eval (when (eq flycheck-go-vet-shadow 'strict) "-shadowstrict")) ;; DEPRECATED
             source)
   :error-patterns
   ((warning line-start (file-name) ":" line ": " (message) line-end))
   :modes go-mode
-  ;; We must explicitly check whether the "vet" command is available
-  :predicate (lambda ()
-               (let ((go (flycheck-checker-executable 'go-vet)))
-                 (ignore-errors (process-lines go "help" "vet"))))
   :next-checkers (go-build
                   go-test
                   ;; Fall back if `go build' or `go test' can be used
                   go-errcheck
                   go-unconvert
-                  go-megacheck)
-  :verify (lambda (_)
-            (let* ((go (flycheck-checker-executable 'go-vet))
-                    (have-vet (ignore-errors (process-lines go "help" "vet"))))
-              (list
-               (flycheck-verification-result-new
-                :label "go vet"
-                :message (if have-vet "present" "missing")
-                :face (if have-vet 'success '(bold error)))))))
+                  go-megacheck))
 
 (flycheck-def-option-var flycheck-go-build-install-deps nil (go-build go-test)
   "Whether to install dependencies in `go build' and `go test'.

--- a/flycheck.el
+++ b/flycheck.el
@@ -7732,7 +7732,7 @@ See URL `https://github.com/golang/lint'."
                   go-build go-test go-errcheck go-unconvert go-megacheck))
 
 (flycheck-def-option-var flycheck-go-vet-print-functions nil go-vet
-  "A list of print-like functions for `go tool vet'.
+  "A list of print-like functions for `go vet'.
 
 Go vet will check these functions for format string problems and
 issues, such as a mismatch between the number of formats used,
@@ -7748,18 +7748,6 @@ take an io.Writer as their first argument, like Fprintf,
                  (string :tag "function"))
   :safe #'flycheck-string-list-p)
 
-(flycheck-def-option-var flycheck-go-vet-shadow nil go-vet
-  "Whether to check for shadowed variables with `go tool vet'.
-
-When non-nil check for shadowed variables.  When `strict' check
-more strictly, which can very noisy.  When nil do not check for
-shadowed variables.
-
-This option requires Go 1.6 or newer."
-  :type '(choice (const :tag "Do not check for shadowed variables" nil)
-                 (const :tag "Check for shadowed variables" t)
-                 (const :tag "Strictly check for shadowed variables" strict)))
-
 (flycheck-def-option-var flycheck-go-megacheck-disabled-checkers nil
                          go-megacheck
   "A list of checkers to disable when running `megacheck'.
@@ -7774,24 +7762,24 @@ enabled. "
   :safe #'flycheck-string-list-p)
 
 (flycheck-define-checker go-vet
-  "A Go syntax checker using the `go tool vet' command.
+  "A Go syntax checker using the `go vet' command.
 
 See URL `https://golang.org/cmd/go/' and URL
 `https://golang.org/cmd/vet/'."
-  :command ("go" "tool" "vet" "-all"
-            (option "-printfuncs=" flycheck-go-vet-print-functions concat
+  :command ("go" "vet"
+            (option "-printf.funcs=" flycheck-go-vet-print-functions concat
                     flycheck-option-comma-separated-list)
-            (option-flag "-shadow" flycheck-go-vet-shadow)
-            (option-list "-tags=" flycheck-go-build-tags concat)
-            (eval (when (eq flycheck-go-vet-shadow 'strict) "-shadowstrict"))
+            ;; (option-flag "-shadow" flycheck-go-vet-shadow) ;; DEPRECATED
+            ;; (option-list "-tags=" flycheck-go-build-tags concat) ;; DEPRECATED
+            ;; (eval (when (eq flycheck-go-vet-shadow 'strict) "-shadowstrict")) ;; DEPRECATED
             source)
   :error-patterns
   ((warning line-start (file-name) ":" line ": " (message) line-end))
   :modes go-mode
-  ;; We must explicitly check whether the "vet" tool is available
+  ;; We must explicitly check whether the "vet" command is available
   :predicate (lambda ()
                (let ((go (flycheck-checker-executable 'go-vet)))
-                 (member "vet" (ignore-errors (process-lines go "tool")))))
+                 (ignore-errors (process-lines go "help" "vet"))))
   :next-checkers (go-build
                   go-test
                   ;; Fall back if `go build' or `go test' can be used
@@ -7800,11 +7788,10 @@ See URL `https://golang.org/cmd/go/' and URL
                   go-megacheck)
   :verify (lambda (_)
             (let* ((go (flycheck-checker-executable 'go-vet))
-                   (have-vet (member "vet" (ignore-errors
-                                             (process-lines go "tool")))))
+                    (have-vet (ignore-errors (process-lines go "help" "vet"))))
               (list
                (flycheck-verification-result-new
-                :label "go tool vet"
+                :label "go vet"
                 :message (if have-vet "present" "missing")
                 :face (if have-vet 'success '(bold error)))))))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3329,8 +3329,8 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 (flycheck-ert-def-checker-test go-gofmt go syntax-error
   (flycheck-ert-should-syntax-check
    "language/go/src/syntax/syntax-error.go" 'go-mode
-   '(5 9 error "expected '(', found 'IDENT' ta" :checker go-gofmt)
-   '(6 1 error "expected ')', found '}'" :checker go-gofmt)))
+   '(5 9 error "expected '(', found ta" :checker go-gofmt)
+   '(6 1 error "expected declaration, found '}'" :checker go-gofmt)))
 
 (flycheck-ert-def-checker-test (go-build go-golint go-vet) go complete-chain
   (skip-unless (funcall (flycheck-checker-get 'go-vet 'predicate)))


### PR DESCRIPTION
[fixes #1523]

Update command/docs/checks to replace `go tool vet` with `go vet`.

Removed deprecated command options/flycheck variables
