### PR TITLE
Fall back to columns highlighting when error begins on a non-symbol

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3450,8 +3450,14 @@ the THING at the column, and END the end of the THING."
             (eq mode 'lines))
         (flycheck--line-region beg)
       (or (pcase mode
-            (`symbols (flycheck-bounds-of-thing-at-point 'symbol beg))
-            (`sexps (flycheck-bounds-of-thing-at-point 'sexp beg)))
+            (`symbols
+             ;; Ensure that we're on a word or symbol.  See
+             ;; https://github.com/flycheck/flycheck/issues/1519
+             (and (< beg (point-max))
+                  (memq (char-syntax (char-after beg)) '(?w ?_))
+                  (flycheck-bounds-of-thing-at-point 'symbol beg)))
+            (`sexps
+             (flycheck-bounds-of-thing-at-point 'sexp beg)))
           (flycheck--column-region beg)))))
 
 (defun flycheck-error-region-for-mode (err mode)


### PR DESCRIPTION
Closes GH-1519.

Suggested-by: @CyberShadow