### PR TITLE
Add two new indication modes: left-margin and right-margin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,110 @@
 32-cvs (in development)
 =======================
 
+- Highlights
+
+  - Many checkers and compiler, such as ``ocaml``, ``rust``, ``eslint``, and
+    others, include end-line and end-column information.  Flycheck can now
+    highlight the exact region that they report.  Authors of checker definitions
+    can use the new ``:end-line`` and ``:end-column`` arguments in
+    ``flycheck-error-new``, or the new ``end-line`` and ``end-column`` fields in
+    error patterns. [GH-1400]
+
+  - Errors that checkers return for other files will now be displayed on the
+    first line of the current buffer instead of begin discarded.  The error list
+    indicates which file each error came from, and navigation moves
+    automatically moves between files.  This change helps with compiled
+    languages, where an error in another file may cause the current file to be
+    considered invalid.  Variables ``flycheck-relevant-error-other-file-show``
+    and ``flycheck-relevant-error-other-file-minimum-level`` control this
+    behavior. [GH-1427]
+
+  - Flycheck can now draw error indicators in margins in addition to fringes.
+    Margins can contain arbitrary characters and images, not just monochrome
+    bitmaps, allowing for a better experience on high-DPI screens.
+    ``flycheck-indication-mode`` controls this behavior, and
+    ``flycheck-set-indication-mode`` can be used to automatically adjust the
+    fringes and margins.  Additionally, Flycheck's will now use high-resolution
+    fringe bitmaps if the fringe is wide enough [GH-1742, GH-1744]
+
+- New features and improvements
+
+  - Flycheck can now trigger a syntax check automatically after switching
+    buffers, using the ``idle-buffer-switch`` option in
+    ``flycheck-check-syntax-automatically``.  This is useful when errors in a
+    file are due to problems in a separate file.  Variables
+    ``flycheck-idle-buffer-switch-delay`` and
+    ``flycheck-buffer-switch-check-intermediate-buffers`` control the
+    functionality. [GH-1297]
+  - Flycheck will now use Emacs' native XML parsing when libXML fails.  This
+    behavior can be changed by customizing ``flycheck-xml-parser``. [GH-1349]
+  - ``flycheck-verify-setup`` now shows more clearly which checkers
+    will run in the buffer, and which are misconfigured. [GH-1478]
+  - Flycheck now locates checker executables using a customizable function,
+    ``flycheck-executable-find``.  The default value of this function allows
+    relative paths (set e.g. in file or dir-local variables) in addition to
+    absolute paths and executable names. [GH-1485]
+  - Checkers that report error positions as a single offset from the start of
+    the file can use the new ``flycheck-error-new-at-pos`` constructor instead
+    of converting that position to a line and a column. [GH-1400]
+  - Config-file variables can now be set to a list of file names.  This is
+    useful for checkers like mypy which don't run correctly when called from a
+    subdirectory without passing an explicit config file. [GH-1711]
+
+- New syntax checkers:
+
+  - Awk with ``gawk`` [GH-1708]
+  - Bazel with ``bazel-buildifier`` [GH-1613]
+  - CUDA with ``cuda-nvcc`` [GH-1508]
+  - CWL with ``schema-salad-tool`` [GH-1361]
+  - Elixir with ``credo`` [GH-1062]
+  - JSON with ``json-jq`` [GH-1568]
+  - Jsonnet with ``jsonnet`` [GH-1345]
+  - MarkdownLint CLI with ``markdownlint`` [GH-1366]
+  - mypy with ``python-mypy`` [GH-1354]
+  - Nix with ``nix-linter`` [GH-1530]
+  - Opam with ``opam lint`` [GH-1532]
+  - protobuf-prototool with ``prototool`` [GH-1591]
+  - Rust with ``rust-clippy`` [GH-1385]
+  - Ruumba with ``eruby-ruumba`` [GH-1616]
+  - Staticcheck with ``go-staticheck`` [GH-1541]
+  - terraform with ``terraform fmt``, ``tflint`` [GH-1586]
+  - Tcl with ``nagelfar`` [GH-1365]
+  - Text prose with ``textlint`` [GH-1534]
+  - VHDL with ``ghdl`` [GH-1160]
+
+- Checker improvements:
+
+  - ``python-pylint`` and ``python-flake8`` are now invoked with ``python -c``,
+    to make it easier to change between Python 2 and Python 3. [GH-1113]
+  - Add ``flycheck-perl-module-list`` to use specified modules when
+    syntax checking code with the ``perl`` checker. [GH-1207]
+  - ``rust-cargo`` now uses ``cargo check`` and ``cargo test``. [GH-1289]
+  - Add ``flycheck-ghc-stack-project-file`` for the
+    ``haskell-stack-ghc`` checker. [GH-1316]
+  - Add ``flycheck-cppcheck-suppressions-file`` to pass a suppressions
+    file to cppcheck. [GH-1329]
+  - Add ``--force-exclusion`` flag to ``rubocop`` command. [GH-1348]
+  - Flycheck now uses ESLint's JSON output instead of checkstyle XML. [GH-1350]
+  - Add ``flychjeck-eslint-args`` to pass arguments to ``javascript-eslint``.
+    [GH-1360]
+  - Flycheck will now execute ``rubocop`` from the directory where a ``Gemfile``
+    is located. If a ``Gemfile`` does not exist, the old behaviour of running
+    the command from the directory where ``.rubocop.yml`` is found will be
+    used. [GH-1368]
+  - Add ``flycheck-sh-bash-args`` to pass arguments to ``sh-bash``. [GH-1439]
+  - ``haskell-stack-ghc`` will not try to install GHC anymore. [GH-1443]
+  - Add ``flycheck-ghdl-ieee-library`` to select which standard IEEE
+    library to use for ghdl. [GH-1547]
+  - The ``javascript-eslint`` checker now supports ``typescript-mode`` by
+    default.
+  - Add ``flycheck-erlang-rebar3-profile`` to select which profile to
+    use when compiling erlang with rebar3. [GH-1560]
+  - Add ``flycheck-relevant-error-other-file-show`` to avoid showing errors
+    from other files. [GH-1579]
+  - The ``nix-linter`` checker now has an error explainer. [GH-1586]
+  - The Emacs Lisp checker can now run in buffers not backed by files. [GH-1695]
+
 - **Breaking changes**
 
   - Remove the ``javascript-jscs`` checker. [GH-1024]
