### PR TITLE
Insert string explanations into standard-output

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5624,7 +5624,7 @@ this error to produce the explanation to display."
            (flycheck-explain-error-mode))
          (cond
           ((functionp explanation) (funcall explanation))
-          ((stringp explanation) (insert explanation))
+          ((stringp explanation) (princ explanation))
           (t (error "Unsupported error explanation: %S" explanation)))
          (display-message-or-buffer standard-output nil 'not-this-window)))))
 


### PR DESCRIPTION
Fixes #1800 

Previously, this was incorrectly inserting the explanation string into
the current buffer, which is the source code buffer where the checker
runs.