### PR TITLE
Add option to avoid showing other files' errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,8 +56,8 @@
   - ``javascript-eslint`` checker now supports ``typescript-mode`` by default.
   - Add ``flycheck-erlang-rebar3-profile`` to select which profile to
     use when compiling erlang with rebar3.
-  - Add ``flycheck-relevant-error-other-file-show`` to avoid showing other
-    file's error.
+  - Add ``flycheck-relevant-error-other-file-show`` to avoid showing errors
+    from other files.
 
 - Improvements
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@
   - ``javascript-eslint`` checker now supports ``typescript-mode`` by default.
   - Add ``flycheck-erlang-rebar3-profile`` to select which profile to
     use when compiling erlang with rebar3.
+  - Add ``flycheck-relevant-error-other-file-show`` to avoid showing other
+    file's error.
 
 - Improvements
 

--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -158,6 +158,13 @@ customize the minimum level:
    level is at least as severe as this one.  If ``nil``, display all errors from
    other files.
 
+To never show any errors from other files, set
+`flycheck-relevant-error-other-file-show` to ``nil``.
+
+.. defcustom:: flycheck-relevant-error-other-file-show
+
+   Whether to show errors from other files.
+
 Explain errors
 ==============
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -707,6 +707,13 @@ display all errors from other files."
   :safe #'flycheck-error-level-p
   :package-version '(flycheck . "32"))
 
+(defcustom flycheck-relevant-error-other-file-show t
+  "Whether to show errors from other files."
+  :group 'flycheck
+  :type 'boolean
+  :package-version '(flycheck . "32")
+  :safe #'booleanp)
+
 (defcustom flycheck-completing-read-function #'completing-read
   "Function to read from minibuffer with completion.
 
@@ -3481,6 +3488,7 @@ Return ERRORS, modified in-place."
   "Determine whether ERR is a relevant error for another file."
   (let ((file-name (flycheck-error-filename err)))
     (and file-name
+         flycheck-relevant-error-other-file-show
          (or (null buffer-file-name)
              (not (flycheck-same-files-p buffer-file-name file-name)))
          (<= (flycheck-error-level-severity


### PR DESCRIPTION
Since showing errors from other files was added recently, I'm adding an option to revert back to not showing them.

Note I tried to look at my changes in the documentation but the `make html-auto` step failed with the same error that appeared recently(?) https://travis-ci.org/flycheck/flycheck/jobs/531994058