### PR TITLE
Add HiDPI support

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3556,7 +3556,10 @@ The following PROPERTIES constitute an error level:
         (plist-get properties :compilation-level))
   (setf (get level 'flycheck-overlay-category)
         (plist-get properties :overlay-category))
-  (setf (get level 'flycheck-fringe-bitmap-double-arrow)
+  (setf (get level
+        (if (flycheck-high-dpi-screen)
+             'flycheck-fringe-bitmap-double-arrow-hdpi
+             'flycheck-fringe-bitmap-double-arrow))
         (plist-get properties :fringe-bitmap))
   (setf (get level 'flycheck-fringe-face)
         (plist-get properties :fringe-face))
@@ -3630,8 +3633,7 @@ show the icon."
       (if (> (* (/ (float resx) sizex) 25.4) 150) t nil))))
 
 (when (fboundp 'define-fringe-bitmap)
-  (if (flycheck-high-dpi-screen)
-    (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
+    (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow-hdpi
         (vector #b0000000000000000
                 #b0000000000000000
                 #b0000000000000000
@@ -3681,7 +3683,7 @@ show the icon."
                 #b00000000
                 #b00000000
                 #b00000000
-                #b00000000))))
+                #b00000000)))
 
 (setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
 (setf (get 'flycheck-error-overlay 'priority) 110)

--- a/flycheck.el
+++ b/flycheck.el
@@ -3677,7 +3677,7 @@ show the icon."
                 #b00000000
                 #b00000000
                 #b00000000
-                #b00000000)))
+                #b00000000))))
 
 (setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
 (setf (get 'flycheck-error-overlay 'priority) 110)

--- a/flycheck.el
+++ b/flycheck.el
@@ -3621,13 +3621,7 @@ show the icon."
          (res (cdr (assoc 'geometry attrs)))
          (resx (- (caddr res) (car res)))
          dpi)
-    (catch 'exit
-      ;; in terminal
-      (unless sizex
-        (throw 'exit 10))
-      ;; on big screen
-      (when (> sizex 1000)
-        (throw 'exit 10))
+    (catch nil
       ;; if dpi > 150 (standard dpi: 96; hdpi: 192)
       (if (> (* (/ (float resx) sizex) 25.4) 150) t nil))))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -3613,25 +3613,77 @@ show the icon."
 
 
 ;;; Built-in error levels
+(defun flycheck-high-dpi-screen ()
+  "Return t if the user has a HiDPI screen"
+  (let* ((attrs (car (display-monitor-attributes-list)))
+         (size (assoc 'mm-size attrs))
+         (sizex (cadr size))
+         (res (cdr (assoc 'geometry attrs)))
+         (resx (- (caddr res) (car res)))
+         dpi)
+    (catch 'exit
+      ;; in terminal
+      (unless sizex
+        (throw 'exit 10))
+      ;; on big screen
+      (when (> sizex 1000)
+        (throw 'exit 10))
+      ;; if dpi > 150 (standard dpi: 96; hdpi: 192)
+      (if (> (* (/ (float resx) sizex) 25.4) 150) t nil))))
+
 (when (fboundp 'define-fringe-bitmap)
-  (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
-    (vector #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b10011000
-            #b01101100
-            #b00110110
-            #b00011011
-            #b00110110
-            #b01101100
-            #b10011000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000)))
+  (if (flycheck-high-dpi-screen)
+    (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
+        (vector #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b1100001111000000
+                #b1100001111000000
+                #b0011110011110000
+                #b0011110011110000
+                #b0000111100111100
+                #b0000111100111100
+                #b0000001111001111
+                #b0000001111001111
+                #b0000111100111100
+                #b0000111100111100
+                #b0011110011110000
+                #b0011110011110000
+                #b1100001111000000
+                #b1100001111000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000
+                #b0000000000000000) 32 16)
+        (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
+            (vector #b00000000
+                #b00000000
+                #b00000000
+                #b00000000
+                #b00000000
+                #b10011000
+                #b01101100
+                #b00110110
+                #b00011011
+                #b00110110
+                #b01101100
+                #b10011000
+                #b00000000
+                #b00000000
+                #b00000000
+                #b00000000
+                #b00000000)))
 
 (setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
 (setf (get 'flycheck-error-overlay 'priority) 110)

--- a/flycheck.el
+++ b/flycheck.el
@@ -3614,7 +3614,11 @@ show the icon."
 
 ;;; Built-in error levels
 (defun flycheck-high-dpi-screen ()
-  "Return t if the user has a HiDPI screen"
+  "Return t if the user has a HiDPI screen."
+  ;; This is slightly more complicated than using (x-display-mm-width)
+  ;; and (x-display-pixel-width), but it gets the width of the current
+  ;; physical screen (rather than of all monitors) for users with
+  ;; multiple monitors.
   (let* ((attrs (car (display-monitor-attributes-list)))
          (size (assoc 'mm-size attrs))
          (sizex (cadr size))


### PR DESCRIPTION
This PR checks whether the current screen is a HiDPI screen.  If it is, the code doubles the size (in pixels) of the `flycheck-fringe-bitmap-double-arrow` bitmap (which results in the
normal visual size for the icon).

If the screen isn't a HiDPI screen, this code prints the normal `>>` icon.

If merged, this resolves #1552 