### PR TITLE
Respect flycheck-highlighting-mode in flycheck-error-pos

### DIFF
--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -492,7 +492,11 @@ current buffer.  Otherwise return nil."
         (format "Expected to be at error %s, but no error at point %s"
                 n (point))
       (let ((pos (cl-position (car errors) flycheck-current-errors)))
-        (format "Expected to be at error %s, but point %s is at error %s"
+        (format "Expected to be at point %s and error %s, \
+but point %s is at error %s"
+                (car (flycheck-error-region-for-mode
+                      (nth (1- n) flycheck-current-errors)
+                      flycheck-highlighting-mode))
                 n (point) (1+ pos))))))
 
 (put 'flycheck-ert-at-nth-error 'ert-explainer

--- a/flycheck.el
+++ b/flycheck.el
@@ -3818,7 +3818,8 @@ ERR is a Flycheck error whose position to get.
 
 The error position is the error column, or the first
 non-whitespace character of the error line, if ERR has no error column."
-  (car (flycheck-error-region-for-mode err 'columns)))
+  (car (flycheck-error-region-for-mode
+        err flycheck-highlighting-mode)))
 
 (defun flycheck-error-format-snippet (err &optional max-length)
   "Extract the text that ERR refers to from the buffer.


### PR DESCRIPTION
With the previous implementation, if the beginning of an overlay didn't match the beginning of the error, then next-error would behave surprisingly.

For example, if a buffer contained abCd and an error with no end-column started on C, we'd highlight abCd but jump to C.  This was particularly bad if there was another error starting on `b', since we'd skip it when jumping right to `C'.

Arguably, jumping to the beginning of the region inferred using flycheck-highlighting-mode isn't quite right either, since the error might have purposefully pointed to `C'.  But we already do this for display in any case, and the problem only exists for checkers that report a position instead of a
region.

One way to work around this would be to constrain the error region to not start before the position returned by the checker.  This might be a reasonable extension to explore in the future.

Closes GH-1779.