### PR TITLE
Update "known Windows issues" link

### DIFF
--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -66,7 +66,7 @@ requests for improved Windows compatibility. If you know Windows and Emacs,
 please take a look at the list of open Windows issues and try to fix any of
 these.
 
-.. _list of open Windows issues: https://github.com/flycheck/flycheck/labels/windows%20only
+.. _list of open Windows issues: https://github.com/flycheck/flycheck/labels/arch%3A%20windows%20only
 
 Feature requests
 ================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,7 +65,7 @@ features go through :ref:`Quickstart <flycheck-quickstart>` guide.
    covers some common setup issues and helps you debug and fix problems with
    Flycheck.
 
-.. _`known windows issues`: https://github.com/flycheck/flycheck/labels/B-Windows%20only
+.. _`known windows issues`: https://github.com/flycheck/flycheck/labels/arch%3A%20windows%20only
 
 .. _flycheck-user-guide:
 


### PR DESCRIPTION
It looks like the label has changed from "B-Windows only" to "arch:
windows only".