### PR TITLE
Use hi-res fringe bitmap when window's left fringe is 16 pixels wide

### DIFF
--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -105,7 +105,9 @@ Fringe icons
 In GUI frames Flycheck also adds indicators to the fringe—the left or right
 border of an Emacs window that is—to help you identify erroneous lines quickly.
 These indicators consist of a rightward-pointing double arrow shape coloured in
-the colour of the corresponding error level.
+the colour of the corresponding error level.  By default the arrow is 8 pixels
+wide, but a 16 pixels version is used if the fringe is `wide enough
+<https://www.gnu.org/software/emacs/manual/html_node/emacs/Fringes.html>`_.
 
 .. note::
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -3952,23 +3952,32 @@ show the icon."
 ;;; Built-in error levels
 (when (fboundp 'define-fringe-bitmap)
   (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
-    (vector #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b10011000
-            #b01101100
-            #b00110110
-            #b00011011
-            #b00110110
-            #b01101100
-            #b10011000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000)))
+    [#b11011000
+     #b01101100
+     #b00110110
+     #b00011011
+     #b00110110
+     #b01101100
+     #b11011000
+     #b00000000])
+  (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow-hi-res
+    [#b0000000000000000
+     #b0000000000000000
+     #b1111001111000000
+     #b0111100111100000
+     #b0011110011110000
+     #b0001111001111000
+     #b0000111100111100
+     #b0000011110011110
+     #b0000011110011110
+     #b0000111100111100
+     #b0001111001111000
+     #b0011110011110000
+     #b0111100111100000
+     #b1111001111000000
+     #b0000000000000000
+     #b0000000000000000]
+    nil 16))
 
 (setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
 (setf (get 'flycheck-error-overlay 'priority) 110)

--- a/flycheck.el
+++ b/flycheck.el
@@ -3894,7 +3894,7 @@ The following PROPERTIES constitute an error level:
         (plist-get properties :compilation-level))
   (setf (get level 'flycheck-overlay-category)
         (plist-get properties :overlay-category))
-  (setf (get level 'flycheck-fringe-bitmaps-double-arrow)
+  (setf (get level 'flycheck-fringe-bitmaps)
         (let ((bitmap (plist-get properties :fringe-bitmap)))
           (if (consp bitmap) bitmap (cons bitmap bitmap))))
   (setf (get level 'flycheck-fringe-face)
@@ -3923,7 +3923,7 @@ The following PROPERTIES constitute an error level:
 
 Optional argument HI-RES non-nil means that the returned bitmap
 will be the high resolution version."
-  (let ((bitmaps (get level 'flycheck-fringe-bitmaps-double-arrow)))
+  (let ((bitmaps (get level 'flycheck-fringe-bitmaps)))
     (if hi-res (cdr bitmaps) (car bitmaps))))
 
 (defun flycheck-error-level-fringe-face (level)
@@ -3989,6 +3989,10 @@ show the icon."
      #b0000000000000000]
     nil 16))
 
+(defconst flycheck-default-fringe-bitmaps
+  (cons 'flycheck-fringe-bitmap-double-arrow
+        'flycheck-fringe-bitmap-double-arrow-hi-res))
+
 (setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
 (setf (get 'flycheck-error-overlay 'priority) 110)
 
@@ -3996,8 +4000,7 @@ show the icon."
   :severity 100
   :compilation-level 2
   :overlay-category 'flycheck-error-overlay
-  :fringe-bitmap (cons 'flycheck-fringe-bitmap-double-arrow
-                       'flycheck-fringe-bitmap-double-arrow-hi-res)
+  :fringe-bitmap flycheck-default-fringe-bitmaps
   :fringe-face 'flycheck-fringe-error
   :error-list-face 'flycheck-error-list-error)
 
@@ -4008,8 +4011,7 @@ show the icon."
   :severity 10
   :compilation-level 1
   :overlay-category 'flycheck-warning-overlay
-  :fringe-bitmap (cons 'flycheck-fringe-bitmap-double-arrow
-                       'flycheck-fringe-bitmap-double-arrow-hi-res)
+  :fringe-bitmap flycheck-default-fringe-bitmaps
   :fringe-face 'flycheck-fringe-warning
   :error-list-face 'flycheck-error-list-warning)
 
@@ -4020,8 +4022,7 @@ show the icon."
   :severity -10
   :compilation-level 0
   :overlay-category 'flycheck-info-overlay
-  :fringe-bitmap (cons 'flycheck-fringe-bitmap-double-arrow
-                       'flycheck-fringe-bitmap-double-arrow-hi-res)
+  :fringe-bitmap flycheck-default-fringe-bitmaps
   :fringe-face 'flycheck-fringe-info
   :error-list-face 'flycheck-error-list-info)
 


### PR DESCRIPTION
This PR implements [an idea mentioned in issue 1741](https://github.com/flycheck/flycheck/issues/1741#issuecomment-618966444) using [the implementation suggested in the same issue](https://github.com/flycheck/flycheck/issues/1741#issuecomment-619039532).