### PR TITLE
Plenty of small error list cleanups

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8522,7 +8522,7 @@ The checker runs `checkdoc-current-buffer'."
             "--eval" (eval flycheck-emacs-lisp-checkdoc-form)
             "--" source)
   :error-patterns
-  ((warning line-start (file-name) ":" line ": " (message) line-end))
+  ((info line-start (file-name) ":" line ": " (message) line-end))
   :modes (emacs-lisp-mode)
   :enabled flycheck--emacs-lisp-enabled-p)
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -1057,6 +1057,12 @@ is used."
   :group 'flycheck-faces
   :package-version '(flycheck . "0.21"))
 
+(defface flycheck-error-list-error-message
+  '((t))
+  "Face for the error message in the error list."
+  :group 'flycheck-faces
+  :package-version '(flycheck . "33"))
+
 (defface flycheck-error-list-highlight
   '((t :bold t))
   "Flycheck face to highlight errors in the error list."
@@ -4812,7 +4818,9 @@ the beginning of the buffer."
 MESSAGE and CHECKER are displayed in a single column to allow the
 message to stretch arbitrarily far."
   (let ((checker-name (propertize (symbol-name checker)
-                                  'face 'flycheck-error-list-checker-name)))
+                                  'face 'flycheck-error-list-checker-name))
+        (message (propertize message
+                             'face 'flycheck-error-list-error-message)))
     (format "%s (%s)" message checker-name)))
 
 (defconst flycheck-error-list-format

--- a/flycheck.el
+++ b/flycheck.el
@@ -2561,7 +2561,7 @@ is applicable from Emacs Lisp code.  Use
     (save-buffer))
 
   (let ((buffer (current-buffer)))
-    (with-help-window (get-buffer-create " *Flycheck checker*")
+    (with-help-window "*Flycheck checker*"
       (with-current-buffer standard-output
         (flycheck--verify-print-header "Syntax checker in buffer " buffer)
         (flycheck--verify-princ-checker checker buffer 'with-mm)
@@ -2600,11 +2600,10 @@ possible problems are shown."
          (other-checkers
           (seq-difference (seq-filter #'flycheck-checker-supports-major-mode-p
                                       flycheck-checkers)
-                          (cons first-checker valid-checkers)))
-         (help-buffer (get-buffer-create " *Flycheck checkers*")))
+                          (cons first-checker valid-checkers))))
 
     ;; Print all applicable checkers for this buffer
-    (with-help-window help-buffer
+    (with-help-window "*Flycheck checkers*"
       (with-current-buffer standard-output
         (flycheck--verify-print-header "Syntax checkers for buffer " buffer)
 
@@ -2653,12 +2652,11 @@ but will not run until properly configured:\n\n")
             (princ
              "\nTry adding these syntax checkers to `flycheck-checkers'.\n")))
 
-        (flycheck--verify-print-footer buffer)))
+        (flycheck--verify-print-footer buffer)
 
-    (with-current-buffer help-buffer
-      (setq-local revert-buffer-function
-                  (lambda (_ignore-auto _noconfirm)
-                    (with-current-buffer buffer (flycheck-verify-setup)))))))
+        (setq-local revert-buffer-function
+                    (lambda (_ignore-auto _noconfirm)
+                      (with-current-buffer buffer (flycheck-verify-setup))))))))
 
 
 ;;; Predicates for generic syntax checkers
@@ -5469,7 +5467,7 @@ this error to produce the explanation to display."
 
 (defun flycheck-display-error-explanation (explanation)
   "Display the EXPLANATION string in a help buffer."
-  (with-help-window (get-buffer-create flycheck-explain-error-buffer)
+  (with-help-window flycheck-explain-error-buffer
     (princ explanation)))
 
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -1033,7 +1033,7 @@ is used."
   :package-version '(flycheck . "0.16"))
 
 (defface flycheck-error-list-filename
-  '((t :inherit font-lock-variable-name-face))
+  '((t :inherit mode-line-buffer-id :bold nil))
   "Face for filenames in the error list."
   :group 'flycheck-faces
   :package-version '(flycheck . "32"))

--- a/flycheck.el
+++ b/flycheck.el
@@ -5116,23 +5116,23 @@ LEVEL is either an error level symbol, or nil, to remove the filter."
           "Minimum error level (errors at lower levels will be hidden): ")))
   (when (and level (not (flycheck-error-level-p level)))
     (user-error "Invalid level: %s" level))
