### PR TITLE
Deprecate typescript-tslint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
   - The variable ``flycheck-current-errors`` now contains errors in the order in
     which they were returned by checkers.  In previous versions of Flycheck,
     this list was sorted by error position and severity. [GH-1749]
+  - The ``tslint`` checker is deprecated; it will go away in a future
+    release. [GH-1704]
 
 32-cvs (frozen on May 3rd, 2020)
 ================================

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1521,9 +1521,15 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: TypeScript
 
+   .. syntax-checker:: javascript-eslint
+      :noindex:
+
+      See `javascript-eslint`.
+
    .. syntax-checker:: typescript-tslint
 
       Check syntax and style with `TSLint <https://github.com/palantir/tslint>`_.
+      This checker is deprecated.
 
       .. syntax-checker-config-file:: flycheck-typescript-tslint-config
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -79,7 +79,7 @@
 (require 'rx)                    ; Regexp fanciness in `flycheck-define-checker'
 (require 'help-mode)             ; `define-button-type'
 (require 'find-func)             ; `find-function-regexp-alist'
-(require 'json)                  ; `flycheck-parse-tslint'
+(require 'json)                  ; `flycheck-parse-json'
 (require 'ansi-color)            ; `flycheck-parse-with-patterns-without-color'
 
 


### PR DESCRIPTION
Closes GH-1446 and closes GH-1472, as eslint supports --stdin, so there are no temp
file problems.  Also closes GH-1585: with tslint being deprecated, we do want to
override it with eslint.