### PR TITLE
Don't sort errors after receiving them from checkers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
-32-cvs (in development)
+33-cvs (in development)
 =======================
+
+- **Breaking changes**
+
+  - The variable ``flycheck-current-errors`` now contains errors in the order in
+    which they were returned by checkers.  In previous versions of Flycheck,
+    this list was sorted by error position and severity. [GH-1749]
+
+32-cvs (frozen on May 3rd, 2020)
+================================
 
 - Highlights
 

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -373,6 +373,10 @@ ERROR is a Flycheck error object."
                                                               'flycheck-error))
                    (flycheck-error-without-group error)))))
 
+(defun flycheck-ert-sort-errors (errors)
+  "Sort ERRORS by `flycheck-error-<'."
+  (seq-sort #'flycheck-error-< errors))
+
 (defun flycheck-ert-should-errors (&rest errors)
   "Test that the current buffers has ERRORS.
 
@@ -387,18 +391,22 @@ With ERRORS, test that each error in ERRORS is present in the
 current buffer, and that the number of errors in the current
 buffer is equal to the number of given ERRORS.  In other words,
 check that the buffer has all ERRORS, and no other errors."
-  (let ((expected (mapcar (apply-partially #'apply #'flycheck-error-new-at)
-                          errors)))
+  (let ((expected (flycheck-ert-sort-errors
+                   (mapcar (apply-partially #'apply #'flycheck-error-new-at)
+                           errors)))
+        (current (flycheck-ert-sort-errors flycheck-current-errors)))
     (should (equal (mapcar #'flycheck-error-without-group expected)
-                   (mapcar #'flycheck-error-without-group
-                           flycheck-current-errors)))
+                   (mapcar #'flycheck-error-without-group current)))
     ;; Check that related errors are the same
-    (cl-mapcar (lambda (err1 err2)
-                 (should (equal (mapcar #'flycheck-error-without-group
-                                        (flycheck-related-errors err1 expected))
-                                (mapcar #'flycheck-error-without-group
-                                        (flycheck-related-errors err2)))))
-               expected flycheck-current-errors)
+    (cl-mapcar
+     (lambda (err1 err2)
+       (should (equal (flycheck-ert-sort-errors
+                       (mapcar #'flycheck-error-without-group
+                               (flycheck-related-errors err1 expected)))
+                      (flycheck-ert-sort-errors
+                       (mapcar #'flycheck-error-without-group
+                               (flycheck-related-errors err2))))))
+     expected current)
     (mapc #'flycheck-ert-should-overlay expected))
   (should (= (length errors)
              (length (flycheck-overlays-in (point-min) (point-max))))))

--- a/flycheck.el
+++ b/flycheck.el
@@ -3822,8 +3822,7 @@ again."
 
 Add ERRORS to `flycheck-current-errors' and process each error
 with `flycheck-process-error-functions'."
-  (setq flycheck-current-errors (sort (append errors flycheck-current-errors)
-                                      #'flycheck-error-<))
+  (setq flycheck-current-errors (append errors flycheck-current-errors))
   (overlay-recenter (point-max))
   (seq-do (lambda (err)
             (run-hook-with-args-until-success 'flycheck-process-error-functions


### PR DESCRIPTION
The error list already sorts errors: no need to redo the work in
flycheck-report-current-errors.  Additionally, the order returned by checkers is
significant in some cases, as when GCC puts notes next to the error they relate
to.