### PR TITLE
 Add customizable highlighting styles 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,13 @@
     fringes and margins.  Additionally, Flycheck's will now use high-resolution
     fringe bitmaps if the fringe is wide enough [GH-1742, GH-1744]
 
+  - Error highlighting is now configurable, using the new
+    ``flycheck-highlighting-style`` variable: instead of applying
+    level-dependent faces (typically with wavy underlines), Flycheck can now
+    insert delimiters around errors, or mix styles depending on how many lines
+    an error covers.  Additionally, stipples are added in the fringes to
+    indicate errors that span multiple lines.
+
 - New features and improvements
 
   - Flycheck can now trigger a syntax check automatically after switching


### PR DESCRIPTION
This makes highlighting customizable: you can choose between applying a face and adding delimiters, conditionally on how many line the error covers.  It also adds a hatched pattern in the fringe to indicate continuation lines in errors.