### PR TITLE
Drop compatibility for Emacs versions below 24.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - **Breaking changes**
 
+  - Flycheck now requires GNU Emacs 24.5 or newer
   - Remove ``javascript-jscs`` checker [GH-1024]
   - Remove ``elixir-dogma`` checker [GH-1450]
   - ``rust-cargo`` now requires Rust 1.17 or newer [GH-1289]

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -38,54 +38,6 @@
 (require 'macroexp)                     ; For macro utilities
 
 
-;;; Compatibility
-
-(eval-and-compile
-  ;; Provide `ert-skip' and friends for Emacs 24.3
-  (defconst flycheck-ert-ert-can-skip (fboundp 'ert-skip)
-    "Whether ERT supports test skipping.")
-
-  (unless (fboundp 'define-error)
-    ;; from Emacs `subr.el'
-    (defun define-error (name message &optional parent)
-      "Define NAME as a new error signal.
-MESSAGE is a string that will be output to the echo area if such an error
-is signaled without being caught by a `condition-case'.
-PARENT is either a signal or a list of signals from which it inherits.
-Defaults to `error'."
-      (unless parent (setq parent 'error))
-      (let ((conditions
-             (if (consp parent)
-                 (apply #'append
-                        (mapcar
-                         (lambda (parent)
-                           (cons parent
-                                 (or (get parent 'error-conditions)
-                                     (error "Unknown signal `%s'" parent))))
-                         parent))
-               (cons parent (get parent 'error-conditions)))))
-        (put name 'error-conditions
-             (delete-dups (copy-sequence (cons name conditions))))
-        (when message (put name 'error-message message)))))
-
-  (unless flycheck-ert-ert-can-skip
-    ;; Fake skipping
-
-    (define-error 'flycheck-ert-skipped "Test skipped")
-
-    (defun ert-skip (data)
-      (signal 'flycheck-ert-skipped data))
-
-    (defmacro skip-unless (form)
-      `(unless (ignore-errors ,form)
-         (signal 'flycheck-ert-skipped ',form)))
-
-    (defun ert-test-skipped-p (result)
-      (and (ert-test-failed-p result)
-           (eq (car (ert-test-failed-condition result))
-               'flycheck-ert-skipped)))))
-
-
 ;;; Internal variables
 
 (defvar flycheck-ert--resource-directory nil
@@ -200,16 +152,7 @@ should use to lookup resource files."
       (error "No tests defined.  \
 Call `flycheck-ert-initialize' after defining all tests!"))
 
-    (setq flycheck-ert--resource-directory resource-dir)
-
-    ;; Emacs 24.3 don't support skipped tests, so we add poor man's test
-    ;; skipping: We mark skipped tests as expected failures by adjusting the
-    ;; expected result of all test cases. Not particularly pretty, but works :)
-    (unless flycheck-ert-ert-can-skip
-      (dolist (test tests)
-        (let ((result (ert-test-expected-result-type test)))
-          (setf (ert-test-expected-result-type test)
-                `(or ,result (satisfies ert-test-skipped-p))))))))
+    (setq flycheck-ert--resource-directory resource-dir)))
 
 
 ;;; Test case definitions

--- a/flycheck.el
+++ b/flycheck.el
@@ -10,7 +10,7 @@
 ;; URL: http://www.flycheck.org
 ;; Keywords: convenience, languages, tools
 ;; Version: 32-cvs
-;; Package-Requires: ((dash "2.12.1") (pkg-info "0.4") (let-alist "1.0.4") (seq "1.11") (emacs "24.3"))
+;; Package-Requires: ((dash "2.12.1") (pkg-info "0.4") (let-alist "1.0.4") (seq "1.11") (emacs "24.5"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -72,7 +72,7 @@
 (require 'dash)
 
 (require 'seq)                   ; Sequence functions
-(require 'subr-x nil 'no-error)  ; Additional utilities, Emacs 24.4 and upwards
+(require 'subr-x)                ; Additional utilities
 (require 'cl-lib)                ; `cl-defstruct' and CL utilities
 (require 'tabulated-list)        ; To list errors
 (require 'easymenu)              ; Flycheck Mode menu definition
@@ -88,47 +88,6 @@
 
 ;; Tell the byte compiler about autoloaded functions from packages
 (declare-function pkg-info-version-info "pkg-info" (package))
-
-
-;;; Compatibility
-(eval-and-compile
-  (unless (fboundp 'string-suffix-p)
-    ;; TODO: Remove when dropping support for Emacs 24.3 and earlier
-    (defun string-suffix-p (suffix string &optional ignore-case)
-      "Return non-nil if SUFFIX is a suffix of STRING.
-If IGNORE-CASE is non-nil, the comparison is done without paying
-attention to case differences."
-      (let ((start-pos (- (length string) (length suffix))))
-        (and (>= start-pos 0)
-             (eq t (compare-strings suffix nil nil
-                                    string start-pos nil ignore-case))))))
-
-  ;; TODO: Remove when dropping support for Emacs 24.3 and earlier
-  (unless (featurep 'subr-x)
-    ;; `subr-x' function for Emacs 24.3 and below
-    (defsubst string-join (strings &optional separator)
-      "Join all STRINGS using SEPARATOR."
-      (mapconcat 'identity strings separator))
-
-    (defsubst string-trim-left (string)
-      "Remove leading whitespace from STRING."
-      (if (string-match "\\`[ \t\n\r]+" string)
-          (replace-match "" t t string)
-        string))
-
-    (defsubst string-trim-right (string)
-      "Remove trailing whitespace from STRING."
-      (if (string-match "[ \t\n\r]+\\'" string)
-          (replace-match "" t t string)
-        string))
-
-    (defsubst string-trim (string)
-      "Remove leading and trailing whitespace from STRING."
-      (string-trim-left (string-trim-right string)))
-
-    (defsubst string-empty-p (string)
-      "Check whether STRING is empty."
-      (string= string ""))))
 
 
 ;;; Customization

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3612,9 +3612,9 @@ Why not:
      "language/javascript/style.js" flycheck-test-javascript-modes
      '(3 10 error "Missing space before function parentheses."
          :checker javascript-standard)
-     '(4 1 error "Expected indentation of 2 spaces but found 1 tab."
+     '(4 1 error "Unexpected tab character."
          :checker javascript-standard)
-     '(4 2 error "Unexpected tab character."
+     '(4 1 error "Expected indentation of 2 spaces but found 1 tab."
          :checker javascript-standard)
      '(4 6 error "'foo' is assigned a value but never used."
          :checker javascript-standard)
@@ -4376,7 +4376,8 @@ The manifest path is relative to
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/multiline-error.rs" 'rust-mode
-     '(7 9 error "mismatched types (expected u8, found i8)" :checker rust :id "E0308" :group 1))))
+     '(7 9 error "mismatched types (expected u8, found i8)" :checker rust :id "E0308" :group 1)
+     '(7 9 info "you can convert an `i8` to `u8` and panic if the converted value wouldn't fit: `i.try_into().unwrap()`" :checker rust :id "E0308" :group 1))))
 
 (flycheck-ert-def-checker-test rust rust warning
   (let ((flycheck-disabled-checkers '(rust-cargo)))
@@ -4390,9 +4391,9 @@ The manifest path is relative to
   (let ((flycheck-disabled-checkers '(rust-cargo)))
     (flycheck-ert-should-syntax-check
      "language/rust/flycheck-test/src/note-and-help.rs" 'rust-mode
-     '(11 9 info "value moved here" :checker rust :id "E0382" :group 1)
-     '(12 9 error "use of moved value: `_x` (value used here after move)" :checker rust :id "E0382" :group 1)
-     '(12 9 info "move occurs because `_x` has type `NonPOD`, which does not implement the `Copy` trait" :checker rust :id "E0382" :group 1))))
+     '(10 9 info "move occurs because `_x` has type `NonPOD`, which does not implement the `Copy` trait" :checker rust :id "E0382" :group 1)
+     '(11 14 info "value moved here" :checker rust :id "E0382" :group 1)
+     '(12 14 error "use of moved value: `_x` (value used here after move)" :checker rust :id "E0382" :group 1))))
 
 (flycheck-ert-def-checker-test rust rust crate-root-not-set
   (let ((flycheck-disabled-checkers '(rust-cargo)))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3079,18 +3079,12 @@ The term \"1\" has type \"nat\" while it is expected to have type \"bool\"." :ch
 
 (ert-deftest flycheck-d-module-re/matches-module-name ()
   :tags '(language-d)
-  (unless (version<= "24.4" emacs-version)
-    (ert-skip "Skipped because CC Mode is broken on 24.3.
-See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (let ((s "module spam.with.eggs ;"))
     (should (string-match flycheck-d-module-re s))
     (should (string= "spam.with.eggs" (match-string 1 s)))))
 
 (ert-deftest flycheck-d-base-directory/no-module-declaration ()
   :tags '(language-d)
-  (unless (version<= "24.4" emacs-version)
-    (ert-skip "Skipped because CC Mode is broken on 24.3.
-See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (flycheck-ert-with-resource-buffer "language/d/src/dmd/no_module.d"
     (should (flycheck-same-files-p
              (flycheck-d-base-directory)
@@ -3098,9 +3092,6 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 
 (ert-deftest flycheck-d-base-directory/with-module-declaration ()
   :tags '(language-d)
-  (unless (version<= "24.4" emacs-version)
-    (ert-skip "Skipped because CC Mode is broken on 24.3.
-See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (flycheck-ert-with-resource-buffer "language/d/src/dmd/warning.d"
     (should (flycheck-same-files-p
              (flycheck-d-base-directory)
@@ -3108,18 +3099,12 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 
 (ert-deftest flycheck-d-base-directory/package-file ()
   :tags '(language-d)
-  (unless (version<= "24.4" emacs-version)
-    (ert-skip "Skipped because CC Mode is broken on 24.3.
-See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (flycheck-ert-with-resource-buffer "language/d/src/dmd/package.d"
     (should (flycheck-same-files-p
              (flycheck-d-base-directory)
              (flycheck-ert-resource-filename "language/d/src")))))
 
 (flycheck-ert-def-checker-test d-dmd d warning-include-path
-  (unless (version<= "24.4" emacs-version)
-    (ert-skip "Skipped because CC Mode is broken on 24.3.
-See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (let ((flycheck-dmd-include-path '("../../lib")))
     (flycheck-ert-should-syntax-check
      "language/d/src/dmd/warning.d" 'd-mode
@@ -3128,18 +3113,12 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
           :checker d-dmd))))
 
 (flycheck-ert-def-checker-test d-dmd d missing-import
-  (unless (version<= "24.4" emacs-version)
-    (ert-skip "Skipped because CC Mode is broken on 24.3.
-See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (flycheck-ert-should-syntax-check
    "language/d/src/dmd/warning.d" 'd-mode
    '(4 8 error "module external_library is in file 'external_library.d' which cannot be read"
        :checker d-dmd)))
 
 (flycheck-ert-def-checker-test d-dmd d continuation-line
-  (unless (version<= "24.4" emacs-version)
-    (ert-skip "Skipped because CC Mode is broken on 24.3.
-See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (flycheck-ert-should-syntax-check
    "language/d/src/dmd/continuation.d" 'd-mode
    '(5 12 error "undefined identifier 'invalid'"
@@ -3186,9 +3165,6 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 
 (flycheck-ert-def-checker-test (emacs-lisp-checkdoc) emacs-lisp
                                inherits-checkdoc-variables
-  ;; This test doesn't run on 24.3 and earlier because the corresponding
-  ;; checkdoc variables were only introduced in 24.4.
-  (skip-unless (version<= "24.4" emacs-version))
   (flycheck-ert-should-syntax-check
    "language/emacs-lisp/local-checkdoc-variables.el" 'emacs-lisp-mode))
 


### PR DESCRIPTION
Fix #1597.

I've also dropped compatibility shims for 24.3 and 24.4.