### PR TITLE
Detect erlang-rebar3 projects with dynamic config

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7810,8 +7810,9 @@ See URL `http://www.erlang.org/'."
   :enabled (lambda () (string-suffix-p ".erl" (buffer-file-name))))
 
 (defun contains-rebar-config (dir-name)
-  "Return DIR-NAME if DIR-NAME/rebar.config exists, nil otherwise."
-  (when (file-exists-p (expand-file-name "rebar.config" dir-name))
+  "Return DIR-NAME if rebar config file exists in DIR-NAME, nil otherwise."
+  (when (or (file-exists-p (expand-file-name "rebar.config" dir-name))
+            (file-exists-p (expand-file-name "rebar.config.script" dir-name)))
     dir-name))
 
 (defun locate-rebar3-project-root (file-name &optional prev-file-name acc)


### PR DESCRIPTION
This fixes an issue where flycheck's `erlang-rebar3` checker isn't correctly detecting a project that uses a dynamic rebar config.

Erlang projects can use a `rebar.config.script` file as an alternative to
`rebar.config` in order to have dynamic configuration. The script file will then
be evaluated by rebar3 and the result used as configuration.

This adds `rebar.config.script` as an alternative to `rebar.config` when
detecting an Erlang rebar3 project.