### PR TITLE
Autoload flycheck-define-checker to prevent unwanted argument expansion

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -6589,6 +6589,10 @@ objects)."
 
 
 ;;; Convenience definition of command-syntax checkers
+
+;; This macro is autoloaded to prevent `with-eval-after-load' from expanding its
+;; arguments.  See https://github.com/flycheck/flycheck/issues/1398.
+;;;###autoload
 (defmacro flycheck-define-checker (symbol docstring &rest properties)
   "Define SYMBOL as command syntax checker with DOCSTRING and PROPERTIES.
 


### PR DESCRIPTION
The problem pops up when using this macro in a with-eval-after-load block.  In
that case, the arguments of the macro are expanded, and then the extra quoting
added by the macro itself on top of self-quoting forms breaks things.

As a concrete example, consider this definition:
```elisp
(with-eval-after-load 'flycheck
  (flycheck-define-checker test
    "Just a test"
    :command ("echo" "a" source)
    :predicate (lambda () t)
    :error-patterns ((error "Error"))
    :standard-input nil
    :modes (fundamental-mode))
  (push 'test flycheck-checkers))
```

Macro-expansion in the argument of with-eval-after-load will expand the (lambda)
form as well as any macro that might appear in :error-patterns, :modes, etc.
When the macro eventually runs, with its arguments expanded, its assumptions
about receiving its arguments unexpanded will be broken, and all sorts of this
will go wrong (starting with the lambda being quoted a second time).

Autoloading ensures that the macroexpander understands that
flycheck-define-checker is a macro, and doesn't expand its arguments first.

Closes GH-1398.