### PR TITLE
Add a :working-directory property to python-pylint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10528,6 +10528,18 @@ which should be used and reported to the user."
                :filename .path)))
           (car (flycheck-parse-json output))))
 
+(defun flycheck-pylint-find-project-root (_checker)
+  "Find the directory to invoke pylint from.
+
+The algorithm is the same as used by epylint: find the first
+directory that doesn't have a __init__.py file."
+  (locate-dominating-file
+   (if buffer-file-name
+       (file-name-directory buffer-file-name)
+     default-directory)
+   (lambda (dir)
+     (not (file-exists-p (expand-file-name "__init__.py" dir))))))
+
 (flycheck-define-checker python-pylint
   "A Python syntax and style checker using Pylint.
 
@@ -10546,6 +10558,7 @@ See URL `https://www.pylint.org/'."
             ;; import bar'), see https://github.com/flycheck/flycheck/issues/280
             source-inplace)
   :error-parser flycheck-parse-pylint
+  :working-directory flycheck-pylint-find-project-root
   :enabled (lambda ()
              (or (not (flycheck-python-needs-module-p 'python-pylint))
                  (flycheck-python-find-module 'python-pylint "pylint")))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4281,7 +4281,7 @@ Why not:
   (let ((flycheck-python-flake8-executable "python3"))
     (flycheck-ert-should-syntax-check
      "language/python/test.py" 'python-mode
-     '(5 1 warning "'sys.antigravit' imported but unused" :id "F401"
+     '(5 1 warning "'.antigravit' imported but unused" :id "F401"
          :checker python-flake8)
      '(7 1 warning "expected 2 blank lines, found 1" :id "E302"
          :checker python-flake8)
@@ -4307,9 +4307,9 @@ Why not:
     (flycheck-ert-should-syntax-check
      "language/python/test.py" 'python-mode
      '(1 1 info "Missing module docstring" :id "missing-module-docstring" :checker python-pylint)
-     '(5 1 error "No name 'antigravit' in module 'sys'" :id "no-name-in-module"
+     '(5 1 error "No name 'antigravit' in module 'python'" :id "no-name-in-module"
          :checker python-pylint)
-     '(5 1 warning "Unused antigravit imported from sys" :id "unused-import"
+     '(5 1 warning "Unused import antigravit" :id "unused-import"
          :checker python-pylint)
      '(7 1 info "Missing class docstring" :id "missing-class-docstring" :checker python-pylint)
      '(7 1 warning "Class 'Spam' inherits from object, can be safely removed from bases in python3"
@@ -4338,9 +4338,9 @@ Why not:
     (flycheck-ert-should-syntax-check
      "language/python/test.py" 'python-mode
      '(1 1 info "Missing module docstring" :id "C0114" :checker python-pylint)
-     '(5 1 error "No name 'antigravit' in module 'sys'" :id "E0611"
+     '(5 1 error "No name 'antigravit' in module 'python'" :id "E0611"
          :checker python-pylint)
-     '(5 1 warning "Unused antigravit imported from sys" :id "W0611"
+     '(5 1 warning "Unused import antigravit" :id "W0611"
          :checker python-pylint)
      '(7 1 info "Missing class docstring" :id "C0115" :checker python-pylint)
      '(7 1 warning "Class 'Spam' inherits from object, can be safely removed from bases in python3"

--- a/test/resources/language/python/test.py
+++ b/test/resources/language/python/test.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from sys import antigravit  # Typo intended!
+from . import antigravit  # Typo intended!
 
 class Spam(object):
 


### PR DESCRIPTION
Closes GH-1758.  The algorithm is the same as used by epylint: find the first directory that doesn't have a ``__init__.py`` file.

CC @thisch
