### PR TITLE
Fixed ImportError when there is a submodule that clashes with a python stdlib module

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9280,7 +9280,7 @@ Return nil if CHECKER's executable is not a Python REPL.
 Otherwise, return a list starting with -c (-m is not enough
 because it adds the current directory to Python's path)."
   (when (flycheck-python-needs-module-p checker)
-    `("-c" ,(concat "import sys,runpy;sys.path.pop(0);"
+    `("-c" ,(concat "import sys;sys.path.pop(0);import runpy;"
                     (format "runpy.run_module(%S)" module-name)))))
 
 (flycheck-def-config-file-var flycheck-flake8rc python-flake8 ".flake8rc"


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.7/runpy.py", line 14, in <module>
    import importlib.machinery # importlib first so we can test #15386 via -m
  File "/home/alexk/projects/elasticmagic/.tox/flake8/lib/python3.7/importlib/__init__.py", line 57, in <module>
    import types
  File "/home/alexk/projects/elasticmagic/elasticmagic/types.py", line 1, in <module>
    import base64
  File "/home/alexk/projects/elasticmagic/.tox/flake8/lib/python3.7/base64.py", line 9, in <module>
    import re
  File "/home/alexk/projects/elasticmagic/.tox/flake8/lib/python3.7/re.py", line 122, in <module>
    import enum
  File "/home/alexk/projects/elasticmagic/.tox/flake8/lib/python3.7/enum.py", line 2, in <module>
    from types import MappingProxyType, DynamicClassAttribute
ImportError: cannot import name 'MappingProxyType' from 'types' (/home/alexk/projects/elasticmagic/elasticmagic/types.py)
```