### PR TITLE
Move pylint to JSON and fix GH-1383

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9960,6 +9960,29 @@ which should be used and reported to the user."
   :safe #'booleanp
   :package-version '(flycheck . "0.25"))
 
+(defun flycheck-parse-pylint (output checker buffer)
+  "Parse JSON OUTPUT of CHECKER on BUFFER as Pylint errors."
+  (mapcar (lambda (err)
+            (let-alist err
+              ;; Pylint can return -1 as a line or a column, hence the call to
+              ;; `max'.  See `https://github.com/flycheck/flycheck/issues/1383'.
+              (flycheck-error-new-at
+               (and .line (max .line 1))
+               (and .column (max (1+ .column) 1))
+               (pcase .type
+                 ;; See "pylint/utils.py"
+                 ((or "fatal" "error") 'error)
+                 ((or "info" "convention") 'info)
+                 ((or "warning" "refactor" _) 'warning))
+               ;; Drop lines showing the error in context
+               (and (string-match (rx (*? nonl) eol) .message)
+                    (match-string 0 .message))
+               :id (if flycheck-pylint-use-symbolic-id .symbol .message-id)
+               :checker checker
+               :buffer buffer
+               :filename .path)))
+          (car (flycheck-parse-json output))))
+
 (flycheck-define-checker python-pylint
   "A Python syntax and style checker using Pylint.
 
@@ -9972,30 +9995,12 @@ See URL `https://www.pylint.org/'."
   :command ("python3"
             (eval (flycheck-python-module-args 'python-pylint "pylint"))
             "--reports=n"
-            "--output-format=text"
-            (eval (if flycheck-pylint-use-symbolic-id
-                      "--msg-template={path}:{line}:{column}:{C}:{symbol}:{msg}"
-                    "--msg-template={path}:{line}:{column}:{C}:{msg_id}:{msg}"))
+            "--output-format=json"
             (config-file "--rcfile=" flycheck-pylintrc concat)
             ;; Need `source-inplace' for relative imports (e.g. `from .foo
             ;; import bar'), see https://github.com/flycheck/flycheck/issues/280
             source-inplace)
-  :error-filter
-  (lambda (errors)
-    (flycheck-sanitize-errors (flycheck-increment-error-columns errors)))
-  :error-patterns
-  ((error line-start (file-name) ":" line ":" column ":"
-          (or "E" "F") ":"
-          (id (one-or-more (not (any ":")))) ":"
-          (message) line-end)
-   (warning line-start (file-name) ":" line ":" column ":"
-            (or "W" "R") ":"
-            (id (one-or-more (not (any ":")))) ":"
-            (message) line-end)
-   (info line-start (file-name) ":" line ":" column ":"
-         (or "C" "I") ":"
-         (id (one-or-more (not (any ":")))) ":"
-         (message) line-end))
+  :error-parser flycheck-parse-pylint
   :enabled (lambda ()
              (or (not (flycheck-python-needs-module-p 'python-pylint))
                  (flycheck-python-find-module 'python-pylint "pylint")))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4184,15 +4184,6 @@ Why not:
      '(2 12 error "Incompatible return value type (got \"str\", expected \"int\")"
          :checker python-mypy))))
 
-(flycheck-ert-def-checker-test python-pylint python syntax-error
-  (let ((flycheck-disabled-checkers '(python-flake8 python-mypy))
-        (python-indent-guess-indent-offset nil) ; Silence Python Mode
-        (flycheck-python-pylint-executable "python3"))
-    (flycheck-ert-should-syntax-check
-     "language/python/syntax-error.py" 'python-mode
-     '(3 13 error "invalid syntax (<unknown>, line 3)"
-         :id "syntax-error" :checker python-pylint))))
-
 (flycheck-ert-def-checker-test python-pylint python nil
   (let ((flycheck-disabled-checkers '(python-flake8 python-mypy))
         (flycheck-python-pylint-executable "python3"))
@@ -4255,6 +4246,17 @@ Why not:
           :checker python-pylint)
      '(22 1 error "Undefined variable 'antigravity'" :id "E0602"
           :checker python-pylint))))
+
+(flycheck-ert-def-checker-test python-pylint python negative-columns
+  (let ((flycheck-disabled-checkers '(python-flake8 python-mypy))
+        (python-indent-guess-indent-offset nil) ; Silence Python Mode
+        (flycheck-python-pylint-executable "python3"))
+    (flycheck-ert-should-syntax-check
+     "language/python/gh_1383.py" 'python-mode
+     '(2 1 warning "Unused import sys"
+         :id "unused-import" :checker python-pylint)
+     '(6 1 warning "String statement has no effect"
+         :id "pointless-string-statement" :checker python-pylint))))
 
 (flycheck-ert-def-checker-test python-pycompile python python27
   (skip-unless (executable-find "python2"))

--- a/test/resources/language/python/gh_1383.py
+++ b/test/resources/language/python/gh_1383.py
@@ -1,0 +1,6 @@
+# pylint: disable=missing-module-docstring
+import sys # This has column 0
+
+"""
+This error has column -1
+"""


### PR DESCRIPTION
Also remove the syntax error test, because Pylint's JSON output incorrectly
escapes angle brackets (see https://github.com/PyCQA/pylint/pull/3467).

Closes GH-1383.