### PR TITLE
Add support for policy themes to perlcritic

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -791,6 +791,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          The severity level as integer for the ``--severity``.
 
+      .. defcustom:: flycheck-perlcritic-theme
+
+		 The theme expression, passed as the ``--theme`` to ``perlcritic``.
+
       .. syntax-checker-config-file:: flycheck-perlcriticrc
 
 .. supported-language:: PHP

--- a/flycheck.el
+++ b/flycheck.el
@@ -8653,6 +8653,15 @@ the `--severity' option to Perl Critic."
   :safe #'integerp
   :package-version '(flycheck . "0.18"))
 
+(flycheck-def-option-var flycheck-perlcritic-theme nil perl-perlcritic
+  "The theme expression for Perl Critic.
+
+The value of this variable is passed as the `--theme' option to `Perl::Critic'.
+See the documentation of `Perl::Critic' for details"
+  :type '(string :tag "Theme expression")
+  :safe #'stringp
+  :package-version '(flycheck . "32-csv"))
+
 (flycheck-def-config-file-var flycheck-perlcriticrc perl-perlcritic
                               ".perlcriticrc"
   :safe #'stringp
@@ -8665,7 +8674,8 @@ See URL `https://metacpan.org/pod/Perl::Critic'."
   :command ("perlcritic" "--no-color" "--verbose" "%f/%l/%c/%s/%p/%m (%e)\n"
             (config-file "--profile" flycheck-perlcriticrc)
             (option "--severity" flycheck-perlcritic-severity nil
-                    flycheck-option-int))
+                    flycheck-option-int)
+            (option "--theme" flycheck-perlcritic-theme))
   :standard-input t
   :error-patterns
   ((info line-start


### PR DESCRIPTION
Closes issue #1550 by adding support for the --theme option of
the perlcritic executable to the perl-perlcritic checker.