### PR TITLE
Add ruby-standardrb checker

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -387,7 +387,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
    .. syntax-checker:: ember-template
 
       Check your Ember templates with
-      `ember-template-lint <https://github.com/ember-template-lint/ember-template-lint>`_ 
+      `ember-template-lint <https://github.com/ember-template-lint/ember-template-lint>`_
 
       .. syntax-checker-config-file:: flycheck-ember-template-lintrc
 
@@ -872,7 +872,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. defcustom:: flycheck-perlcritic-theme
 
-		 The theme expression, passed as the ``--theme`` to ``perlcritic``.
+         The theme expression, passed as the ``--theme`` to ``perlcritic``.
 
       .. syntax-checker-config-file:: flycheck-perlcriticrc
 
@@ -1115,6 +1115,21 @@ to view the docstring of the syntax checker.  Likewise, you may use
          option.
 
       .. syntax-checker-config-file:: flycheck-rubocoprc
+
+   .. syntax-checker:: ruby-standard
+
+      Check syntax and lint with `Standard <https://github.com/testdouble/standard/>`_.
+
+      .. note::
+
+         This syntax checker and ruby-rubocop are mutually exclusive, since Standard employs an opinionated rubocop config.
+
+      .. defcustom:: flycheck-rubocop-lint-only
+         :noindex:
+
+         See `flycheck-rubocop-lint-only`.
+
+      .. syntax-checker-config-file:: flycheck-ruby-standardrc
 
    .. syntax-checker:: ruby-reek
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -2057,11 +2057,12 @@ nil otherwise."
 
 (defconst flycheck-find-checker-regexp
   (rx line-start (zero-or-more (syntax whitespace))
-      "(" symbol-start "flycheck-define-checker" symbol-end
-      (eval (list 'regexp find-function-space-re))
-      symbol-start
-      "%s"
+      "(" symbol-start
+      (or "flycheck-define-checker" "flycheck-define-command-checker")
       symbol-end
+      (eval (list 'regexp find-function-space-re))
+      (? "'")
+      symbol-start "%s" symbol-end
       (or (syntax whitespace) line-end))
   "Regular expression to find a checker definition.")
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -241,6 +241,7 @@ attention to case differences."
     rst-sphinx
     rst
     ruby-rubocop
+    ruby-standard
     ruby-reek
     ruby-rubylint
     ruby
@@ -10070,50 +10071,80 @@ This is either a parent directory containing a Gemfile, or nil."
 (flycheck-def-config-file-var flycheck-rubocoprc ruby-rubocop ".rubocop.yml"
   :safe #'stringp)
 
-(flycheck-def-option-var flycheck-rubocop-lint-only nil ruby-rubocop
-  "Whether to only report code issues in Rubocop.
+(flycheck-def-option-var flycheck-rubocop-lint-only nil
+                         (ruby-rubocop ruby-standard)
+  "Whether to only report code issues in Rubocop and Standard.
 
-When non-nil, only report code issues in Rubocop, via `--lint'.
-Otherwise report style issues as well."
+When non-nil, only report code issues, via `--lint'.  Otherwise
+report style issues as well."
   :safe #'booleanp
   :type 'boolean
   :package-version '(flycheck . "0.16"))
 
-(flycheck-define-checker ruby-rubocop
+(defconst flycheck-ruby-rubocop-error-patterns
+  '((info line-start (file-name) ":" line ":" column ": C: "
+          (optional (id (one-or-more (not (any ":")))) ": ") (message) line-end)
+    (warning line-start (file-name) ":" line ":" column ": W: "
+             (optional (id (one-or-more (not (any ":")))) ": ") (message)
+             line-end)
+    (error line-start (file-name) ":" line ":" column ": " (or "E" "F") ": "
+           (optional (id (one-or-more (not (any ":")))) ": ") (message)
+           line-end)))
+
+(flycheck-def-executable-var ruby-rubocop "rubocop")
+(flycheck-define-command-checker 'ruby-rubocop
   "A Ruby syntax and style checker using the RuboCop tool.
 
 You need at least RuboCop 0.34 for this syntax checker.
 
 See URL `http://batsov.com/rubocop/'."
-  :command ("rubocop"
-            "--display-cop-names"
-            "--force-exclusion"
-            "--format" "emacs"
-            ;; Explicitly disable caching to prevent Rubocop 0.35.1 and earlier
-            ;; from caching standard input.  Later versions of Rubocop
-            ;; automatically disable caching with --stdin, see
-            ;; https://github.com/flycheck/flycheck/issues/844 and
-            ;; https://github.com/bbatsov/rubocop/issues/2576
-            "--cache" "false"
-            (config-file "--config" flycheck-rubocoprc)
-            (option-flag "--lint" flycheck-rubocop-lint-only)
-            ;; Rubocop takes the original file name as argument when reading
-            ;; from standard input
-            "--stdin" source-original)
+  ;; ruby-standard is defined based on this checker
+  :command '("rubocop"
+             "--display-cop-names"
+             "--force-exclusion"
+             "--format" "emacs"
+             ;; Explicitly disable caching to prevent Rubocop 0.35.1 and earlier
+             ;; from caching standard input.  Later versions of Rubocop
+             ;; automatically disable caching with --stdin, see
+             ;; https://github.com/flycheck/flycheck/issues/844 and
+             ;; https://github.com/bbatsov/rubocop/issues/2576
+             "--cache" "false"
+             (config-file "--config" flycheck-rubocoprc)
+             (option-flag "--lint" flycheck-rubocop-lint-only)
+             ;; Rubocop takes the original file name as argument when reading
+             ;; from standard input
+             "--stdin" source-original)
   :standard-input t
-  :working-directory flycheck-ruby--find-project-root
-  :error-patterns
-  ((info line-start (file-name) ":" line ":" column ": C: "
-         (optional (id (one-or-more (not (any ":")))) ": ") (message) line-end)
-   (warning line-start (file-name) ":" line ":" column ": W: "
-            (optional (id (one-or-more (not (any ":")))) ": ") (message)
-            line-end)
-   (error line-start (file-name) ":" line ":" column ": " (or "E" "F") ": "
-          (optional (id (one-or-more (not (any ":")))) ": ") (message)
-          line-end))
-  :modes (enh-ruby-mode ruby-mode)
-  :next-checkers ((warning . ruby-reek)
-                  (warning . ruby-rubylint)))
+  :working-directory #'flycheck-ruby--find-project-root
+  :error-patterns flycheck-ruby-rubocop-error-patterns
+  :modes '(enh-ruby-mode ruby-mode)
+  :next-checkers '((warning . ruby-reek)
+                   (warning . ruby-rubylint)))
+
+(flycheck-def-config-file-var flycheck-ruby-standardrc ruby-standard
+                              ".standard.yml"
+  :safe #'stringp)
+
+(flycheck-def-executable-var ruby-standard "standardrb")
+(flycheck-define-command-checker 'ruby-standard
+  "A Ruby syntax and style checker using the StandardRB gem.
+
+See URL `https://github.com/testdouble/standard' for more information."
+  ;; This checker is derived from ruby-rubocop; see above
+  :command '("standardrb"
+             "--display-cop-names"
+             "--force-exclusion"
+             "--format" "emacs"
+             "--cache" "false"
+             (config-file "--config" flycheck-ruby-standardrc)
+             (option-flag "--lint" flycheck-ruby-rubocop-lint-only)
+             "--stdin" source-original)
+  :standard-input t
+  :working-directory #'flycheck-ruby--find-project-root
+  :error-patterns flycheck-ruby-rubocop-error-patterns
+  :modes '(enh-ruby-mode ruby-mode)
+  :next-checkers '((warning . ruby-reek)
+                   (warning . ruby-rubylint)))
 
 ;; Default to `nil' to let Reek find its configuration file by itself
 (flycheck-def-config-file-var flycheck-reekrc ruby-reek nil

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4265,6 +4265,17 @@ Why not:
        :id "Lint/Syntax"
        :checker ruby-rubocop)))
 
+(flycheck-ert-def-checker-test ruby-standard ruby syntax-error
+  (let ((flycheck-disabled-checkers '(ruby-rubocop)))
+    (flycheck-ert-should-syntax-check
+     "language/ruby/syntax-error.rb" 'ruby-mode
+     '(5 7 error "unexpected token tCONSTANT (Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+         :id "Lint/Syntax"
+         :checker ruby-standard)
+     '(5 24 error "unterminated string meets end of file (Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)"
+         :id "Lint/Syntax"
+         :checker ruby-standard))))
+
 (flycheck-ert-def-checker-test ruby-rubylint ruby syntax-error
   (ert-skip "Pending: https://github.com/YorickPeterse/ruby-lint/issues/202")
   (let ((flycheck-disabled-checkers '(ruby-rubocop ruby-reek)))
@@ -4289,7 +4300,7 @@ Why not:
 (flycheck-ert-def-checker-test (ruby-rubocop ruby-reek ruby-rubylint) ruby with-rubylint
   (flycheck-ert-should-syntax-check
    "language/ruby/warnings.rb" 'ruby-mode
-   '(1 1 info "Missing magic comment `# frozen_string_literal: true`."
+   '(1 1 info "Missing frozen string literal comment."
        :id "Style/FrozenStringLiteralComment" :checker ruby-rubocop)
    '(3 nil warning "Person assumes too much for instance variable '@name'"
        :id "InstanceVariableAssumption" :checker ruby-reek)

--- a/test/specs/languages/test-help.el
+++ b/test/specs/languages/test-help.el
@@ -64,9 +64,10 @@
               (progn
                 (expect (buffer-name) :to-equal "flycheck.el")
                 (expect (looking-at (rx bol
-                                        "(flycheck-define-checker"
+                                        (or "(flycheck-define-checker"
+                                            "(flycheck-define-command-checker")
                                         symbol-end
-                                        " "
+                                        " " (? "'")
                                         symbol-start
                                         (group (1+ (or (syntax word)
                                                        (syntax symbol))))


### PR DESCRIPTION
---
name: Ruby Standardrb
about: Provide a new checker implementation
title: Add `ruby-standardrb` checker
labels: 'component: checkers'
assignees: ''

---

## Checklist
- [X] I have read the [Contributor's guide][].
- [ ] I have documented this checker in the [manual][].
- [X] I have added a test for this checker in [flycheck-test.el][].
- [ ] (*If you have written a test*) I have created a companion PR to add the
      checker tool in [flycheck/docker-tools][].
- [ ] I have mentioned the checker in the [Changelog][].

## Description
Describe the checker you added.

## Additional context
Additional relevant information about the checker and its integration into Flycheck.

[Changelog]: https://github.com/flycheck/flycheck/blob/master/CHANGES.rst
[manual]: https://www.flycheck.org/en/latest/languages.html
[flycheck-test.el]: https://github.com/flycheck/flycheck/blob/master/test/flycheck-test.el
[flycheck/docker-tools]: https://github.com/flycheck/docker-tools
[Contributor's guide]: https://www.flycheck.org/en/latest/contributor/contributing.html