### PR TITLE
Add json-jq checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@
 
   - CUDA with ``cuda-nvcc`` [GH-1508]
   - CWL with ``schema-salad-tool`` [GH-1361]
+  - JSON with ``json-jq`` [GH-1568]
   - Jsonnet with ``jsonnet`` [GH-1345]
   - MarkdownLint CLI with ``markdownlint`` [GH-1366]
   - Nix with ``nix-linter`` [GH-1530]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,18 +17,18 @@
 
 - New syntax checkers:
 
-  - Jsonnet with ``jsonnet`` [GH-1345]
-  - Tcl with ``nagelfar`` [GH-1365]
+  - CUDA with ``cuda-nvcc`` [GH-1508]
   - CWL with ``schema-salad-tool`` [GH-1361]
+  - Jsonnet with ``jsonnet`` [GH-1345]
   - MarkdownLint CLI with ``markdownlint`` [GH-1366]
-  - Rust with ``rust-clippy`` [GH-1385]
-  - VHDL with ``ghdl`` [GH-1160]
-  - mypy with ``python-mypy`` [GH-1354]
   - Nix with ``nix-linter`` [GH-1530]
   - Opam with ``opam lint`` [GH-1532]
-  - Text prose with ``textlint`` [GH-1534]
-  - CUDA with ``cuda-nvcc`` [GH-1508]
+  - Rust with ``rust-clippy`` [GH-1385]
   - Staticcheck with ``go-staticheck`` [GH-1541]
+  - Tcl with ``nagelfar`` [GH-1365]
+  - Text prose with ``textlint`` [GH-1534]
+  - VHDL with ``ghdl`` [GH-1160]
+  - mypy with ``python-mypy`` [GH-1354]
 
 - New features:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -703,7 +703,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: JSON
 
-   Flycheck checks JSON with `json-jsonlint` or `json-python-json`.
+   Flycheck checks JSON with `json-jsonlint`, `json-python-json`, or
+   `json-jq`.
 
    .. syntax-checker:: json-jsonlint
 
@@ -712,6 +713,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
    .. syntax-checker:: json-python-json
 
       Check JSON with Python's built-in :py:mod:`json` module.
+
+   .. syntax-checker:: json-jq
+
+      Check JSON with jq_.
+
+      This checker accepts multiple consecutive JSON values in a single input, which is useful for jsonlines data.
+
+      .. _jq: https://stedolan.github.io/jq/
 
 .. supported-language:: Jsonnet
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -204,6 +204,7 @@ attention to case differences."
     javascript-standard
     json-jsonlint
     json-python-json
+    json-jq
     jsonnet
     less
     less-stylelint
@@ -8688,6 +8689,23 @@ See URL `https://docs.python.org/3.5/library/json.html#command-line-interface'."
   :modes json-mode
   ;; The JSON parser chokes if the buffer is empty and has no JSON inside
   :predicate (lambda () (not (flycheck-buffer-empty-p))))
+
+(flycheck-define-checker json-jq
+  "JSON checker using the jq tool.
+
+This checker accepts multiple consecutive JSON values in a
+single input, which is useful for jsonlines data.
+
+See URL `https://stedolan.github.io/jq/'."
+  :command ("jq" "." source null-device)
+  ;; Example error message:
+  ;;   parse error: Expected another key-value pair at line 3, column 1
+  :error-patterns
+  ((error line-start
+          (optional "parse error: ")
+          (message) "at line " line ", column " column
+          (zero-or-more not-newline) line-end))
+  :modes json-mode)
 
 (flycheck-define-checker jsonnet
   "A Jsonnet syntax checker using the jsonnet binary.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3703,6 +3703,12 @@ Why not:
      "language/json.json" 'json-mode
      '(1 44 error "Extra data" :checker json-python-json))))
 
+(flycheck-ert-def-checker-test json-jq json nil
+  (let ((flycheck-disabled-checkers '(json-jsonlint json-python-json)))
+    (flycheck-ert-should-syntax-check
+     "language/json.json" 'json-mode
+     '(1 44 error "Expected value before ','" :checker json-jq))))
+
 (flycheck-ert-def-checker-test less less file-error
   (let* ((candidates (list "no-such-file.less"
                            "npm://no-such-file.less"


### PR DESCRIPTION
This adds a JSON checker using the jq tool.

This checker accepts multiple consecutive JSON values in a single
input, which is useful for jsonlines data.

See https://stedolan.github.io/jq/.