### PR TITLE
Cache results of flycheck-goto-line to speed up overlay creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,8 @@
   - Config-file variables can now be set to a list of file names.  This is
     useful for checkers like mypy which don't run correctly when called from a
     subdirectory without passing an explicit config file. [GH-1711]
+  - Thanks to algorithmic improvements in error reporting, Flycheck is now much
+    faster in large buffers. [GH-1750]
 
 - New syntax checkers:
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -1648,22 +1648,21 @@ FILE-NAME is nil, return `default-directory'."
 (cl-defstruct (flycheck-line-cache
                (:constructor flycheck-line-cache-new))
   "Cache structure used to speed up `flycheck-goto-line'."
-  buffer tick point line)
+  tick point line)
 
-(defvar flycheck--line-cache
-  (flycheck-line-cache-new
-   :buffer nil :tick 0 :point nil :line nil))
+(defvar-local flycheck--line-cache nil
+  "Cache used to speed ip `flycheck-goto-line'.")
 
 (defsubst flycheck--init-line-cache ()
   "Initialize or reinitialize `flycheck--line-cache'."
-  (let ((buf (current-buffer))
-        (tick (buffer-modified-tick)))
-    (unless (and (eq (flycheck-line-cache-buffer flycheck--line-cache) buf)
-                 (= (flycheck-line-cache-tick flycheck--line-cache) tick))
-      (setf (flycheck-line-cache-buffer flycheck--line-cache) buf
-            (flycheck-line-cache-tick flycheck--line-cache) tick
-            (flycheck-line-cache-point flycheck--line-cache) 1
-            (flycheck-line-cache-line flycheck--line-cache) 1))))
+  (let ((tick (buffer-modified-tick)))
+    (if flycheck--line-cache
+        (unless (= (flycheck-line-cache-tick flycheck--line-cache) tick)
+          (setf (flycheck-line-cache-tick flycheck--line-cache) tick
+                (flycheck-line-cache-point flycheck--line-cache) 1
+                (flycheck-line-cache-line flycheck--line-cache) 1))
+      (setq-local flycheck--line-cache
+                  (flycheck-line-cache-new :tick tick :point 1 :line 1)))))
 
 (defun flycheck-goto-line (line)
   "Move point to beginning of line number LINE.


### PR DESCRIPTION
Overlay creation can have significant costs in large buffers, even with a relatively small numbers of errors.  The previous implementation of `flycheck-goto-line` counted lines from `(point-min)` for each error, while this new implementation starts counting from the last position returned by `flycheck-goto-line`, when possible.  This is particularly valuable when errors are sorted by line, because we end up scanning the whole buffer at most once, instead of once per error.

I wrote the following benchmark to measure the impact of this:

```elisp
;; Save as `flycheck-benchmark.el'
;; Run as `cask exec emacs -Q --batch -l flycheck-benchmark.el'

(byte-compile-file "flycheck.el")
(require 'flycheck "flycheck.elc")

;; environment.py in Sphinx
(defconst flycheck-benchmark-nerrors 120)
(defconst flycheck-benchmark-file "flycheck.el")

(defconst flycheck-benchmark-buffer
  (with-current-buffer (get-buffer-create "*flycheck-benchmarks*")
    (insert-file-contents flycheck-benchmark-file)
    (current-buffer)))

(defconst flycheck-benchmark-nlines
  (with-current-buffer flycheck-benchmark-buffer
    (goto-char (point-max))
    (line-number-at-pos)))

(defconst flycheck-benchmark-lines
  (let ((lines nil)
        (rng (cl-make-random-state)))
    (dotimes (_ flycheck-benchmark-nerrors)
      (push (cl-random (1- flycheck-benchmark-nlines) rng) lines))
    lines))

(defconst flycheck-benchmark-errors
  (mapcar
   (lambda (line)
     (flycheck-error-new
      :line line :column 1
      :end-line (1+ line) :end-column 1
      :buffer flycheck-benchmark-buffer
      :checker 'emacs-lisp
      :message "dummy error"
      :filename flycheck-benchmark-file
      :level 'warning))
   flycheck-benchmark-lines))

(progn
  (with-current-buffer flycheck-benchmark-buffer
    (delete-all-overlays)
    (goto-char (point-min))
    (setq flycheck-current-errors nil)
    (print
     (benchmark-run-compiled 1
       (flycheck-report-current-errors flycheck-benchmark-errors)))))
```

It reports a configurable number of overlays (default: 120) in a buffer containing the contents of `flycheck.el` (which we can hopefully agree is "reasonably" large, at ~12k lines ^^).

Running the benchmark I get a fairly consistent 290ms with one GC (15ms) for the old version, and a fairly consistent 27-28ms with one GC (15ms) for the old version, so this patch provides a roughly 10x speedup on this example.

With a smaller number of errors (57, the number of errors currently in subr.el in the Emacs distribution) I get 160ms vs 27ms, and even with 15 errors I get 58ms vs 27ms.  With a larger number of errors (400, the current threshold), I get 850ms vs 16ms (50x).

I'm not sure the fluctuations in the faster code (16 vs 27ms) are significant, but the speedup definitely is :)

I'm not a fan of the added complexity, but since this is a case where we're causing measurable Emacs pauses on even moderately-sized files I think it's worth considering.
