### PR TITLE
Inhibit substitution of command keys and quotes in help-echo strings

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4137,7 +4137,7 @@ overlays."
     (with-current-buffer buf
       (-when-let* ((fn flycheck-help-echo-function)
                    (errs (flycheck-overlay-errors-at pos)))
-        (funcall fn errs)))))
+        (propertize (funcall fn errs) 'help-echo-inhibit-substitution t)))))
 
 (defun flycheck-help-echo-all-error-messages (errs)
   "Concatenate error messages and ids from ERRS."


### PR DESCRIPTION
This long-standing issue is described in https://lists.gnu.org/archive/html/emacs-devel/2019-10/msg00090.html ; the tl;dr is that Emacs changes `` ` `` and ``'`` into ``‘`` and ``’`` in error messages, which isn't quite right. 