### PR TITLE
Allow command checkers to specify environment for starting processes

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5700,6 +5700,18 @@ of command checkers is `flycheck-sanitize-errors'.
      or as special symbol or form for
      `flycheck-substitute-argument', which see.
 
+`:environment FUNCTION`
+     A function to build process environment.
+
+     FUNCTION is a function taking two arguments: ENVIRONMENT and
+     CHECKER.  ENVIRONMENT will be initialized to the value of
+     standard variable `process-environment'.  Return value of
+     the function should be a list (possibly even empty) in the
+     same format as `process-environment'.
+
+     This property is optional.  If omitted, processes are
+     started in unmodified `process-environment'.
+
 `:error-patterns PATTERNS'
      A list of patterns to parse the output of the `:command'.
 
@@ -5767,6 +5779,7 @@ default `:verify' function of command checkers."
                                     (funcall verify-fn checker)))))))
 
   (let ((command (plist-get properties :command))
+        (environment (plist-get properties :environment))
         (patterns (plist-get properties :error-patterns))
         (parser (or (plist-get properties :error-parser)
                     #'flycheck-parse-with-patterns))
@@ -5808,6 +5821,7 @@ default `:verify' function of command checkers."
                              patterns)))
       (pcase-dolist (`(,prop . ,value)
                      `((command        . ,command)
+                       (environment    . ,environment)
                        (error-parser   . ,parser)
                        (error-patterns . ,patterns)
                        (standard-input . ,standard-input)))
@@ -6094,6 +6108,12 @@ symbols in the command."
          (seq-map (lambda (arg) (flycheck-substitute-argument arg checker))
                   (flycheck-checker-arguments checker))))
 
+(defun flycheck-checker-process-environment (checker)
+  "Get the process environment for a CHECKER."
+  (-if-let (builder (flycheck-checker-get checker 'environment))
+      (funcall builder checker (seq-copy process-environment))
+    process-environment))
+
 (defun flycheck--process-send-buffer-contents-chunked (process)
   "Send contents of current buffer to PROCESS in small batches.
 
@@ -6158,6 +6178,8 @@ and rely on Emacs' own buffering and chunking."
         (let* ((program (flycheck-find-checker-executable checker))
                (args (flycheck-checker-substituted-arguments checker))
                (command (flycheck--wrap-command program args))
+               (process-environment (flycheck-checker-process-environment
+                                     checker))
                (sentinel-events nil)
                ;; Use pipes to receive output from the syntax checker.  They are
                ;; more efficient and more robust than PTYs, which Emacs uses by
@@ -7338,6 +7360,7 @@ SYMBOL with `flycheck-def-executable-var'."
   (declare (indent 1)
            (doc-string 2))
   (let ((command (plist-get properties :command))
+        (environment (plist-get properties :environment))
         (parser (plist-get properties :error-parser))
         (filter (plist-get properties :error-filter))
         (explainer (plist-get properties :error-explainer))
@@ -7351,6 +7374,8 @@ SYMBOL with `flycheck-def-executable-var'."
        (flycheck-define-command-checker ',symbol
          ,docstring
          :command ',command
+         ,@(when environment
+             `(:environment #',environment))
          ,@(when parser
              `(:error-parser #',parser))
          :error-patterns ',(plist-get properties :error-patterns)


### PR DESCRIPTION
This simple change adds possibility for command-based checkers to specify environment (i.e. environment variables) in which their processes are started. This is completely optional and not used by any existing checker. I plan to eventually use this functionality in `flycheck-eldev`. In Eldev it is possible to switch Emacs binary you use, but not as a command line option (command line is parsed by Elisp code, so it's a bit too late), only by modifying an environment variable.

Verified by `make check specs unit`. Also verified that it actually affects process environment e.g. by using this locally:

    :environment (lambda (checker environment) (cons "ELDEV_EMACS=lol" environment))

After this Eldev couldn't launch, as expected.