### PR TITLE
Don't use internal rx functions

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1400,16 +1400,16 @@ Safely delete all files and directories listed in
   "Translate the `(file-name)' FORM into a regular expression."
   (let ((body (or (cdr form) '((minimal-match
                                 (one-or-more not-newline))))))
-    (rx-submatch-n `(group-n 1 ,@body))))
+    (rx-to-string `(group-n 1 ,@body) t)))
 
 (defun flycheck-rx-message (form)
   "Translate the `(message)' FORM into a regular expression."
   (let ((body (or (cdr form) '((one-or-more not-newline)))))
-    (rx-submatch-n `(group-n 4 ,@body))))
+    (rx-to-string `(group-n 4 ,@body) t)))
 
 (defun flycheck-rx-id (form)
   "Translate the `(id)' FORM into a regular expression."
-  (rx-submatch-n `(group-n 5 ,@(cdr form))))
+  (rx-to-string `(group-n 5 ,@(cdr form)) t))
 
 (defun flycheck-rx-to-string (form &optional no-group)
   "Like `rx-to-string' for FORM, but with special keywords:


### PR DESCRIPTION
Use rx-to-string instead of the internal rx-submatch-n, which is gone
in Emacs 27 and never was intended for public use.  Fixes GH-1626.