### PR TITLE
[feat] Support auto-formatting/fixing eslint buffer code

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8730,6 +8730,14 @@ CHECKER and BUFFER denote the CHECKER that returned OUTPUT and
 the BUFFER that was checked respectively.
 
 See URL `https://eslint.org' for more information about ESLint."
+  (with-temp-buffer
+    (let ((output (let-alist (caar (flycheck-parse-json output)) .output)))
+      (if output
+          (progn
+            (insert output)
+            (let ((output-buffer (current-buffer)))
+              (with-current-buffer buffer
+                (replace-buffer-contents output-buffer)))))))
   (mapcar (lambda (err)
             (let-alist err
               (flycheck-error-new-at

--- a/flycheck.el
+++ b/flycheck.el
@@ -8730,9 +8730,9 @@ CHECKER and BUFFER denote the CHECKER that returned OUTPUT and
 the BUFFER that was checked respectively.
 
 See URL `https://eslint.org' for more information about ESLint."
-  (with-temp-buffer
-    (let ((output (let-alist (caar (flycheck-parse-json output)) .output)))
-      (if output
+  (let ((output (let-alist (caar (flycheck-parse-json output)) .output)))
+    (if output
+        (with-temp-buffer
           (progn
             (insert output)
             (let ((output-buffer (current-buffer)))


### PR DESCRIPTION
If a user adds `--fix-dry-run` to `flycheck-eslint-args` or otherwise gets `output` to
be returned in the eslint JSON output, then the buffer being checked will be updated
with the fixed output from the JSON.

The one remaining issue I'm aware of is that if there are fixes in the output then
updating the buffer triggers another run of the checker immediately after.  Is there a
way temporarily disable change tracking while calling `replace-buffer-contents`?

It may also be valuable to abstract this so it can be re-used with other
auto-formatters/fixers.

I couldn't run `$ make check specs unit` as it seems to be dependent on Mac OS X.  I did
as much testing as I could.