### PR TITLE
Parse optional end column in haskell-hlint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9502,17 +9502,17 @@ See URL `https://github.com/ndmitchell/hlint'."
             source-inplace)
   :error-patterns
   ((info line-start
-         (file-name) ":" line ":" column
+         (file-name) ":" line ":" column (optional "-" end-column)
          ": Suggestion: "
          (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
          line-end)
    (warning line-start
-            (file-name) ":" line ":" column
+            (file-name) ":" line ":" column (optional "-" end-column)
             ": Warning: "
             (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
             line-end)
    (error line-start
-          (file-name) ":" line ":" column
+          (file-name) ":" line ":" column (optional "-" end-column)
           ": Error: "
           (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
           line-end))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3816,8 +3816,8 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
      '(4 1 warning "Eta reduce
 Found:
   spam eggs = map lines eggs
-Why not:
-  spam = map lines" :checker haskell-hlint)
+Perhaps:
+  spam = map lines" :checker haskell-hlint :end-line 4 :end-column 26)
      '(4 1 warning "Top-level binding with no type signature:
   spam :: [String] -> [[String]]"
          :id "-Wmissing-signatures"
@@ -3825,8 +3825,8 @@ Why not:
      '(7 8 info "Redundant bracket
 Found:
   (putStrLn \"hello world\")
-Why not:
-  putStrLn \"hello world\"" :checker haskell-hlint))))
+Perhaps:
+  putStrLn \"hello world\"" :checker haskell-hlint :end-line 7 :end-column 31))))
 
 (flycheck-ert-def-checker-test
     haskell-stack-ghc haskell nonstandard-stack-yaml-file
@@ -3875,8 +3875,8 @@ Why not:
      '(4 1 warning "Eta reduce
 Found:
   spam eggs = map lines eggs
-Why not:
-  spam = map lines" :checker haskell-hlint)
+Perhaps:
+  spam = map lines" :checker haskell-hlint :end-line 4 :end-column 26)
      '(4 1 warning "Top-level binding with no type signature:
   spam :: [String] -> [[String]]"
          :id "-Wmissing-signatures"
@@ -3884,8 +3884,8 @@ Why not:
      '(7 8 info "Redundant bracket
 Found:
   (putStrLn \"hello world\")
-Why not:
-  putStrLn \"hello world\"" :checker haskell-hlint))))
+Perhaps:
+  putStrLn \"hello world\"" :checker haskell-hlint :end-line 7 :end-column 31))))
 
 (flycheck-ert-def-checker-test html-tidy html nil
   (flycheck-ert-should-syntax-check


### PR DESCRIPTION
Sometimes hlint prints the end column of a hint:

  Main.hs:37:12: Suggestion: Redundant $
  Found:
    $
  Perhaps you should remove it.

  Main.hs:37:14-31: Warning: Redundant bracket
  Found:
    ("Running server")
  Perhaps:
    "Running server"