### PR TITLE
Remove deprecated go-megacheck

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
   - Improve detection of default directory for ``haskell-ghc`` to consider
     ``hpack`` project files [GH-1435]
   - Replace ``go tool vet`` with ``go vet`` [GH-1548]
+  - Remove the deprecated ``go-megacheck`` checker, which is replaced by
+    ``go-staticcheck``.
 
 - New syntax checkers:
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -449,8 +449,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
    4. `go-build` or `go-test`
    5. `go-errcheck`
    6. `go-unconvert`
-   7. `go-megacheck`
-   8. `go-staticcheck`
+   7. `go-staticcheck`
 
    .. syntax-checker:: go-gofmt
 
@@ -533,20 +532,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
       Check for unnecessary type conversions with unconvert_.
 
       .. _unconvert: https://github.com/mdempsky/unconvert
-
-   .. syntax-checker:: go-megacheck
-
-      Lint code with megacheck_.
-
-      .. note::
-
-         megacheck_ is officially deprecated; it's recommended to switch to staticcheck_.
-
-      .. defcustom:: flycheck-go-megacheck-disabled-checkers
-
-         A list of checkers to disable when running megacheck_.
-
-      .. _megacheck: https://github.com/dominikh/go-tools
 
    .. syntax-checker:: go-staticcheck
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -190,7 +190,6 @@ attention to case differences."
     go-test
     go-errcheck
     go-unconvert
-    go-megacheck
     go-staticcheck
     groovy
     haml
@@ -7928,8 +7927,7 @@ See URL `https://golang.org/cmd/gofmt/'."
                   (warning . go-build) (warning . go-test)
                   (warning . go-errcheck)
                   (warning . go-unconvert)
-                  (warning . go-staticcheck)
-                  (warning . go-megacheck)))
+                  (warning . go-staticcheck)))
 
 (flycheck-define-checker go-golint
   "A Go style checker using Golint.
@@ -7941,7 +7939,7 @@ See URL `https://github.com/golang/lint'."
   :modes go-mode
   :next-checkers (go-vet
                   ;; Fall back, if go-vet doesn't exist
-                  go-build go-test go-errcheck go-unconvert go-megacheck))
+                  go-build go-test go-errcheck go-unconvert))
 
 (flycheck-def-option-var flycheck-go-vet-print-functions nil go-vet
   "A list of print-like functions for `go vet'.
@@ -7958,19 +7956,6 @@ take an io.Writer as their first argument, like Fprintf,
 -printfuncs=Warn:1,Warnf:1 "
   :type '(repeat :tag "print-like functions"
                  (string :tag "function"))
