### PR TITLE
Update tflint checker to latest format

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11811,18 +11811,20 @@ information about tflint."
   (mapcar (lambda (err)
             (let-alist err
               (flycheck-error-new-at
-               .line
-               nil
-               (pcase .type
-                 ("ERROR"   'error)
-                 ("WARNING" 'warning)
+               .range.start.line
+               .range.start.column
+               (pcase .rule.severity
+                 ("error"   'error)
+                 ("warning" 'warning)
                  (_         'error))
                .message
-               :id .detector
+               :end-line .range.end.line
+               :end-column .range.end.column
+               :id .rule.name
                :checker checker
                :buffer buffer
                :filename (buffer-file-name buffer))))
-          (car (flycheck-parse-json output))))
+          (cdr (assq 'issues (car (flycheck-parse-json output))))))
 
 (flycheck-define-checker terraform-tflint
   "A Terraform checker using tflint.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4410,8 +4410,12 @@ Why not:
 (flycheck-ert-def-checker-test terraform-tflint terraform nil
   (flycheck-ert-should-syntax-check
    "language/terraform/tflint/error.tf" 'terraform-mode
-   '(3 nil error "instance_type is not a valid value"
-       :id "aws_instance_invalid_type" :checker terraform-tflint)))
+   '(2 12 warning "Module source \"git://hashicorp.com/consul.git\" is not pinned"
+       :id "terraform_module_pinned_source" :checker terraform-tflint
+       :end-line 2 :end-column 44)
+   '(7 19 error "\"t1.2xlarge\" is an invalid value as instance_type"
+       :id "aws_instance_invalid_type" :checker terraform-tflint
+       :end-line 7 :end-column 31)))
 
 (flycheck-ert-def-checker-test markdown-markdownlint-cli markdown nil
   (flycheck-ert-should-syntax-check

--- a/test/resources/language/terraform/tflint/error.tf
+++ b/test/resources/language/terraform/tflint/error.tf
@@ -1,3 +1,7 @@
+module "unpinned" {
+  source = "git://hashicorp.com/consul.git"
+}
+
 resource "aws_instance" "web" {
   ami           = "ami-b73b63a0"
   instance_type = "t1.2xlarge" # invalid type


### PR DESCRIPTION
tflint recently updated its json format

<details>
<summary>
make SELECTOR='(tag checker-terraform-tflint)' integ
</summary>

```
make SELECTOR='(tag checker-terraform-tflint)' integ
cask exec emacs -Q --batch -L .  --load test/flycheck-test --load test/run.el -f flycheck-run-tests-main '(and (tag external-tool) (tag checker-terraform-tflint))'
Running tests on Emacs 28.0.50, built at 2020-05-24
Running 1 tests (2020-05-24 19:36:17-0500, selector ‘(and "flycheck-" (and (tag external-tool) (tag checker-terraform-tflint)))’)
   passed  1/1  flycheck-define-checker/terraform-tflint/default (0.273260 sec)

Ran 1 tests, 1 results as expected, 0 unexpected (2020-05-24 19:36:17-0500, 0.273481 sec)
```
</details>
