### PR TITLE
Add comment about how errors without line numbers are discarded to hopefully save confusion

### DIFF
--- a/doc/developer/developing.rst
+++ b/doc/developer/developing.rst
@@ -28,7 +28,8 @@ started (see :ref:`flycheck-syntax-checks`), the following happens:
    the error.
 3. Flycheck then filters the collected errors to keep only the relevant ones.
    For instance, errors directed at other files than the one you are editing are
-   discarded.
+   discarded.  The exact sementics of which errors are relevant is defined in
+   ``flycheck-relevant-error-p``.
 4. Relevant errors are highlighted by Flycheck in the buffer, according to user
    preference.  By default, each error adds a mark in the fringe at the line it
    occurs, and underlines the symbol at the position of the error using

--- a/flycheck.el
+++ b/flycheck.el
@@ -3628,6 +3628,10 @@ otherwise."
         (flycheck-relevant-error-other-file-p err))
        message
        (not (string-empty-p message))
+       ;; Errors without line numbers are discarded.  If a linter
+       ;; reports relevant errors without line numbers, use
+       ;; `flycheck-fill-empty-line-numbers' as the checker's
+       ;; `:error-filter' to set them to line 0.
        (flycheck-error-line err)))))
 
 (defun flycheck-relevant-errors (errors)


### PR DESCRIPTION
I spent an hour or so figuring out why the systemd-analyze checker isn't returning errors when the `systemd-analyze verify` command clearly does, and finally realized that it's because I didn't add dummy line numbers in the `:error-filter` when I added a new error pattern which has an optional line number in #1624.

(The pull for the issue above is in #1702.)

Add a comment to explain that `flycheck-fill-empty-line-numbers` should be used to add a line number to those errors, and a sentence in the developer documentation to point to where this is implemented, hopefully saving future confusions.
