### PR TITLE
Change order of proto_path flags for protoc

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9235,11 +9235,13 @@ are relative to the file being checked."
 See URL `https://developers.google.com/protocol-buffers/'."
   :command ("protoc" "--error_format" "gcc"
             (eval (concat "--java_out=" (flycheck-temp-dir-system)))
-            (option-list "--proto_path=" flycheck-protoc-import-path concat)
-            ;; Add the file directory of protobuf path to resolve import
-            ;; directives
+            ;; Add the current directory to resolve imports
             (eval (concat "--proto_path="
                           (file-name-directory (buffer-file-name))))
+            ;; Add other import paths; this needs to be after the current
+            ;; directory to produce the right output.  See URL
+            ;; `https://github.com/flycheck/flycheck/pull/1655'
+            (option-list "--proto_path=" flycheck-protoc-import-path concat)
             source-inplace)
   :error-patterns
   ((info line-start (file-name) ":" line ":" column


### PR DESCRIPTION
The order of the `proto_path` flags for `protoc` impacts the format of the output, and confuses flycheck when it's parsing the output. 

Example:

```shell
protoc --error_format=gcc --java_out=/tmp/ --proto_path="/Users/samiur/Dev/canopy/packages/canopy-grpc/protos/" --proto_path="/Users/samiur/Dev/canopy/packages/canopy-grpc/protos/canopy/grpc/indexer" ~/Dev/canopy/packages/canopy-grpc/protos/canopy/grpc/indexer/flycheck_indexer.proto
```
outputs:
```shell
canopy/grpc/indexer/flycheck_indexer.proto:402:22: Field number 14 has already been used in "canopy.grpc.SearchFilter" by field "has_viewed"
```

Whereas
```
protoc --error_format=gcc --java_out=/tmp/ --proto_path="/Users/samiur/Dev/canopy/packages/canopy-grpc/protos/canopy/grpc/indexer" --proto_path="/Users/samiur/Dev/canopy/packages/canopy-grpc/protos/"  ~/Dev/canopy/packages/canopy-grpc/protos/canopy/grpc/indexer/flycheck_indexer.proto
```
outputs:
```
flycheck_indexer.proto:402:22: Field number 14 has already been used in "canopy.grpc.SearchFilter" by field "has_viewed".
```

When the folder is included in the path, flycheck is unable to trace the line to the right file. Putting the folder which contains the file to be checked before the expanded proto_paths fixes this.