-  :safe #'flycheck-string-list-p)
-
-(flycheck-def-option-var flycheck-go-megacheck-disabled-checkers nil
-                         go-megacheck
-  "A list of checkers to disable when running `megacheck'.
-
-The value of this variable is a list of strings, where each
-string is a checker to be disabled. Valid checkers are `simple',
-`staticcheck' and `unused'. When nil, all checkers will be
-enabled. "
-  :type '(set (const :tag "Disable simple" "simple")
-              (const :tag "Disable staticcheck" "staticcheck")
-              (const :tag "Disable unused" "unused"))
   :safe #'flycheck-string-list-p)
 
 (flycheck-define-checker go-vet
@@ -7990,8 +7975,7 @@ See URL `https://golang.org/cmd/go/' and URL
                   ;; Fall back if `go build' or `go test' can be used
                   go-errcheck
                   go-unconvert
-                  go-staticcheck
-                  go-megacheck)
+                  go-staticcheck)
   :verify (lambda (_)
             (let* ((go (flycheck-checker-executable 'go-vet))
                    (have-vet (member "vet" (ignore-errors
@@ -8012,8 +7996,7 @@ while syntax checking."
   :package-version '(flycheck . "0.25"))
 
 (flycheck-def-option-var flycheck-go-build-tags nil
-                         (go-build go-test go-errcheck
-                                   go-megacheck go-staticcheck)
+                         (go-build go-test go-errcheck go-staticcheck)
   "A list of tags for `go build'.
 
 Each item is a string with a tag to be given to `go build'."
@@ -8070,8 +8053,7 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
                     (not (string-suffix-p "_test.go" (buffer-file-name)))))
   :next-checkers ((warning . go-errcheck)
                   (warning . go-unconvert)
-                  (warning . go-staticcheck)
-                  (warning . go-megacheck)))
+                  (warning . go-staticcheck)))
 
 (flycheck-define-checker go-test
   "A Go syntax and type checker using the `go test' command.
@@ -8093,8 +8075,7 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
                   (string-suffix-p "_test.go" (buffer-file-name))))
   :next-checkers ((warning . go-errcheck)
                   (warning . go-unconvert)
-                  (warning . go-staticcheck)
-                  (warning . go-megacheck)))
+                  (warning . go-staticcheck)))
 
 (flycheck-define-checker go-errcheck
   "A Go checker for unchecked errors.
@@ -8123,8 +8104,7 @@ See URL `https://github.com/kisielk/errcheck'."
   :modes go-mode
   :predicate (lambda () (flycheck-buffer-saved-p))
   :next-checkers ((warning . go-unconvert)
-                  (warning . go-staticcheck)
-                  (warning . go-megacheck)))
+                  (warning . go-staticcheck)))
 
 (flycheck-define-checker go-unconvert
   "A Go checker looking for unnecessary type conversions.
@@ -8134,32 +8114,11 @@ See URL `https://github.com/mdempsky/unconvert'."
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ": " (message) line-end))
   :modes go-mode
-  :predicate (lambda () (flycheck-buffer-saved-p))
-  :next-checkers ((warning . go-megacheck)))
-
-(flycheck-define-checker go-megacheck
-  "A Go checker that performs static analysis and linting using the `megacheck'
-command.
-
-Requires Go 1.6 or newer. See URL
-`https://github.com/dominikh/go-tools'."
-  :command ("megacheck"
-            (option-list "-tags=" flycheck-go-build-tags concat)
-            (eval (mapcar (lambda (checker) (concat "-" checker
-                                                    ".enabled=false"))
-                          flycheck-go-megacheck-disabled-checkers))
-            ;; Run in current directory to make megacheck aware of symbols
-            ;; declared in other files.
-            ".")
-  :error-patterns
-  ((warning line-start (file-name) ":" line ":" column ": " (message) line-end))
-  :modes go-mode)
+  :predicate (lambda () (flycheck-buffer-saved-p)))
 
 (flycheck-define-checker go-staticcheck
   "A Go checker that performs static analysis and linting using
-the `staticcheck' command. `staticcheck' is the successor to
-`megacheck'; while the latter isn't fully deprecated yet, it's
-recommended to migrate to `staticcheck'.
+the `staticcheck' command.
 
 `staticcheck' is explicitly fully compatible with \"the last two
 versions of go\". `staticheck' can target earlier versions (with

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3379,7 +3379,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
            :checker go-build)))))
 
 (flycheck-ert-def-checker-test go-build go directory-with-two-packages
-  (let ((flycheck-disabled-checkers '(go-errcheck go-unconvert go-megacheck go-staticcheck)))
+  (let ((flycheck-disabled-checkers '(go-errcheck go-unconvert go-staticcheck)))
     (flycheck-ert-with-env
         `(("GOPATH" . ,(flycheck-ert-resource-filename "checkers/go")))
       (flycheck-ert-should-syntax-check
@@ -3416,32 +3416,6 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
      "language/go/src/unconvert/unconvert.go" 'go-mode
      '(7 17 warning "unnecessary conversion"
          :checker go-unconvert))))
-
-(flycheck-ert-def-checker-test go-megacheck go nil
-  :tags '(language-go external-tool)
-  (let ((flycheck-disabled-checkers '(go-golint go-staticcheck)))
-    (flycheck-ert-with-env
-        `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
-      (flycheck-ert-should-syntax-check
-       "language/go/src/megacheck/megacheck1.go" 'go-mode
-       '(8 6 warning "should omit values from range; this loop is equivalent to `for range ...` (S1005)"
-           :checker go-megacheck)
-       '(12 21 warning "calling strings.Replace with n == 0 will return no results, did you mean -1? (SA1018)"
-            :checker go-megacheck)
-       '(16 6 warning "func unused is unused (U1000)"
-            :checker go-megacheck)))))
-
-(flycheck-ert-def-checker-test go-megacheck-disabled-checkers go nil
-  :tags '(language-go external-tool)
-  (let ((flycheck-disabled-checkers '(go-golint)))
-    (flycheck-ert-with-env
-        `(("GOPATH" . ,(flycheck-ert-resource-filename "language/go")))
-      ;; Run with simple and unused checkers disabled
-      (let ((flycheck-go-megacheck-disabled-checkers '("simple" "unused")))
-        (flycheck-ert-should-syntax-check
-         "language/go/src/megacheck/megacheck1.go" 'go-mode
-         '(12 21 warning "calling strings.Replace with n == 0 will return no results, did you mean -1? (SA1018)"
-              :checker go-megacheck))))))
 
 (flycheck-ert-def-checker-test go-staticcheck go nil
   :tags '(language-go external-tool)

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4142,10 +4142,10 @@ Why not:
 (flycheck-ert-def-checker-test ruby-rubocop ruby syntax-error
   (flycheck-ert-should-syntax-check
    "language/ruby/syntax-error.rb" 'ruby-mode
-   '(5 7 error "unexpected token tCONSTANT (Using Ruby 2.2 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+   '(5 7 error "unexpected token tCONSTANT (Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
        :id "Lint/Syntax"
        :checker ruby-rubocop)
-   '(5 24 error "unterminated string meets end of file (Using Ruby 2.2 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+   '(5 24 error "unterminated string meets end of file (Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
        :id "Lint/Syntax"
        :checker ruby-rubocop)))
 
@@ -4173,6 +4173,8 @@ Why not:
 (flycheck-ert-def-checker-test (ruby-rubocop ruby-reek ruby-rubylint) ruby with-rubylint
   (flycheck-ert-should-syntax-check
    "language/ruby/warnings.rb" 'ruby-mode
+   '(1 1 info "Missing magic comment `# frozen_string_literal: true`."
+       :id "Style/FrozenStringLiteralComment" :checker ruby-rubocop)
    '(3 nil warning "Person assumes too much for instance variable '@name'"
        :id "InstanceVariableAssumption" :checker ruby-reek)
    '(3 1 info "Missing top-level class documentation comment."


### PR DESCRIPTION
The linter is now fully deprecated.

Fix #1556.