@@ -16,92 +120,6 @@
   - Replace ``go tool vet`` with ``go vet``. [GH-1548]
   - Remove the deprecated ``go-megacheck`` checker, which is replaced by
     ``go-staticcheck``. [GH-1583]
-
-- New syntax checkers:
-
-  - CUDA with ``cuda-nvcc`` [GH-1508]
-  - CWL with ``schema-salad-tool`` [GH-1361]
-  - JSON with ``json-jq`` [GH-1568]
-  - Jsonnet with ``jsonnet`` [GH-1345]
-  - MarkdownLint CLI with ``markdownlint`` [GH-1366]
-  - Nix with ``nix-linter`` [GH-1530]
-  - Opam with ``opam lint`` [GH-1532]
-  - Rust with ``rust-clippy`` [GH-1385]
-  - Staticcheck with ``go-staticheck`` [GH-1541]
-  - Tcl with ``nagelfar`` [GH-1365]
-  - Text prose with ``textlint`` [GH-1534]
-  - VHDL with ``ghdl`` [GH-1160]
-  - mypy with ``python-mypy`` [GH-1354]
-  - terraform with ``terraform fmt`` [GH-1586]
-  - terraform-tflint with ``tflint`` [GH-1586]
-  - protobuf-prototool with ``prototool`` [GH-1591]
-  - Bazel with ``bazel-buildifier`` [GH-1613]
-  - Ruumba with ``eruby-ruumba`` [GH-1616]
-  - Elixir with ``credo`` [GH-1062]
-  - Awk with ``gawk`` [GH-1708]
-
-- New features:
-
-  - Add ``flycheck-cppcheck-suppressions-file`` to pass a suppressions
-    file to cppcheck. [GH-1329]
-  - Add ``--force-exclusion`` flag to ``rubocop`` command. [GH-1348]
-  - Add ``flycheck-ghc-stack-project-file`` for the
-    ``haskell-stack-ghc`` checker. [GH-1316]
-  - Add ``flycheck-perl-module-list`` to use specified modules when
-    syntax checking code with the ``perl`` checker. [GH-1207]
-  - Add ``flycheck-sh-bash-args`` to pass arguments to ``sh-bash``. [GH-1439]
-  - Add ``flychjeck-eslint-args`` to pass arguments to ``javascript-eslint``.
-    [GH-1360]
-  - Add ``flycheck-default-executable-find``, the new default value for
-    ``flycheck-executable-find``, to allow using relative paths to checkers
-    (set e.g. in file or dir-local variables). [GH-1485]
-  - Add ``idle-buffer-switch`` option for use in
-    ``flycheck-check-syntax-automatically``.  Variables
-    ``flycheck-idle-buffer-switch-delay`` and
-    ``flycheck-buffer-switch-check-intermediate-buffers`` control the
-    functionality. [GH-1297]
-  - Add ``flycheck-ghdl-ieee-library`` to select which standard IEEE
-    library to use for ghdl. [GH-1547]
-  - The ``javascript-eslint`` checker now supports ``typescript-mode`` by
-    default.
-  - Add ``flycheck-erlang-rebar3-profile`` to select which profile to
-    use when compiling erlang with rebar3.
-  - Add ``flycheck-relevant-error-other-file-show`` to avoid showing errors
-    from other files. [GH-1579]
-  - Add an error explainer for the ``nix-linter`` checker. [GH-1586]
-  - Checkers can now specify the exact region covered by an error, using
-    the ``:end-line`` and ``:end-column`` properties. [GH-1400]
-  - Error patterns can now mention ``end-line`` and ``end-column`` in addition
-    to ``line`` and ``column``.
-
-- Improvements
-
-  - When a checker returns errors for another file, they will be displayed
-    instead of ignored.  They can be navigated to from the error list.
-    This change helps with compiled languages, where an error in another file
-    may cause the current file to be considered invalid. [GH-1427]
-  - ``flycheck-verify-setup`` now shows more clearly which checkers
-    will run in the buffer, and which are misconfigured. [GH-1478]
-  - Flycheck will now use Emacs' native XML parsing when libXML fails.  This
-    behavior can be changed by customizing ``flycheck-xml-parser``. [GH-1349]
-  - Flycheck now uses ESLint's JSON output instead of checkstyle XML. [GH-1350]
-  - Flycheck will execute ``rubocop`` from the directory where a ``Gemfile`` is
-    located. If a ``Gemfile`` does not exist, the old behaviour of running
-    the command from the directory where ``.rubocop.yml`` is found will be
-    used. [GH-1368]
-  - ``rust-cargo`` now uses ``cargo check`` and ``cargo test``. [GH-1289]
-  - ``python-pylint`` and ``python-flake8`` are now invoked with ``python -c``,
-    to make it easier to change between Python 2 and Python 3. [GH-1113]
-  - ``haskell-stack-ghc`` will not try to install GHC anymore. [GH-1443]
-  - Checkers that report error positions as a single offset from the start of
-    the file can use the new ``flycheck-error-new-at-pos`` constructor instead
-    of converting that position to a line and a column.
-  - ``flycheck-compile`` now locates the checker executable relative to
-    ``exec-path`` instead of the shell's ``PATH``.
-  - The Emacs Lisp checker can now run in buffers not backed by files. [GH-1695]
-  - Config-file variables can now be set to a list of file names.  This is
-    useful for checkers like mypy which don't run correctly when called from a
-    subdirectory without passing an explicit config file. [GH-1711]
 
 31 (Oct 07, 2017)
 =================

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -117,9 +117,6 @@ wide, but a 16 pixels version is used if the fringe is `wide enough
    distribution please take a look at its documentation if you're unsure about
    the appearance of Flycheck's indicators.
 
-   Note that we discourage you from changing the shape of Flycheck’s fringe
-   indicators.
-
 You can customise the location of these indicators (left or right fringe) with
 `flycheck-indication-mode`, which also lets you turn off these indicators
 completely; additionally, you can move these indicators into the margins instead
@@ -142,14 +139,15 @@ of the fringes:
       Do not indicate errors and warnings in the fringe or in the margin.
 
 The following faces control the colours of fringe and margin indicators.
-However they do not let you change the shape of the indicators—to achieve this
-you'd have to redefine the error levels with `flycheck-define-error-level`.
 
 .. defface:: flycheck-fringe-error
              flycheck-fringe-warning
              flycheck-fringe-info
 
    The icon faces for ``error``, ``warning`` and ``info`` levels respectively.
+
+To change the fringe bitmap or the symbol used in the margins, use the function
+``flycheck-redefine-standard-error-levels``.
 
 Mode line
 =========

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -138,6 +138,24 @@ of the fringes:
    ``nil``
       Do not indicate errors and warnings in the fringe or in the margin.
 
+By default, Emacs displays fringes, but not margins.  With ``left-margin`` and
+``right-margin`` indication modes, you will need to enable margins in your
+``.emacs``.  For example:
+
+.. code-block:: elisp
+
+   (setq-default left-fringe-width 1 right-fringe-width 8
+                 left-margin-width 1 right-margin-width 0)
+
+If you intend to use margins only with Flycheck, consider using
+``flycheck-set-indication-mode`` in a hook instead; this function adjusts
+margins and fringes for the current buffer.
+
+.. code-block:: elisp
+
+   (setq-default flycheck-indication-mode 'left-margin)
+   (add-hook 'flycheck-mode-hook #'flycheck-set-indication-mode)
+
 The following faces control the colours of fringe and margin indicators.
 
 .. defface:: flycheck-fringe-error

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -99,11 +99,11 @@ The highlights use the following faces depending on the error level:
    The highlighting face for ``error``, ``warning`` and ``info`` levels
    respectively.
 
-Fringe icons
-============
+Fringe and margin icons
+=======================
 
-In GUI frames Flycheck also adds indicators to the fringe—the left or right
-border of an Emacs window that is—to help you identify erroneous lines quickly.
+In GUI frames, Flycheck also adds indicators to the fringe—the left or right
+border of an Emacs window—to help you identify erroneous lines quickly.
 These indicators consist of a rightward-pointing double arrow shape coloured in
 the colour of the corresponding error level.  By default the arrow is 8 pixels
 wide, but a 16 pixels version is used if the fringe is `wide enough
