### PR TITLE
Fix error list highlighting

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2725,7 +2725,7 @@ buffer manually.
    (flycheck-mode
     (flycheck-clear)
 
-    (pcase-dolist (`(,hook . ,fn) flycheck-hooks-alist)
+    (pcase-dolist (`(,hook . ,fn) (reverse flycheck-hooks-alist))
       (add-hook hook fn nil 'local))
 
     (setq flycheck-old-next-error-function
@@ -4930,7 +4930,6 @@ non-nil."
                (with-current-buffer flycheck-error-list-source-buffer
                  (flycheck-overlay-errors-in (line-beginning-position)
                                              (line-end-position))))))
-        (message "Got errors %S from buffer %S" current-errors flycheck-error-list-source-buffer)
         (let ((old-overlays flycheck-error-list-highlight-overlays)
               (min-point (point-max))
               (max-point (point-min)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -4924,9 +4924,13 @@ source buffer, and on the same line as point.  Then recenter the
 error list to the highlighted error, unless PRESERVE-POS is
 non-nil."
   (when (get-buffer flycheck-error-list-buffer)
-    (let ((current-errors (flycheck-overlay-errors-in (line-beginning-position)
-                                                      (line-end-position))))
-      (with-current-buffer flycheck-error-list-buffer
+    (with-current-buffer flycheck-error-list-buffer
+      (let ((current-errors
+             (when (buffer-live-p flycheck-error-list-source-buffer)
+               (with-current-buffer flycheck-error-list-source-buffer
+                 (flycheck-overlay-errors-in (line-beginning-position)
+                                             (line-end-position))))))
+        (message "Got errors %S from buffer %S" current-errors flycheck-error-list-source-buffer)
         (let ((old-overlays flycheck-error-list-highlight-overlays)
               (min-point (point-max))
               (max-point (point-min)))


### PR DESCRIPTION
`flycheck-error-list-highlight-errors` can be called from various contexts and buffers, and the previous implementation just assumed that the right source buffer was current.  This new implementation always respects the value of `flycheck-error-list-source-buffer`.

Closes GH-1726.