### PR TITLE
Fix systemd-analyze parsing and unit test

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10854,7 +10854,8 @@ See URL
   :command ("systemd-analyze" "verify" source)
   :error-parser flycheck-parse-with-patterns-without-color
   :error-patterns
-  ((error line-start "[" (file-name) ":" line "] " (message) line-end))
+  ((error line-start (file-name) ":" (optional line ":") (message) line-end)
+   (error line-start "[" (file-name) ":" line "]" (message) line-end))
   :modes (systemd-mode))
 
 (flycheck-def-config-file-var flycheck-chktexrc tex-chktex ".chktexrc"

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4613,14 +4613,28 @@ The manifest path is relative to
        :checker sql-sqlint)))
 
 (flycheck-ert-def-checker-test systemd-analyze systemd nil
-  (flycheck-ert-should-syntax-check
-   "language/systemd-analyze-test.service" 'systemd-mode
-   '(3 nil error "Invalid URL, ignoring: foo://bar"
-       :checker systemd-analyze)
-   '(6 nil error "Unknown lvalue 'ExecSmart' in section 'Service'"
-       :checker systemd-analyze)
-   '(8 nil error "Unknown section 'Dog'. Ignoring."
-       :checker systemd-analyze)))
+  (let* ((systemd-version
+          (--> (shell-command-to-string
+                (format "%s --version"
+                        (flycheck-find-checker-executable 'systemd-analyze)))
+               split-string
+               cl-second))
+         (key-unknown-message
+          (cond
+           ((ignore-errors (version< systemd-version "241"))
+            "Unknown lvalue 'ExecSmart' in section 'Service'")
+           ((ignore-errors (version< systemd-version "243"))
+            "Unknown lvalue 'ExecSmart' in section 'Service', ignoring")
+           (t
+            "Unknown key name 'ExecSmart' in section 'Service', ignoring."))))
+    (flycheck-ert-should-syntax-check
+     "language/systemd-analyze-test.service" 'systemd-mode
+     '(3 nil error "Invalid URL, ignoring: foo://bar"
+         :checker systemd-analyze)
+     `(6 nil error ,key-unknown-message
+         :checker systemd-analyze)
+     '(8 nil error "Unknown section 'Dog'. Ignoring."
+         :checker systemd-analyze))))
 
 (flycheck-ert-def-checker-test tex-chktex (tex latex) nil
   (flycheck-ert-should-syntax-check

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4613,28 +4613,14 @@ The manifest path is relative to
        :checker sql-sqlint)))
 
 (flycheck-ert-def-checker-test systemd-analyze systemd nil
-  (let* ((systemd-version
-          (--> (shell-command-to-string
-                (format "%s --version"
-                        (flycheck-find-checker-executable 'systemd-analyze)))
-               split-string
-               cl-second))
-         (key-unknown-message
-          (cond
-           ((ignore-errors (version< systemd-version "241"))
-            "Unknown lvalue 'ExecSmart' in section 'Service'")
-           ((ignore-errors (version< systemd-version "243"))
-            "Unknown lvalue 'ExecSmart' in section 'Service', ignoring")
-           (t
-            "Unknown key name 'ExecSmart' in section 'Service', ignoring."))))
-    (flycheck-ert-should-syntax-check
-     "language/systemd-analyze-test.service" 'systemd-mode
-     '(3 nil error "Invalid URL, ignoring: foo://bar"
-         :checker systemd-analyze)
-     `(6 nil error ,key-unknown-message
-         :checker systemd-analyze)
-     '(8 nil error "Unknown section 'Dog'. Ignoring."
-         :checker systemd-analyze))))
+  (flycheck-ert-should-syntax-check
+   "language/systemd-analyze-test.service" 'systemd-mode
+   '(3 nil error "Invalid URL, ignoring: foo://bar"
+       :checker systemd-analyze)
+   '(6 nil error "Unknown key name 'ExecSmart' in section 'Service', ignoring."
+       :checker systemd-analyze)
+   '(8 nil error "Unknown section 'Dog'. Ignoring."
+       :checker systemd-analyze)))
 
 (flycheck-ert-def-checker-test tex-chktex (tex latex) nil
   (flycheck-ert-should-syntax-check


### PR DESCRIPTION
Fix several issues with the systemd-analyze checker:

- The unit test is broken. https://github.com/systemd/systemd/commit/71b21730d49ca53f0ccf1afc039c5962bbb85662 (released in systemd 241) and https://github.com/systemd/systemd/commit/28f30f4051c3424b5f0757c76856a1102763e04f (released in systemd 243) changed the error message for an unknown key name.

  This PR makes the unit test use the right message depending on which version is on the system.

- It cannot parse the error messages. This is because 1. `systemd-analyze verify` sometimes (at least on my machine) outputs colors, and 2. the message format has changed.

  This PR removes color from its output explicitly, like the `erlang-rebar3` checker (I've put it into a separate function, `flycheck-parse-out-color`.), and adds a new error pattern. This overlaps with #1275, but that PR has been blocked for over 2 years now, and didn't keep the old pattern (which, according to https://github.com/flycheck/flycheck/pull/1275#commitcomment-22970010, should be kept).