@@ -121,22 +121,29 @@ wide, but a 16 pixels version is used if the fringe is `wide enough
    indicators.
 
 You can customise the location of these indicators (left or right fringe) with
-`flycheck-indication-mode` which also lets you turn off these indicators
-completely:
+`flycheck-indication-mode`, which also lets you turn off these indicators
+completely; additionally, you can move these indicators into the margins instead
+of the fringes:
 
 .. defcustom:: flycheck-indication-mode
 
    How Flycheck indicates errors and warnings in the buffer fringes:
 
    ``left-fringe`` or ``right-fringe``
-      Use the left or right fringe respectively.
+      Use the left or right fringe respectively.  Fringes can only contain
+      monochrome bitmaps, so Flycheck draws small pixel-art arrows.
+
+   ``left-margin`` or ``right-margin``
+      Use the left or right margin respectively.  Margins can support all of
+      Emacs' rendering facilities, so Flycheck uses the ``»`` character, which
+      scales with the font size.
 
    ``nil``
-      Do not indicate errors and warnings in the fringe.
+      Do not indicate errors and warnings in the fringe or in the margin.
 
-The following faces control the colours of the fringe indicators.  However they
-do not let you change the shape of the indicators—to achieve this you'd have to
-redefine the error levels with `flycheck-define-error-level`.
+The following faces control the colours of fringe and margin indicators.
+However they do not let you change the shape of the indicators—to achieve this
+you'd have to redefine the error levels with `flycheck-define-error-level`.
 
 .. defface:: flycheck-fringe-error
              flycheck-fringe-warning

--- a/flycheck.el
+++ b/flycheck.el
@@ -4029,45 +4029,59 @@ Returns MARGIN-STR with FACE applied."
     flycheck-fringe-bitmap-double-arrow-hi-res
     nil 16))
 
-(defconst flycheck-default-fringe-bitmaps
-  (cons 'flycheck-fringe-bitmap-double-arrow
-        'flycheck-fringe-bitmap-double-arrow-hi-res))
+(defun flycheck-redefine-standard-error-levels
+    (&optional margin-str fringe-bitmap)
+  "Redefine Flycheck's standard error levels.
 
-(setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
-(setf (get 'flycheck-error-overlay 'priority) 110)
+This is useful to change the character drawn in the
+margins (MARGIN-STR, a string) or the bitmap drawn in the
+fringes (FRINGE-BITMAP, a fringe bitmap symbol or a cons of such
+symbols, as in `flycheck-define-error-level')."
+  (unless margin-str
+    (setq margin-str "»"))
 
