### PR TITLE
Fix systemd-analyze checker not adding dummy line numbers

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11067,6 +11067,7 @@ See URL
   :error-patterns
   ((error line-start (file-name) ":" (optional line ":") (message) line-end)
    (error line-start "[" (file-name) ":" line "]" (message) line-end))
+  :error-filter flycheck-fill-empty-line-numbers
   :modes (systemd-mode))
 
 (flycheck-def-config-file-var flycheck-chktexrc tex-chktex ".chktexrc"


### PR DESCRIPTION
#1624 added a new pattern for `systemd-analyze` that allows for missing line numbers to match errors like `foobar.service: Command /home/foo/bar is not executable: No such file or directory` (from #1269). However, these errors would be discarded by `flycheck-relevant-errors-p`, as a dummy line number wasn't added back.

This PR adds them back with `flycheck-fill-empty-line-numbers` so that those errors can show up.