### PR TITLE
cuda-nvcc: add flag to support forcing CUDA file type as CUDA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@
   - protobuf-prototool with ``prototool`` [GH-1591]
   - Bazel with ``bazel-buildifier`` [GH-1613]
   - Ruumba with ``eruby-ruumba`` [GH-1616]
+  - Elixir with ``credo`` [GH-1062]
 
 - New features:
 
@@ -48,7 +49,7 @@
   - Add ``flycheck-perl-module-list`` to use specified modules when
     syntax checking code with the ``perl`` checker. [GH-1207]
   - Add ``flycheck-sh-bash-args`` to pass arguments to ``sh-bash`` [GH-1439].
-  - Add ``flychjeck-eslint-args`` to pass arguments to ``javascript-eslint``
+  - Add ``flychjeck-eslint-args`` to pass arguments to ``javascript-eslint``.
     [GH-1360]
   - Add ``flycheck-default-executable-find``, the new default value for
     ``flycheck-executable-find``, to allow using relative paths to checkers
@@ -66,6 +67,8 @@
   - Add ``flycheck-relevant-error-other-file-show`` to avoid showing errors
     from other files. [GH-1579]
   - Add an error explainer for the ``nix-linter`` checker. [GH-1586]
+  - Checkers can now specify the exact region covered by an error, using
+    the :end-line and :end-column properties. [GH-1400]
 
 - Improvements
 

--- a/Cask
+++ b/Cask
@@ -18,6 +18,7 @@
  (depends-on "cwl-mode")
  (depends-on "d-mode")
  (depends-on "dockerfile-mode")
+ (depends-on "elixir-mode")
  (depends-on "erlang")
  (depends-on "ess")
  (depends-on "geiser")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -253,7 +253,7 @@ class IssueReferences(Transform):
                 # Adjust the position of the last issue reference in the
                 # text
                 last_issue_ref_end = match.end()
-                # Extract the issue text and the issue numer
+                # Extract the issue text and the issue number
                 issuetext = match.group(0)
                 issue_id = match.group(1)
                 # Turn the issue into a proper reference

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -335,6 +335,16 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _hadolint: https://github.com/hadolint/hadolint
 
+.. supported-language:: Elixir
+
+   .. syntax-checker:: elixir-credo
+
+      Check code style with `credo <https://github.com/rrrene/credo>`_
+
+      .. defcustom:: flycheck-elixir-credo-strict
+
+         When non-nil, run credo in strict mode, via ``--strict``.
+
 .. supported-language:: Emacs Lisp
 
    Flycheck checks Emacs Lisp with `emacs-lisp` and then with
@@ -382,6 +392,15 @@ to view the docstring of the syntax checker.  Likewise, you may use
       :infonode:`(elisp)Library Headers`
          Information about library headers for Emacs Lisp files.
 
+.. supported-language:: Ember Templates
+
+   .. syntax-checker:: ember-template
+
+      Check your Ember templates with
+      `ember-template-lint <https://github.com/ember-template-lint/ember-template-lint>`_
+
+      .. syntax-checker-config-file:: flycheck-ember-template-lintrc
+
 .. supported-language:: Erlang
 
    Flycheck checks Erlang with `erlang-rebar3` in rebar projects and
@@ -407,8 +426,9 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. defcustom:: flycheck-erlang-rebar3-profile
 
          The profile to use when compiling, e.g. "default" or "test".
-         The default value is nil which will use test profile
-         in test directories and default profile otherwise.
+         The default value is nil which will use the test profile in test
+         directories, the eqc profile in eqc directories and the default profile
+         otherwise.
 
 .. supported-language:: ERuby
 
@@ -863,7 +883,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. defcustom:: flycheck-perlcritic-theme
 
-		 The theme expression, passed as the ``--theme`` to ``perlcritic``.
+         The theme expression, passed as the ``--theme`` to ``perlcritic``.
 
       .. syntax-checker-config-file:: flycheck-perlcriticrc
 
@@ -1106,6 +1126,21 @@ to view the docstring of the syntax checker.  Likewise, you may use
          option.
 
       .. syntax-checker-config-file:: flycheck-rubocoprc
