### PR TITLE
Use file-truename in check-same-files

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1214,7 +1214,7 @@ emulate inode (see fstat() in emacs/src/w32.c)."
         (and attrs-a attrs-b  ;; Make sure both file-a and file-b exist.
              (equal (nth 10 attrs-a) (nth 10 attrs-b))    ;; inode
              (equal (nth 11 attrs-a) (nth 11 attrs-b))))  ;; filesystem
-      (string= (file-chase-links file-a) (file-chase-links file-b))))
+      (string= (file-truename file-a) (file-truename file-b))))
 
 (defvar-local flycheck-temporaries nil
   "Temporary files and directories created by Flycheck.")


### PR DESCRIPTION
file-chase-links does not look at parent directory links.
file-truename does.

An example illustrated by #1634:

On MacOS, `/var` is a symbolic link to `/private/var`. Therefore,
`(file-chase-links "/var/file.txt") => "/var/file.txt")`, but
`(file-truename "/var/file.txt") => "/private/var/file.txt"`

As a result, `check-same-files` would incorrectly report these as
different files.

Fixes #1634.