-  (-when-let (buf (get-buffer flycheck-error-list-buffer))
-    (with-current-buffer buf
-      (setq-local flycheck-error-list-minimum-level level)
-      (flycheck-error-list-refresh)
-      (flycheck-error-list-recenter-at (point-min)))))
+  (flycheck-error-list-with-buffer
+    (setq-local flycheck-error-list-minimum-level level)
+    (force-mode-line-update)
+    (flycheck-error-list-refresh)
+    (flycheck-error-list-recenter-at (point-min))))
 
 (defun flycheck-error-list-reset-filter (&optional refresh)
   "Remove local error filters and reset to the default filter.
 
 Interactively, or with non-nil REFRESH, refresh the error list."
   (interactive '(t))
-  (-when-let (buf (get-buffer flycheck-error-list-buffer))
-    (with-current-buffer buf
-      (kill-local-variable 'flycheck-error-list-minimum-level)
-      (when refresh
-        (flycheck-error-list-refresh)
-        (flycheck-error-list-recenter-at (point-min))))))
+  (flycheck-error-list-with-buffer
+    (kill-local-variable 'flycheck-error-list-minimum-level)
+    (when refresh
+      (flycheck-error-list-refresh)
+      (flycheck-error-list-recenter-at (point-min))
+      (force-mode-line-update))))
 
 (defun flycheck-error-list-apply-filter (errors)
   "Filter ERRORS according to `flycheck-error-list-minimum-level'."

--- a/flycheck.el
+++ b/flycheck.el
@@ -5239,7 +5239,7 @@ nil, if there is no next error."
 (defun flycheck-error-list-highlight-errors (&optional preserve-pos)
   "Highlight errors in the error list.
 
-Highlight all errors in the error lists that are at point in the
+Highlight all errors in the error list that are at point in the
 source buffer, and on the same line as point.  Then recenter the
 error list to the highlighted error, unless PRESERVE-POS is
 non-nil."

--- a/flycheck.el
+++ b/flycheck.el
@@ -2542,6 +2542,12 @@ to enable disabled checkers.")))
   (princ (format "System:           %s\n" system-configuration))
   (princ (format "Window system:    %S\n" window-system)))
 
+(define-derived-mode flycheck-verify-mode help-mode
+  "Flycheck verification"
+  "Major mode to display Flycheck verification results."
+  ;; `help-mode-finish' will restore `buffer-read-only'
+  (setq buffer-read-only nil))
+
 (defun flycheck-verify-checker (checker)
   "Check whether a CHECKER can be used in this buffer.
 
@@ -2563,6 +2569,7 @@ is applicable from Emacs Lisp code.  Use
   (let ((buffer (current-buffer)))
     (with-help-window "*Flycheck checker*"
       (with-current-buffer standard-output
+        (flycheck-verify-mode)
         (flycheck--verify-print-header "Syntax checker in buffer " buffer)
         (flycheck--verify-princ-checker checker buffer 'with-mm)
         (if (with-current-buffer buffer (flycheck-may-use-checker checker))
@@ -2605,6 +2612,8 @@ possible problems are shown."
     ;; Print all applicable checkers for this buffer
     (with-help-window "*Flycheck checkers*"
       (with-current-buffer standard-output
+        (flycheck-verify-mode)
+
         (flycheck--verify-print-header "Syntax checkers for buffer " buffer)
 
         (if first-checker

--- a/flycheck.el
+++ b/flycheck.el
@@ -1020,15 +1020,14 @@ is used."
   :package-version '(flycheck . "0.16")
   :group 'flycheck-faces)
 
-;; The base faces for the following two faces are inspired by Compilation Mode
 (defface flycheck-error-list-line-number
-  '((t :inherit font-lock-constant-face))
+  '((t))
   "Face for line numbers in the error list."
   :group 'flycheck-faces
   :package-version '(flycheck . "0.16"))
 
 (defface flycheck-error-list-column-number
-  '((t :inherit font-lock-constant-face))
+  '((t))
   "Face for line numbers in the error list."
   :group 'flycheck-faces
   :package-version '(flycheck . "0.16"))

--- a/flycheck.el
+++ b/flycheck.el
@@ -4895,21 +4895,13 @@ message to stretch arbitrarily far."
         (flycheck-buffer)))))
 
 (define-button-type 'flycheck-error-list
-  'action #'flycheck-error-list-button-goto-error
+  'action #'flycheck-error-list-goto-error
   'help-echo "mouse-1, RET: goto error"
   'face nil)
 
-(defun flycheck-error-list-button-goto-error (button)
-  "Go to the error at BUTTON."
-  (flycheck-error-list-goto-error (button-start button)))
-
 (define-button-type 'flycheck-error-list-explain-error
-  'action #'flycheck-error-list-button-explain-error
+  'action #'flycheck-error-list-explain-error
   'help-echo "mouse-1, RET: explain error")
-
-(defun flycheck-error-list-button-explain-error (button)
-  "Explain the error at BUTTON."
-  (flycheck-error-list-explain-error (button-start button)))
 
 (defsubst flycheck-error-list-make-cell (text &optional face help-echo type)
   "Make an error list cell with TEXT and FACE.

--- a/flycheck.el
+++ b/flycheck.el
@@ -4009,7 +4009,8 @@ The following PROPERTIES constitute an error level:
 `:severity SEVERITY'
      A number denoting the severity of this level.  The higher
      the number, the more severe is this level compared to other
-     levels.  Defaults to 0.
+     levels.  Defaults to 0; info is -10, warning is 10, and
+     error is 100.
 
      The severity is used by `flycheck-error-level-<' to
      determine the ordering of errors according to their levels.

--- a/flycheck.el
+++ b/flycheck.el
@@ -1059,7 +1059,7 @@ is used."
   :package-version '(flycheck . "0.21"))
 
 (defface flycheck-error-list-highlight
-  '((t :inherit highlight))
+  '((t :bold t))
   "Flycheck face to highlight errors in the error list."
   :package-version '(flycheck . "0.15")
   :group 'flycheck-faces)

--- a/flycheck.el
+++ b/flycheck.el
@@ -2273,15 +2273,20 @@ Pop up a help buffer with the documentation of CHECKER."
      (list (flycheck-read-checker prompt default))))
   (unless (flycheck-valid-checker-p checker)
     (user-error "You didn't specify a Flycheck syntax checker"))
-  (help-setup-xref (list #'flycheck-describe-checker checker)
-                   (called-interactively-p 'interactive))
-  (save-excursion
-    (with-help-window (help-buffer)
-      (let ((filename (flycheck-checker-get checker 'file))
-            (modes (flycheck-checker-get checker 'modes))
-            (predicate (flycheck-checker-get checker 'predicate))
-            (print-doc (flycheck-checker-get checker 'print-doc))
-            (next-checkers (flycheck-checker-get checker 'next-checkers)))
+  (let ((filename (flycheck-checker-get checker 'file))
+        (modes (flycheck-checker-get checker 'modes))
+        (predicate (flycheck-checker-get checker 'predicate))
+        (print-doc (flycheck-checker-get checker 'print-doc))
+        (next-checkers (flycheck-checker-get checker 'next-checkers))
+        (help-xref-following
+         ;; Ensure that we don't reuse buffers like `flycheck-verify-checker',
+         ;; and that we don't error out if a `help-flycheck-checker-doc' button
+         ;; is added outside of a documentation window.
+         (and help-xref-following (eq major-mode 'help-mode))))
+    (help-setup-xref (list #'flycheck-describe-checker checker)
+                     (called-interactively-p 'interactive))
+    (save-excursion
+      (with-help-window (help-buffer)
         (princ (format "%s is a Flycheck syntax checker" checker))
         (when filename
           (princ (format " in `%s'" (file-name-nondirectory filename)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -1290,7 +1290,7 @@ just return nil."
   (browse-url "http://www.flycheck.org"))
 
 (define-obsolete-function-alias 'flycheck-info
-  'flycheck-manual "26" "Open the Flycheck manual.")
+  'flycheck-manual "Flycheck 26" "Open the Flycheck manual.")
 
 
 ;;; Utility functions
@@ -5110,19 +5110,21 @@ LEVEL is either an error level symbol, or nil, to remove the filter."
     (user-error "Invalid level: %s" level))
   (-when-let (buf (get-buffer flycheck-error-list-buffer))
     (with-current-buffer buf
-      (setq-local flycheck-error-list-minimum-level level))
-    (flycheck-error-list-refresh)
-    (flycheck-error-list-recenter-at (point-min))))
+      (setq-local flycheck-error-list-minimum-level level)
+      (flycheck-error-list-refresh)
+      (flycheck-error-list-recenter-at (point-min)))))
 
 (defun flycheck-error-list-reset-filter (&optional refresh)
   "Remove local error filters and reset to the default filter.
 
 Interactively, or with non-nil REFRESH, refresh the error list."
   (interactive '(t))
-  (kill-local-variable 'flycheck-error-list-minimum-level)
-  (when refresh
-    (flycheck-error-list-refresh)
-    (flycheck-error-list-recenter-at (point-min))))
+  (-when-let (buf (get-buffer flycheck-error-list-buffer))
+    (with-current-buffer buf
+      (kill-local-variable 'flycheck-error-list-minimum-level)
+      (when refresh
+        (flycheck-error-list-refresh)
+        (flycheck-error-list-recenter-at (point-min))))))
 
 (defun flycheck-error-list-apply-filter (errors)
   "Filter ERRORS according to `flycheck-error-list-minimum-level'."

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1024,7 +1024,7 @@
       (should (eq (flycheck-get-checker-for-buffer) 'emacs-lisp-checkdoc))
       (flycheck-ert-buffer-sync)
       (flycheck-ert-should-errors
-       '(12 nil warning "First sentence should end with punctuation"
+       '(12 nil info "First sentence should end with punctuation"
             :checker emacs-lisp-checkdoc)))))
 
 (ert-deftest flycheck-checker/disabled-checker-is-not-used ()
@@ -1051,7 +1051,7 @@
         (should (eq (flycheck-get-checker-for-buffer) 'emacs-lisp-checkdoc))
         (flycheck-ert-buffer-sync)
         (flycheck-ert-should-errors
-         '(12 nil warning "First sentence should end with punctuation"
+         '(12 nil info "First sentence should end with punctuation"
               :checker emacs-lisp-checkdoc))))))
 
 (ert-deftest flycheck-select-checker/selecting-sets-the-syntax-checker ()
@@ -1111,7 +1111,7 @@
       (flycheck-ert-buffer-sync)
       (should-not flycheck-checker)
       (flycheck-ert-should-errors
-       '(12 nil warning "First sentence should end with punctuation"
+       '(12 nil info "First sentence should end with punctuation"
             :checker emacs-lisp-checkdoc)))))
 
 (ert-deftest flycheck-disable-checker/disables-checker ()
@@ -2104,7 +2104,7 @@
          :checker emacs-lisp)
      '(11 8 warning "`message' called with 0 args to fill 1 format field(s)"
           :checker emacs-lisp)
-     '(12 nil warning "First sentence should end with punctuation"
+     '(12 nil info "First sentence should end with punctuation"
           :checker emacs-lisp-checkdoc)
      '(15 1 warning "`message' called with 0 args to fill 1 format field(s)"
           :checker emacs-lisp))))
@@ -2861,7 +2861,7 @@ evaluating BODY."
                                          "bin/dummy-emacs")))
     (flycheck-ert-should-syntax-check
      "language/emacs-lisp/warnings.el" 'emacs-lisp-mode
-     '(12 nil warning "First sentence should end with punctuation"
+     '(12 nil info "First sentence should end with punctuation"
           :checker emacs-lisp-checkdoc)
      '(17 4 error "t is not true!" :checker emacs-lisp)
      '(19 11 warning "This is a stupid message" :checker emacs-lisp))))
@@ -3443,7 +3443,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
 (flycheck-ert-def-checker-test (emacs-lisp emacs-lisp-checkdoc) emacs-lisp nil
   (flycheck-ert-should-syntax-check
    "language/emacs-lisp/warnings.el" 'emacs-lisp-mode
-   '(12 nil warning "First sentence should end with punctuation"
+   '(12 nil info "First sentence should end with punctuation"
         :checker emacs-lisp-checkdoc)
    '(16 6 warning "foobar called with 1 argument, but accepts only 0"
         :checker emacs-lisp)
@@ -3454,7 +3454,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
                                uses-right-major-mode
   (flycheck-ert-should-syntax-check
    "language/emacs-lisp/checkdoc-elisp-mode-regression.el" 'emacs-lisp-mode
-   '(11 nil warning "All variables and subroutines might as well have a documentation string"
+   '(11 nil info "All variables and subroutines might as well have a documentation string"
         :checker emacs-lisp-checkdoc)))
 
 (flycheck-ert-def-checker-test (emacs-lisp-checkdoc) emacs-lisp
@@ -3470,7 +3470,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
   (let ((inhibit-message t))
     (flycheck-ert-should-syntax-check
      "language/emacs-lisp/warnings.el.gz" 'emacs-lisp-mode
-     '(12 nil warning "First sentence should end with punctuation"
+     '(12 nil info "First sentence should end with punctuation"
           :checker emacs-lisp-checkdoc)
      '(16 6 warning "foobar called with 1 argument, but accepts only 0"
           :checker emacs-lisp)
@@ -3523,7 +3523,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
     (unwind-protect
         (flycheck-ert-should-syntax-check
          "language/emacs-lisp/warnings.el" 'emacs-lisp-mode
-         '(12 nil warning "First sentence should end with punctuation"
+         '(12 nil info "First sentence should end with punctuation"
               :checker emacs-lisp-checkdoc))
       (remove-hook 'emacs-lisp-mode-hook disable-byte-comp))))
 

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -30,10 +30,11 @@
 (defmacro flycheck/with-error-list-buffer (&rest body)
   "Run BODY in a temporary error list buffer."
   (declare (indent 0))
-  `(with-temp-buffer
+  `(with-current-buffer (get-buffer-create flycheck-error-list-buffer)
      (delay-mode-hooks (flycheck-error-list-mode))
      (setq delayed-mode-hooks nil)
-     ,@body))
+     (prog1 (progn ,@body)
+       (kill-buffer flycheck-error-list-buffer))))
 
 (describe "Error List"
   (it "has the correct buffer name"


### PR DESCRIPTION
- *Force mode line updates after changing the error list filter* right now pressing `F` in the error list doesn't always update the modeline, leaving the incorrect filter visible.
 
- *Always refresh in flycheck-error-list-set-source* This makes for a slightly cleaner implementation of `list-errors`

- *Fix two incorrect uses of point-min* These were running in the wrong buffer

- *Ensure that flycheck-describe-checker doesn't reuse verification buffers* Clicking a link in the verification buffer would reuse it to display the help buffer, which was confusing

- *Add a separate major mode for verification buffers* A drive-by cleanup, but also needed by the above 

- *Remove two unnecessary wrapper functions* Clicking anywhere on a button already works, so no need to lookup the beginning of the button.

- *Simplify calls to with-help-buffer (no need to call get-buffer first)* Another drive-by cleanup

- *Document default error levels* (and their priorities)

- *Report CheckDoc messages as info, not warning* This makes it nicer to look at a list of elisp warnings, since the actual warnings stand out.
