### PR TITLE
Fix `flycheck-eslint-config-exists-p` for ESLint 6

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8621,8 +8621,10 @@ for more information about the custom directories."
 (defun flycheck-eslint-config-exists-p ()
   "Whether there is a valid eslint config for the current buffer."
   (let* ((executable (flycheck-find-checker-executable 'javascript-eslint))
-         (exitcode (and executable (call-process executable nil nil nil
-                                                 "--print-config" "."))))
+         (exitcode (and executable
+                        (call-process executable nil nil nil
+                                      "--print-config" (or buffer-file-name
+                                                           "index.js")))))
     (eq exitcode 0)))
 
 (defun flycheck-parse-eslint (output checker buffer)


### PR DESCRIPTION
See https://github.com/eslint/eslint/pull/11885

> Since v4.1.0, ESLint has supported glob-based configuration. So --print-config with a directory path doesn't make sense anymore. Configurations are not per directory.
