### PR TITLE
Capture ‘note’ messages in python-mypy checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9539,7 +9539,9 @@ See URL `http://mypy-lang.org/'."
   ((error line-start (file-name) ":" line (optional ":" column)
           ": error:" (message) line-end)
    (warning line-start (file-name) ":" line (optional ":" column)
-            ": warning:" (message) line-end))
+            ": warning:" (message) line-end)
+   (info line-start (file-name) ":" line (optional ":" column)
+         ": note:" (message) line-end))
   :modes python-mode
   ;; Ensure the file is saved, to work around
   ;; https://github.com/python/mypy/issues/4746.


### PR DESCRIPTION
This extends the python-mypy checker to also collect ‘note’ messages,
which look like this:

```
somefile.py:123: note:     foo: builtins.dict[builtins.str, Any]
```

The format is identical to the error and warning messages which are
already handled by Flycheck, so just add another error pattern using
Flycheck's ‘info’ severity level.