-(flycheck-define-error-level 'error
-  :severity 100
-  :compilation-level 2
-  :overlay-category 'flycheck-error-overlay
-  :margin-spec (flycheck-make-margin-spec "»" 'flycheck-fringe-error)
-  :fringe-bitmap flycheck-default-fringe-bitmaps
-  :fringe-face 'flycheck-fringe-error
-  :error-list-face 'flycheck-error-list-error)
+  (unless fringe-bitmap
+    (setq fringe-bitmap
+          (cons 'flycheck-fringe-bitmap-double-arrow
+                'flycheck-fringe-bitmap-double-arrow-hi-res)))
 
-(setf (get 'flycheck-warning-overlay 'face) 'flycheck-warning)
-(setf (get 'flycheck-warning-overlay 'priority) 100)
+  (setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
+  (setf (get 'flycheck-error-overlay 'priority) 110)
 
-(flycheck-define-error-level 'warning
-  :severity 10
-  :compilation-level 1
-  :overlay-category 'flycheck-warning-overlay
-  :margin-spec (flycheck-make-margin-spec "»" 'flycheck-fringe-warning)
-  :fringe-bitmap flycheck-default-fringe-bitmaps
-  :fringe-face 'flycheck-fringe-warning
-  :error-list-face 'flycheck-error-list-warning)
+  (flycheck-define-error-level 'error
+    :severity 100
+    :compilation-level 2
+    :overlay-category 'flycheck-error-overlay
+    :margin-spec (flycheck-make-margin-spec margin-str 'flycheck-fringe-error)
+    :fringe-bitmap fringe-bitmap
+    :fringe-face 'flycheck-fringe-error
+    :error-list-face 'flycheck-error-list-error)
 
-(setf (get 'flycheck-info-overlay 'face) 'flycheck-info)
-(setf (get 'flycheck-info-overlay 'priority) 90)
+  (setf (get 'flycheck-warning-overlay 'face) 'flycheck-warning)
+  (setf (get 'flycheck-warning-overlay 'priority) 100)
 
-(flycheck-define-error-level 'info
-  :severity -10
-  :compilation-level 0
-  :overlay-category 'flycheck-info-overlay
-  :margin-spec (flycheck-make-margin-spec "»" 'flycheck-fringe-info)
-  :fringe-bitmap flycheck-default-fringe-bitmaps
-  :fringe-face 'flycheck-fringe-info
-  :error-list-face 'flycheck-error-list-info)
+  (flycheck-define-error-level 'warning
+    :severity 10
+    :compilation-level 1
+    :overlay-category 'flycheck-warning-overlay
+    :margin-spec (flycheck-make-margin-spec margin-str 'flycheck-fringe-warning)
+    :fringe-bitmap fringe-bitmap
+    :fringe-face 'flycheck-fringe-warning
+    :error-list-face 'flycheck-error-list-warning)
+
+  (setf (get 'flycheck-info-overlay 'face) 'flycheck-info)
+  (setf (get 'flycheck-info-overlay 'priority) 90)
+
+  (flycheck-define-error-level 'info
+    :severity -10
+    :compilation-level 0
+    :overlay-category 'flycheck-info-overlay
+    :margin-spec (flycheck-make-margin-spec margin-str 'flycheck-fringe-info)
+    :fringe-bitmap fringe-bitmap
+    :fringe-face 'flycheck-fringe-info
+    :error-list-face 'flycheck-error-list-info))
+
+(flycheck-redefine-standard-error-levels)
 
 
 ;;; Error filtering

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1805,6 +1805,7 @@
 (flycheck-define-error-level 'test-level
   :severity 1337
   :overlay-category 'category
+  :margin-spec ">>"
   :fringe-bitmap 'left-triangle
   :fringe-face 'highlight
   :error-list-face 'font-lock-constant-face)
@@ -1834,35 +1835,54 @@
   (should (eq (flycheck-error-level-error-list-face 'test-level)
               'font-lock-constant-face)))
 
-(ert-deftest flycheck-error-level-make-fringe-icon/has-fringe-bitmap ()
+(ert-deftest flycheck-error-level-make-indicator/has-margin-spec ()
   :tags '(error-level)
-  (pcase-let* ((icon (flycheck-error-level-make-fringe-icon
+  (pcase-let* ((icon (flycheck-error-level-make-indicator
+                      'test-level 'left-margin))
+               (`(_ ,spec) (get-text-property 0 'display icon)))
+    (should (equal spec ">>"))))
+
+(ert-deftest flycheck-error-level-make-indicator/has-fringe-bitmap ()
+  :tags '(error-level)
+  (pcase-let* ((icon (flycheck-error-level-make-indicator
                       'test-level 'left-fringe))
                (`(_ ,bitmap _) (get-text-property 0 'display icon)))
     (should (eq bitmap 'left-triangle))))
 
-(ert-deftest flycheck-error-level-make-fringe-icon/has-fringe-face ()
+(ert-deftest flycheck-error-level-make-indicator/has-fringe-face ()
   :tags '(error-level)
-  (pcase-let* ((icon (flycheck-error-level-make-fringe-icon 'test-level 'left-fringe))
+  (pcase-let* ((icon (flycheck-error-level-make-indicator 'test-level 'left-fringe))
                (`(_ _ ,face) (get-text-property 0 'display icon)))
     (should (eq face 'highlight))))
 
-(ert-deftest flycheck-error-level-make-fringe-icon/left-fringe ()
+(ert-deftest flycheck-error-level-make-indicator/left-fringe ()
   :tags '(error-level)
-  (pcase-let* ((icon (flycheck-error-level-make-fringe-icon 'test-level 'left-fringe))
+  (pcase-let* ((icon (flycheck-error-level-make-indicator 'test-level 'left-fringe))
                (`(,side _ _) (get-text-property 0 'display icon)))
     (should (eq side 'left-fringe))))
 
-(ert-deftest flycheck-error-level-make-fringe-icon/right-fringe ()
+(ert-deftest flycheck-error-level-make-indicator/right-fringe ()
   :tags '(error-level)
-  (pcase-let* ((icon (flycheck-error-level-make-fringe-icon 'test-level 'right-fringe))
+  (pcase-let* ((icon (flycheck-error-level-make-indicator 'test-level 'right-fringe))
                (`(,side _ _) (get-text-property 0 'display icon)))
     (should (eq side 'right-fringe))))
 
-(ert-deftest flycheck-error-level-make-fringe-icon/invalid-side ()
+(ert-deftest flycheck-error-level-make-indicator/left-margin ()
   :tags '(error-level)
-  (let ((err (should-error (flycheck-error-level-make-fringe-icon 'test-level
-                                                                  'up-fringe))))
+  (pcase-let* ((icon (flycheck-error-level-make-indicator 'test-level 'left-margin))
+               (`(,side _ _) (get-text-property 0 'display icon)))
+    (should (equal side '(margin left-margin)))))
+
+(ert-deftest flycheck-error-level-make-indicator/right-margin ()
+  :tags '(error-level)
+  (pcase-let* ((icon (flycheck-error-level-make-indicator 'test-level 'right-margin))
+               (`(,side _ _) (get-text-property 0 'display icon)))
+    (should (equal side '(margin right-margin)))))
+
+(ert-deftest flycheck-error-level-make-indicator/invalid-side ()
+  :tags '(error-level)
+  (let ((err (should-error (flycheck-error-level-make-indicator 'test-level
+                                                                'up-fringe))))
     (should (string= (cadr err) "Invalid fringe side: up-fringe"))))
 
 


### PR DESCRIPTION
Unlike fringes, margin indicators are not limited to bitmaps, so we can display images or characters or anything else that Emacs can display.  The easiest way to try this out is `M-x flycheck-set-indication-mode` on this branch.

Here's how it looks:

- Fringes (latest Flycheck)

  ![fringe](https://user-images.githubusercontent.com/8181630/80232788-fb493b00-8644-11ea-8cbb-400196da5ae9.png)

- Margins (this branch, with `flycheck-indication-mode` set to `left-margin`)

  ![margin](https://user-images.githubusercontent.com/8181630/80232801-013f1c00-8645-11ea-8eff-8e918289b73f.png)
