### PR TITLE
Fix error-pattern for yaml-yamllint checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11262,9 +11262,9 @@ See URL `https://github.com/adrienverge/yamllint'."
             (config-file "-c" flycheck-yamllintrc))
   :error-patterns
   ((error line-start
-          (file-name) ":" line ":" column ": [error] " (message) line-end)
+          "stdin:" line ":" column ": [error] " (message) line-end)
    (warning line-start
-            (file-name) ":" line ":" column ": [warning] " (message) line-end))
+            "stdin:" line ":" column ": [warning] " (message) line-end))
   :modes yaml-mode)
 
 (provide 'flycheck)


### PR DESCRIPTION
Checker was configured to use stdin, but its error-pattern was configured to expected
file-name instead. Updated its error-pattern to expect `stdin:...`

Tested using emacs 26.3 on macos.