### PR TITLE
Fix flycheck-ruby-rubocop on buffers with no backing file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ New Features
 Bugs Fixed
 ----------
 
+- [#1793]: Fix flycheck-ruby-rubocop on buffers with no backing file
+
 ----------
 Changes
 ----------


### PR DESCRIPTION
I was trying to use the `flycheck-ruby-rubocop` checker on an org-mode snippet buffer, and found that rubocop was giving an error like the following.

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/EmptyLinesAroundAttributeAccessor (0.83)
 - Layout/SpaceAroundMethodCallOperator (0.82)
 - Lint/DeprecatedOpenSSLConstant (0.84)
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/ExponentialNotation (0.82)
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
 - Style/SlicingWithRange (0.83)
For more information: https://docs.rubocop.org/en/latest/versioning/
Inspecting 1 file
.

0 files inspected, no offenses detected
no implicit conversion of nil into String
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/path_util.rb:39:in `fnmatch?'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/path_util.rb:39:in `match_path?'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/cop.rb:264:in `block in file_name_matches_any?'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/cop.rb:258:in `any?'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/cop.rb:258:in `file_name_matches_any?'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/cop.rb:214:in `relevant_file?'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/cop.rb:219:in `excluded_file?'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/commissioner.rb:68:in `block in remove_irrelevant_cops'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/commissioner.rb:67:in `reject!'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/commissioner.rb:67:in `remove_irrelevant_cops'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/commissioner.rb:39:in `investigate'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/team.rb:124:in `investigate'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/team.rb:112:in `offenses'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:295:in `inspect_file'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:245:in `block in do_inspection_loop'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:277:in `block in iterate_until_no_changes'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:270:in `loop'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:270:in `iterate_until_no_changes'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:241:in `do_inspection_loop'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:122:in `block in file_offenses'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:146:in `file_offense_cache'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:120:in `file_offenses'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:111:in `process_file'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:90:in `block in each_inspected_file'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:89:in `each'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:89:in `reduce'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:89:in `each_inspected_file'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:78:in `inspect_files'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/runner.rb:39:in `run'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cli/command/execute_runner.rb:21:in `execute_runner'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cli/command/execute_runner.rb:13:in `run'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cli/command.rb:10:in `run'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cli/environment.rb:17:in `run'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cli.rb:65:in `run_command'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cli.rb:72:in `execute_runners'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/lib/rubocop/cli.rb:41:in `run'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/exe/rubocop:13:in `block in <top (required)>'
/Users/amake/.rbenv/versions/2.7.0/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/Users/amake/.gem/ruby/2.7.0/gems/rubocop-0.84.0/exe/rubocop:12:in `<top (required)>'
/Users/amake/.gem/ruby/2.7.0/bin/rubocop:23:in `load'
/Users/amake/.gem/ruby/2.7.0/bin/rubocop:23:in `<main>'
```

You can easily reproduce this with

```
echo "foo" | rubocop --stdin '' 
```

The "real" problem is that rubocop errors out when given an empty-string argument to `--stdin`. This happens in an org-mode snippet buffer because the `(file-name)` token resolves to `""`.

While it would be nice to get this addressed in rubocop, unfortunately I don't think we'd get backported fixes to all historical versions of interest, so I think it would be nice to handle this gracefully within flycheck.

~My solution isn't very graceful; in particular it's unfortunate that the patterns need to be duplicated, but I couldn't figure anything else out: If you capture the `(file-name)` then the issues won't be associated with the correct buffer.~

~If there is a better way please let me know.~