### PR TITLE
Add support for eqc to flycheck-erlang-rebar3-profile

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -399,7 +399,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. defcustom:: flycheck-erlang-rebar3-profile
 
          The profile to use when compiling, e.g. "default" or "test".
-         The default value is nil which will use test profile in test
+         The default value is nil which will use the test profile in test
          directories, eqc if the eqc directories and default profile
          otherwise.
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -400,7 +400,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          The profile to use when compiling, e.g. "default" or "test".
          The default value is nil which will use the test profile in test
-         directories, eqc if the eqc directories and default profile
+         directories, the eqc profile in eqc directories and the default profile
          otherwise.
 
 .. supported-language:: ERuby

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -399,8 +399,9 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. defcustom:: flycheck-erlang-rebar3-profile
 
          The profile to use when compiling, e.g. "default" or "test".
-         The default value is nil which will use test profile
-         in test directories and default profile otherwise.
+         The default value is nil which will use test profile in test
+         directories, eqc if the eqc directories and default profile
+         otherwise.
 
 .. supported-language:: ERuby
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7838,6 +7838,12 @@ dirname is test or else default."
                    (directory-file-name
                     (file-name-directory buffer-file-name)))))
     "test")
+   ((and buffer-file-name
+         (string= "eqc"
+                  (file-name-base
+                   (directory-file-name
+                    (file-name-directory buffer-file-name)))))
+    "eqc")
    (t "default")))
 
 (flycheck-define-checker erlang-rebar3

--- a/flycheck.el
+++ b/flycheck.el
@@ -7831,19 +7831,12 @@ used as profile."
 Use flycheck-erlang-rebar3-profile if set, otherwise use test profile if
 dirname is test or else default."
   (cond
-   (flycheck-erlang-rebar3-profile flycheck-erlang-rebar3-profile)
-   ((and buffer-file-name
-         (string= "test"
-                  (file-name-base
-                   (directory-file-name
-                    (file-name-directory buffer-file-name)))))
-    "test")
-   ((and buffer-file-name
-         (string= "eqc"
-                  (file-name-base
-                   (directory-file-name
-                    (file-name-directory buffer-file-name)))))
-    "eqc")
+   (flycheck-erlang-rebar3-profile)
+   ((seq-contains '("test" "eqc")
+                  (and buffer-file-name
+                       (file-name-base
+                        (directory-file-name
+                         (file-name-directory buffer-file-name))))))
    (t "default")))
 
 (flycheck-define-checker erlang-rebar3


### PR DESCRIPTION
If the file is in the eqc directory use the eqc profile