### PR TITLE
Fix filtering racket-raco errors when using nil shells

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9711,8 +9711,8 @@ See URL `https://racket-lang.org/'."
      (flycheck-increment-error-columns
       (seq-remove
        (lambda (err)
-         (string=
-          "/usr/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt"
+         (string-suffix-p
+          "/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt"
           (flycheck-error-filename err)))
        errors))))
   :error-patterns


### PR DESCRIPTION
The hardcoded path is different in every `nix shell` invocation, so
errors from expand.rkt are still visible.

But there is a common suffix that is long and unique enough so we can
still avoid collision filtering out user errors.