### PR TITLE
Disambiguate reference to exec-path in -executable-find

### DIFF
--- a/doc/info.py
+++ b/doc/info.py
@@ -139,8 +139,8 @@ def update_htmlxref(app):
             app.env.info_htmlxref = HTMLXRefDB.parse(
                 requests.get(HTMLXRefDB.XREF_URL).text)
         except requests.exceptions.ConnectionError:
-            app.warn('Failed to load xref DB.  '
-                     'Info references will not be resolved')
+            logger.warning('Failed to load xref DB.  '
+                           'Info references will not be resolved')
             app.env.info_htmlxref = None
 
 
@@ -161,8 +161,8 @@ def resolve_info_references(app, _env, refnode, contnode):
     target = ws_re.sub(' ', refnode['reftarget'])
     match = INFO_RE.match(target)
     if not match:
-        app.env.warn(refnode.source, 'Invalid info target: {0}'.format(target),
-                     refnode.line)
+        logger.warning('Invalid info target: {0}'.format(target),
+                       location=(refnode.source, refnode.line))
         return contnode
 
     manual = match.group('manual')
@@ -173,7 +173,7 @@ def resolve_info_references(app, _env, refnode, contnode):
         uri = xrefdb.resolve(manual, node)
         if not uri:
             message = 'Cannot resolve info manual {0}'.format(manual)
-            app.env.warn(refnode.source, message, refnode.line)
+            logger.warning(message, location=(refnode.source, refnode.line))
             return contnode
         else:
             reference = nodes.reference('', '', internal=False,

--- a/flycheck.el
+++ b/flycheck.el
@@ -467,9 +467,9 @@ path of an executable and shall return the full path to the
 executable, or nil if the executable does not exit.
 
 The default is `flycheck-default-executable-find', which searches
-`exec-path' when given a command name, and resolves paths to
-absolute ones.  You can customize this option to search for
-checkers in other environments such as bundle or NixOS
+variable `exec-path' when given a command name, and resolves
+paths to absolute ones.  You can customize this option to search
+for checkers in other environments such as bundle or NixOS
 sandboxes."
   :group 'flycheck
   :type '(choice
@@ -4576,7 +4576,9 @@ POS defaults to `point'."
       ;; if necessary.
       (when other-file-error
         (with-current-buffer buffer
-          (unless (seq-contains flycheck-current-errors error-copy 'equal)
+          ;; `seq-contains-p' is only in seq >= 2.21, which isn't in ELPA
+          (unless (with-no-warnings
+                    (seq-contains flycheck-current-errors error-copy 'equal))
             (when flycheck-mode
               (flycheck-buffer))))))))
 


### PR DESCRIPTION
The latest master complains about `flycheck.el:470: Disambiguate exec-path by preceding w/ function,command,variable,option or symbol.`