### PR TITLE
Unify and improve help-echo text and error buffer messages

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3579,6 +3579,24 @@ The error position is the error column, or the first
 non-whitespace character of the error line, if ERR has no error column."
   (car (flycheck-error-region-for-mode err 'columns)))
 
+(defun flycheck-error-format-snippet (err &optional max-length)
+  "Extract the text that ERR refers to from the buffer.
+
+Newlines and blanks are replaced by single spaces.  If ERR
+doesn't include an end-position, return nil.
+
+MAX-LENGTH is how many characters to read from the buffer, at
+most.  It defaults to 20."
+  (flycheck-error-with-buffer err
+    (save-restriction
+      (widen)
+      (pcase (flycheck--exact-region err)
+        (`(,beg . ,end)
+         (truncate-string-to-width
+          (replace-regexp-in-string
+           "\\s-+" " " (buffer-substring beg (min end (point-max))))
+          (or max-length 20) nil nil t))))))
+
 (defun flycheck-error-format-message-and-id (err)
   "Format the message and id of ERR as human-readable string."
   (let ((id (flycheck-error-id err))

--- a/flycheck.el
+++ b/flycheck.el
@@ -5123,19 +5123,19 @@ and if the echo area is not occupied by minibuffer input."
 (defun flycheck-display-error-messages (errors)
   "Display the messages of ERRORS.
 
-Concatenate all non-nil messages of ERRORS separated by empty
-lines, and display them with `display-message-or-buffer', which
-shows the messages either in the echo area or in a separate
-buffer, depending on the number of lines.  See Info
-node `(elisp)Displaying Messages' for more information.
+Concatenate all non-nil messages of ERRORS as with
+`flycheck-help-echo-all-error-messages', and display them with
+`display-message-or-buffer', which shows the messages either in
+the echo area or in a separate buffer, depending on the number of
+lines.  See Info node `(elisp)Displaying Messages' for more
+information.
 
 In the latter case, show messages in the buffer denoted by
 variable `flycheck-error-message-buffer'."
   (when (and errors (flycheck-may-use-echo-area-p))
-    (let ((messages (seq-map #'flycheck-error-format-message-and-id errors)))
-      (display-message-or-buffer (string-join messages "\n\n")
-                                 flycheck-error-message-buffer
-                                 'not-this-window)
+    (let ((message (flycheck-help-echo-all-error-messages errors)))
+      (display-message-or-buffer
+       message flycheck-error-message-buffer 'not-this-window)
       ;; We cannot rely on `display-message-or-buffer' returning the right
       ;; window. See URL `https://github.com/flycheck/flycheck/issues/1643'.
       (-when-let ((buf (get-buffer flycheck-error-message-buffer)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -4370,13 +4370,14 @@ overlays."
 
 (defun flycheck-help-echo-all-error-messages (errs)
   "Concatenate error messages and ids from ERRS."
-  (mapconcat
-   (lambda (err)
-     (when err
-       (if (flycheck-error-message err)
-           (flycheck-error-format-message-and-id err)
-         (format "Unknown %s" (flycheck-error-level err)))))
-   errs "\n\n"))
+  (pcase (delq nil errs) ;; FIXME why would errors be nil here?
+    (`(,err) ;; A single error
+     (flycheck-error-format-message-and-id err))
+    (_ ;; Zero or multiple errors
+     (mapconcat
+      (lambda (err)
+        (flycheck-error-format-message-and-id err 'include-snippet))
+      errs "\n"))))
 
 (defun flycheck-filter-overlays (overlays)
   "Get all Flycheck overlays from OVERLAYS, in original order."

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -2126,7 +2126,24 @@
     (flycheck-add-overlay (flycheck-error-new-at 1 1 'info "info"))
     (flycheck-add-overlay (flycheck-error-new-at 1 1 'warning "warning"))
     (flycheck-add-overlay (flycheck-error-new-at 1 1 'error "error"))
-    (should (string= (help-at-pt-string) "info\n\nwarning\n\nerror"))))
+    (should (string= (help-at-pt-string) "info\nwarning\nerror"))))
+
+(ert-deftest flycheck-add-overlay/help-echo-stacks-errors-region ()
+  :tags '(overlay)
+  "Check that help-echo messages include snippets when available."
+  (flycheck-ert-with-temp-buffer
+    (insert "int main() {}")
+    (goto-char 5)
+    (flycheck-add-overlay
+     (flycheck-error-new-at 1 1 'info "info" :end-column 14))
+    (flycheck-add-overlay
+     (flycheck-error-new-at 1 5 'warning "warning" :end-column 9))
+    (flycheck-add-overlay
+     (flycheck-error-new-at 1 5 'error "error" :end-column 11))
+    (let ((text-quoting-style 'grave))
+      (should (string=
+               (help-at-pt-string)
+               "`int main() {}': info\n`main': warning\n`main()': error")))))
 
 
 ;;; Error navigation in the current buffer


### PR DESCRIPTION
This PR solves two issues:

1. The text we display in help-echo isn't consistent with the text we display in the minibuffer (or is pos-tip, etc).

2. That text is ambiguous when there's more than one error at point.

The fix for 1 is easy: use the same code (it's almost the same already, modulo the error ordering).  The fix for 2 is to display a small snippet of code along with the error message (but we can only do that when we have a precise region).

And a concrete example of 2: Consider the following OCaml snippet:

```
  let _ = (1 ^ "A") +. 4.0
           ^ int, not string
          ^^^^^^^^^ string, not float
```

With point on 1, we used to just show this:

```
  string, not float

  int, not string
```

Now we show this:

```
  ‘(1 ^ "A")’: string, not float
  ‘1’: int, not string
```