### PR TITLE
Fix displaying flycheck error in own buffer

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4874,10 +4874,13 @@ variable `flycheck-error-message-buffer'."
       (let ((result (display-message-or-buffer (string-join messages "\n\n")
                                                flycheck-error-message-buffer
                                                'not-this-window)))
+        ;; We cannot rely on `display-message-or-buffer' returning the right
+        ;; window. See URL `https://github.com/flycheck/flycheck/issues/1643'.
         (when (window-live-p result)
-          (with-current-buffer (window-buffer result)
-            (unless (derived-mode-p 'flycheck-error-message-mode)
-              (flycheck-error-message-mode))))))))
+          (-when-let ((buffer (get-buffer flycheck-error-message-buffer)))
+            (with-current-buffer buffer
+              (unless (derived-mode-p 'flycheck-error-message-mode)
+                (flycheck-error-message-mode)))))))))
 
 (defun flycheck-display-error-messages-unless-error-list (errors)
   "Show messages of ERRORS unless the error list is visible.


### PR DESCRIPTION
display-message-or-buffer does not always return the window with thep
popup. We need to handle this case.
