### PR TITLE
Add bazel checker with buildifier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@
   - terraform with ``terraform fmt`` [GH-1586]
   - terraform-tflint with ``tflint`` [GH-1586]
   - protobuf-prototool with ``prototool`` [GH-1591]
+  - Bazel with ``bazel-buildifier`` [GH-1613]
 
 - New features:
 

--- a/Cask
+++ b/Cask
@@ -12,6 +12,7 @@
 
  ;; Various modes for use in the unit tests
  (depends-on "adoc-mode")
+ (depends-on "bazel-mode")
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")
  (depends-on "cwl-mode")

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -62,6 +62,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _AsciiDoc: http://www.methods.co.nz/asciidoc
 
+.. supported-language:: Bazel
+
+   .. syntax-checker:: bazel-buildifier
+
+      Check Bazel with buildifier_.
+
+      .. _buildifier: https://github.com/bazelbuild/buildtools
+
 .. supported-language:: C/C++
    :index_as: C
               C++

--- a/flycheck.el
+++ b/flycheck.el
@@ -163,6 +163,7 @@ attention to case differences."
   '(ada-gnat
     asciidoctor
     asciidoc
+    bazel-buildifier
     c/c++-clang
     c/c++-gcc
     c/c++-cppcheck
@@ -6631,6 +6632,21 @@ See URL `http://asciidoctor.org'."
             "asciidoctor: WARNING: <stdin>: Line " line ": " (message)
             line-end))
   :modes adoc-mode)
+
+(flycheck-define-checker bazel-buildifier
+  "An Bazel checker using the buildifier.
+
+See URL `https://github.com/bazelbuild/buildtools/blob/master/buildifier'."
+  :command ("buildifier" "-lint=warn")
+  :standard-input t
+  :error-patterns
+  ((error line-start
+          "<stdin>:" line ":" column ": " (message)
+          line-end)
+   (warning line-start
+            "<stdin>:" line ": " (id (one-or-more (in word "-"))) ": " (message)
+            line-end))
+  :modes bazel-mode)
 
 (flycheck-def-args-var flycheck-clang-args c/c++-clang
   :package-version '(flycheck . "0.22"))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2871,6 +2871,16 @@ evaluating BODY."
    '(4 nil warning "section title out of sequence: expected level 1, got level 2" :checker asciidoctor)
    '(6 nil error "unmatched macro: endif::[]" :checker asciidoctor)))
 
+(flycheck-ert-def-checker-test bazel-buildifier bazel error
+  (flycheck-ert-should-syntax-check
+   "language/bazel/syntax-error.bazel" 'bazel-mode
+   '(1 11 error "syntax error near !" :checker bazel-buildifier)))
+
+(flycheck-ert-def-checker-test bazel-buildifier bazel nil
+  (flycheck-ert-should-syntax-check
+   "language/bazel/warnings.bazel" 'bazel-mode
+   '(1 nil warning "The file has no module docstring. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)" :id "module-docstring" :checker bazel-buildifier)))
+
 (flycheck-ert-def-checker-test c/c++-clang (c c++) error
   (let ((flycheck-disabled-checkers '(c/c++-gcc)))
     (flycheck-ert-should-syntax-check

--- a/test/resources/language/bazel/syntax-error.bazel
+++ b/test/resources/language/bazel/syntax-error.bazel
@@ -1,0 +1,3 @@
+cc_binary!(
+    name = "hello-world",
+)

--- a/test/resources/language/bazel/warnings.bazel
+++ b/test/resources/language/bazel/warnings.bazel
@@ -1,0 +1,4 @@
+cc_binary(
+    name = "hello-world",
+    srcs = ["hello-world.cc"],
+)


### PR DESCRIPTION
Add bazel checker with [buildifier](https://github.com/bazelbuild/buildtools/blob/master/buildifier)

<details>
<summary>
make SELECTOR='(tag checker-bazel-buildifier)' integ
</summary>

```
make SELECTOR='(tag checker-bazel-buildifier)' integ
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-bazel-buildifier))'
Loading /Users/mariorodas/src/flycheck/.cask/26.2/elpa/julia-mode-20190813.1326/julia-latexsubs...
Running tests on Emacs 26.2, built at 2019-08-18
Running 2 tests (2019-08-18 09:12:57-0500)
Can't guess python-indent-offset, using defaults: 4
Can't guess python-indent-offset, using defaults: 4
   passed  1/2  flycheck-define-checker/bazel-buildifier/default
Can't guess python-indent-offset, using defaults: 4
Can't guess python-indent-offset, using defaults: 4
   passed  2/2  flycheck-define-checker/bazel-buildifier/error

Ran 2 tests, 2 results as expected (2019-08-18 09:12:59-0500)
````
</details>

