### PR TITLE
Update `markdownlint-cli` error syntax

### DIFF
--- a/Cask.24
+++ b/Cask.24
@@ -26,7 +26,7 @@
  (depends-on "groovy-mode")
  (depends-on "haml-mode")
  (depends-on "handlebars-mode")
- (depends-on "haskell-mode")
+ ;; (depends-on "haskell-mode")    ; requires Emacs 25.1+
  (depends-on "js2-mode")
  (depends-on "js3-mode")
  (depends-on "rjsx-mode")

--- a/flycheck.el
+++ b/flycheck.el
@@ -9794,7 +9794,7 @@ See URL `https://github.com/igorshubovych/markdownlint-cli'."
             source)
   :error-patterns
   ((error line-start
-          (file-name) ": " line ": " (id (one-or-more (not (any space))))
+          (file-name) ":" line " " (id (one-or-more (not (any space))))
           " " (message) line-end))
   :error-filter
   (lambda (errors)


### PR DESCRIPTION
This fixes issue reported here: https://github.com/flycheck/flycheck/issues/1647

The breaking change in the upstream checker is here: https://github.com/igorshubovych/markdownlint-cli/commit/17b717ad9db1e2213db51811652a63496f7c7880