+
+   .. syntax-checker:: ruby-standard
+
+      Check syntax and lint with `Standard <https://github.com/testdouble/standard/>`_.
+
+      .. note::
+
+         This syntax checker and ruby-rubocop are mutually exclusive, since Standard employs an opinionated rubocop config.
+
+      .. defcustom:: flycheck-rubocop-lint-only
+         :noindex:
+
+         See `flycheck-rubocop-lint-only`.
+
+      .. syntax-checker-config-file:: flycheck-ruby-standardrc
 
    .. syntax-checker:: ruby-reek
 
@@ -1444,7 +1479,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. note::
 
-         textlint plugins need to be installed seperately.
+         textlint plugins need to be installed separately.
 
 .. supported-language:: TeX/LaTeX
 

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -100,7 +100,7 @@ Defaults to `error'."
 Like `with-temp-buffer', but resets the modification state of the
 temporary buffer to make sure that it is properly killed even if
 it has a backing file and is modified."
-  (declare (indent 0))
+  (declare (indent 0) (debug t))
   `(with-temp-buffer
      (unwind-protect
          ,(macroexp-progn body)
@@ -115,7 +115,7 @@ it has a backing file and is modified."
 
 BODY is evaluated with `current-buffer' being a buffer with the
 contents FILE-NAME."
