### PR TITLE
Add terraform checkers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@
   - VHDL with ``ghdl`` [GH-1160]
   - mypy with ``python-mypy`` [GH-1354]
   - terraform with ``terraform fmt`` [GH-1586]
+  - terraform-tflint with ``tflint`` [GH-1586]
 
 - New features:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@
   - Text prose with ``textlint`` [GH-1534]
   - VHDL with ``ghdl`` [GH-1160]
   - mypy with ``python-mypy`` [GH-1354]
+  - terraform with ``terraform fmt`` [GH-1586]
 
 - New features:
 

--- a/Cask
+++ b/Cask
@@ -49,6 +49,7 @@
  (depends-on "scss-mode")
  (depends-on "slim-mode")
  (depends-on "systemd")
+ (depends-on "terraform-mode")
  (depends-on "tuareg")
  (depends-on "typescript-mode")
  (depends-on "web-mode")

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1370,6 +1370,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check Tcl syntax with `Nagelfar <http://nagelfar.sourceforge.net/>`_.
 
+.. supported-language:: Terraform
+
+   .. syntax-checker:: terraform
+
+      Check Terraform syntax with `terraform fmt`_
+
+      .. _terraform fmt: https://www.terraform.io/docs/commands/fmt.html
+
 .. supported-language:: Text
 
    .. syntax-checker:: proselint

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1378,6 +1378,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _terraform fmt: https://www.terraform.io/docs/commands/fmt.html
 
+   .. syntax-checker:: terraform-tflint
+
+      Check Terraform with `tflint <https://github.com/wata727/tflint>`_
+
 .. supported-language:: Text
 
    .. syntax-checker:: proselint

--- a/flycheck.el
+++ b/flycheck.el
@@ -262,6 +262,7 @@ attention to case differences."
     systemd-analyze
     tcl-nagelfar
     terraform
+    terraform-tflint
     tex-chktex
     tex-lacheck
     texinfo
@@ -10770,6 +10771,40 @@ See URL `https://www.terraform.io/docs/commands/fmt.html'."
           "\n\n  on <stdin> line " line ":\n  (source code not available)\n\n"
           (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
           line-end))
+  :next-checkers ((warning . terraform-tflint))
+  :modes terraform-mode)
+
+(defun flycheck-parse-tflint-linter (output checker buffer)
+  "Parse tflint warnings from JSON OUTPUT.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and
+the BUFFER that was checked respectively.
+
+See URL `https://github.com/wata727/tflint' for more
+information about tflint."
+  (mapcar (lambda (err)
+            (let-alist err
+              (flycheck-error-new-at
+               .line
+               nil
+               (pcase .type
+                 (`"ERROR"   'error)
+                 (`"WARNING" 'warning)
+                 ;; Default to error
+                 (_          'error))
+               .message
+               :id .detector
+               :checker checker
+               :buffer buffer
+               :filename (buffer-file-name buffer))))
+          (car (flycheck-parse-json output))))
+
+(flycheck-define-checker terraform-tflint
+  "A Terraform checker using tflint.
+
+See URL `https://github.com/wata727/tflint'."
+  :command ("tflint" "--error-with-issues" "--format=json" source)
+  :error-parser flycheck-parse-tflint-linter
   :modes terraform-mode)
 
 (flycheck-define-checker tex-chktex

--- a/flycheck.el
+++ b/flycheck.el
@@ -261,6 +261,7 @@ attention to case differences."
     sql-sqlint
     systemd-analyze
     tcl-nagelfar
+    terraform
     tex-chktex
     tex-lacheck
     texinfo
@@ -10757,6 +10758,19 @@ See URL `http://nagelfar.sourceforge.net/'."
    (warning line-start (file-name) ": " line ": W " (message) line-end)
    (error   line-start (file-name) ": " line ": E " (message) line-end))
   :modes tcl-mode)
+
+(flycheck-define-checker terraform
+  "A Terraform syntax checker with `terraform fmt'.
+
+See URL `https://www.terraform.io/docs/commands/fmt.html'."
+  :command ("terraform" "fmt" "-no-color" "-")
+  :standard-input t
+  :error-patterns
+  ((error line-start "Error: " (one-or-more not-newline)
+          "\n\n  on <stdin> line " line ":\n  (source code not available)\n\n"
+          (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
+          line-end))
+  :modes terraform-mode)
 
 (flycheck-define-checker tex-chktex
   "A TeX and LaTeX syntax and style checker using chktex.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4089,6 +4089,12 @@ Why not:
    '(2 nil error "An argument definition must end with a newline."
        :checker terraform)))
 
+(flycheck-ert-def-checker-test terraform-tflint terraform nil
+  (flycheck-ert-should-syntax-check
+   "language/terraform/error.tf" 'terraform-mode
+   '(3 nil error "\"t1.2xlarge\" is invalid instance type."
+       :id "aws_instance_invalid_type" :checker terraform-tflint)))
+
 (flycheck-ert-def-checker-test markdown-markdownlint-cli markdown nil
   (flycheck-ert-should-syntax-check
    "language/markdown.md" 'markdown-mode

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4081,6 +4081,14 @@ Why not:
    '(12 nil error "Wrong number of arguments \(4\) to \"set\""
         :checker tcl-nagelfar)))
 
+(flycheck-ert-def-checker-test terraform terraform nil
+  (flycheck-ert-should-syntax-check
+   "language/terraform/syntax-error.tf" 'terraform-mode
+   '(2 nil error "The \";\" character is not valid. Use newlines to separate arguments and blocks,\nand commas to separate items in collection values."
+       :checker terraform)
+   '(2 nil error "An argument definition must end with a newline."
+       :checker terraform)))
+
 (flycheck-ert-def-checker-test markdown-markdownlint-cli markdown nil
   (flycheck-ert-should-syntax-check
    "language/markdown.md" 'markdown-mode

--- a/test/resources/language/terraform/error.tf
+++ b/test/resources/language/terraform/error.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge" # invalid type
+}

--- a/test/resources/language/terraform/syntax-error.tf
+++ b/test/resources/language/terraform/syntax-error.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1";
+}


### PR DESCRIPTION
Hi, I've added checkers for terraform

Tests:

<details>
<summary>
make SELECTOR='(tag checker-terraform)' integ
</summary>

```
make SELECTOR='(tag checker-terraform)' integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck.el
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-ert.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-terraform))'
Loading /Users/marsam/code/flycheck/.cask/26.2/elpa/julia-mode-20190407.2119/julia-latexsubs...
Running tests on Emacs 26.2, built at 2019-06-18
Running 1 tests (2019-06-18 22:01:19-0500)
   passed  1/1  flycheck-define-checker/terraform/default

Ran 1 tests, 1 results as expected (2019-06-18 22:01:20-0500)
````
</details>

<details>
<summary>
make SELECTOR='(tag checker-terraform-tflint)' integ
</summary>

```
make SELECTOR='(tag checker-terraform-tflint)' integ
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck.el
cask exec emacs -Q --batch -L .  -l maint/flycheck-compile.el -f flycheck/batch-byte-compile flycheck-ert.el
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-terraform-tflint))'
Loading /Users/marsam/code/flycheck/.cask/26.2/elpa/julia-mode-20190407.2119/julia-latexsubs...
Running tests on Emacs 26.2, built at 2019-06-18
Running 1 tests (2019-06-18 22:02:06-0500)
   passed  1/1  flycheck-define-checker/terraform-tflint/default

Ran 1 tests, 1 results as expected (2019-06-18 22:02:08-0500)

```
</details>
