### PR TITLE
Allow specifying end column and end line for errors

### DIFF
--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1499,11 +1499,12 @@
     (insert "    (message) ;; Hello world\n    (message")
     (emacs-lisp-mode)
     ;; Test an expression at the error column for all modes
-    (let ((err (flycheck-error-new-at 1 7)))
+    (let ((err (flycheck-error-new-at 1 7 nil nil :end-column 8 :end-line 1)))
       (should (equal (flycheck-error-region-for-mode err 'lines) '(5 . 29)))
       (should (equal (flycheck-error-region-for-mode err 'columns) '(7 . 8)))
       (should (equal (flycheck-error-region-for-mode err 'symbols) '(6 . 13)))
-      (should (equal (flycheck-error-region-for-mode err 'sexps) '(6 . 13))))
+      (should (equal (flycheck-error-region-for-mode err 'sexps) '(6 . 13)))
+      (should (equal (flycheck-error-region err) '(8 . 9))))
     ;; Test an error column which does not point to an expression
     (let ((err (flycheck-error-new-at 2 5)))
       (should (equal (flycheck-error-region-for-mode err 'lines) '(34 . 42)))


### PR DESCRIPTION
- backends like lsp-ui could provide that data.

Before:
![before](https://user-images.githubusercontent.com/13259670/73605512-f2961b00-45a7-11ea-94e9-6bac83eb4e8e.png)

After:
![after](https://user-images.githubusercontent.com/13259670/73605513-f45fde80-45a7-11ea-86f7-30be9430f5cd.png)