-  (declare (indent 1))
+  (declare (indent 1) (debug t))
   `(let ((file-name ,file-name))
      (unless (file-exists-p file-name)
        (error "%s does not exist" file-name))

--- a/test/resources/language/elixir/lib/infos.ex
+++ b/test/resources/language/elixir/lib/infos.ex
@@ -1,0 +1,5 @@
+defmodule Infos do
+  def give_infos() do
+    IO.puts "Hello World"
+  end
+end

--- a/test/resources/language/elixir/lib/warnings.ex
+++ b/test/resources/language/elixir/lib/warnings.ex
@@ -1,0 +1,11 @@
+defmodule Warnings do
+  @moduledoc "Removes info warning"
+
+  def give_warnings do
+    if true && true do
+    end
+
+    if length(list) == 0 do
+    end
+  end
+end

--- a/test/resources/language/elixir/mix.exs
+++ b/test/resources/language/elixir/mix.exs
@@ -1,0 +1,13 @@
+defmodule FlycheckTests.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :flycheck_tests,
+     version: "0.0.1",
+     deps: deps()]
+  end
+
+  def deps do
+    [{:credo, "~> 0.9.2"}]
+  end
+end

--- a/test/resources/language/ember-template-lint/ember-template-lint/.template-lintrc.js
+++ b/test/resources/language/ember-template-lint/ember-template-lint/.template-lintrc.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+'use strict'
+
+module.exports = {
+  extends: 'recommended',
+  rules: {
+    'no-bare-strings': true
+  },
+  pending: ['warning']
+}

--- a/test/resources/language/ember-template-lint/ember-template-lint/error.hbs
+++ b/test/resources/language/ember-template-lint/ember-template-lint/error.hbs
@@ -1,0 +1,3 @@
+<div>
+                <span></span>
+</div>

--- a/test/resources/language/ember-template-lint/ember-template-lint/warning.hbs
+++ b/test/resources/language/ember-template-lint/ember-template-lint/warning.hbs
@@ -1,0 +1,1 @@
+This file only emits a warning because it has been marked as "pending" in the configuration file.

--- a/test/resources/language/pug/foo-base.pug
+++ b/test/resources/language/pug/foo-base.pug
@@ -1,0 +1,4 @@
+html
+  head
+  body
+    block content

--- a/test/resources/language/pug/foo-unknown-filter.pug
+++ b/test/resources/language/pug/foo-unknown-filter.pug
@@ -1,0 +1,1 @@
+:myfilter

--- a/test/resources/language/pug/foo.pug
+++ b/test/resources/language/pug/foo.pug
@@ -1,0 +1,9 @@
+extends foo-base
+
+block content
+  h1 Hello World
+  h2 Some h2 content
+  h3 Some h3 content
+  h4 Some h4 content
+
+h5 This is going to cause an error

--- a/test/run.el
+++ b/test/run.el
@@ -107,7 +107,7 @@ Node `(ert)Test Selectors' for information about test selectors."
 ;; as it's easier to fix failures with the full output, since we cannot always
 ;; easily reproduce locally (for integration tests running on CI).
 (defun flycheck-run-unlimit-ert-pretty-printer ()
-  "Instal advice to unlimit the ERT output."
+  "Install advice to unlimit the ERT output."
   (advice-add 'ert--pp-with-indentation-and-newline :around
               (lambda (orig &rest args)
                 (let ((print-length nil)

--- a/test/specs/languages/test-help.el
+++ b/test/specs/languages/test-help.el
@@ -64,9 +64,10 @@
               (progn
                 (expect (buffer-name) :to-equal "flycheck.el")
                 (expect (looking-at (rx bol
-                                        "(flycheck-define-checker"
+                                        (or "(flycheck-define-checker"
+                                            "(flycheck-define-command-checker")
                                         symbol-end
-                                        " "
+                                        " " (? "'")
                                         symbol-start
                                         (group (1+ (or (syntax word)
                                                        (syntax symbol))))

--- a/test/specs/languages/test-typescript.el
+++ b/test/specs/languages/test-typescript.el
@@ -34,13 +34,15 @@
   \"failure\":\"unused variable: 'invalidAlignment'\",
   \"name\":\"sample.ts\",
   \"ruleName\":\"no-unused-variable\",
+  \"ruleSeverity\":\"ERROR\",
   \"startPosition\":{\"character\":9,\"line\":0,\"position\":9}},
  {\"endPosition\":{\"character\":14,\"line\":2,\"position\":76},
   \"failure\":\"missing semicolon\",
   \"name\":\"sample.ts\",
   \"ruleName\":\"semicolon\",
+  \"ruleSeverity\":\"WARNING\",
   \"startPosition\":{\"character\":14,\"line\":2,\"position\":76}}]")
-          (json-with-deprecations "no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
+          (json-with-unknown-severity "no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
 
   Could not find implementations for the following rules specified in the configuration:
       label-undefined
@@ -55,12 +57,13 @@
  \"failure\":\"unused variable: 'invalidAlignment'\",
  \"name\":\"sample.ts\",
  \"ruleName\":\"no-unused-variable\",
+ \"ruleSeverity\":\"XXX\",
  \"startPosition\":{\"character\":9,\"line\":0,\"position\":9}}]"))
       (it "parses TSLint JSON output"
         (expect (flycheck-parse-tslint json 'checker 'buffer)
                 :to-be-equal-flycheck-errors
                 (list
-                 (flycheck-error-new-at 1 10 'warning
+                 (flycheck-error-new-at 1 10 'error
                                         "unused variable: 'invalidAlignment'"
                                         :id "no-unused-variable"
                                         :checker 'checker
@@ -72,8 +75,8 @@
                                         :checker 'checker
                                         :buffer 'buffer
                                         :filename "sample.ts"))))
-      (it "parses TSLint JSON output with deprecation output"
-        (expect (flycheck-parse-tslint json-with-deprecations 'checker 'buffer)
+      (it "parses TSLint JSON output with unknown severity"
+        (expect (flycheck-parse-tslint json-with-unknown-severity 'checker 'buffer)
                 :to-be-equal-flycheck-errors
                 (list
                  (flycheck-error-new-at 1 10 'warning

--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -27,7 +27,7 @@
 
 (require 'flycheck-buttercup)
 
-(describe "Utilties"
+(describe "Utilities"
 
   (describe "flycheck-buffer-empty-p"
 


### PR DESCRIPTION
Add option for checker `cuda-nvcc`

- option `flycheck-cuda-explicitly-specify-cuda-language`

In cases where editing header files (file name extensions of `.h` or `.huc`), the `cuda-nvcc` checker would complain 

```
Suspicious state from syntax checker cuda-nvcc: Flycheck checker cuda-nvcc returned non-zero exit code 1, but its output contained no errors: nvcc fatal   : Don't know what to do with '/tmp/flycheckMzNdps/vec3.cuh'

Try installing a more recent version of cuda-nvcc, and please open a bug report if the issue persists in the latest release.  Thanks!
```

the error is 

    `nvcc` "fatal   : Don't know what to do with file.cuh"

This patch adds an optional flag to pass to `nvcc` to force it to assume the file type is CUDA and then the `nvcc` command performs as required.

