### PR TITLE
Support multi-line suggestions Haskell hlint-3.1.4

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9577,17 +9577,20 @@ See URL `https://github.com/ndmitchell/hlint'."
             source-inplace)
   :error-patterns
   ((info line-start
-         (file-name) ":" line ":" column (optional "-" end-column)
+         (file-name) ":" (or (: line ":" column (optional "-" end-column))
+                             (: "(" line "," column ")-(" end-line "," end-column ")"))
          ": Suggestion: "
          (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
          line-end)
    (warning line-start
-            (file-name) ":" line ":" column (optional "-" end-column)
+            (file-name) ":" (or (: line ":" column (optional "-" end-column))
+                                (: "(" line "," column ")-(" end-line "," end-column ")"))
             ": Warning: "
             (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
             line-end)
    (error line-start
-          (file-name) ":" line ":" column (optional "-" end-column)
+          (file-name) ":" (or (: line ":" column (optional "-" end-column))
+                              (: "(" line "," column ")-(" end-line "," end-column ")"))
           ": Error: "
           (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
           line-end))

--- a/flycheck.el
+++ b/flycheck.el
@@ -9577,20 +9577,23 @@ See URL `https://github.com/ndmitchell/hlint'."
             source-inplace)
   :error-patterns
   ((info line-start
-         (file-name) ":" (or (: line ":" column (optional "-" end-column))
-                             (: "(" line "," column ")-(" end-line "," end-column ")"))
+         (file-name) ":"
+         (or (: line ":" column (optional "-" end-column))
+             (: "(" line "," column ")-(" end-line "," end-column ")"))
          ": Suggestion: "
          (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
          line-end)
    (warning line-start
-            (file-name) ":" (or (: line ":" column (optional "-" end-column))
-                                (: "(" line "," column ")-(" end-line "," end-column ")"))
+            (file-name) ":"
+            (or (: line ":" column (optional "-" end-column))
+                (: "(" line "," column ")-(" end-line "," end-column ")"))
             ": Warning: "
             (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
             line-end)
    (error line-start
-          (file-name) ":" (or (: line ":" column (optional "-" end-column))
-                              (: "(" line "," column ")-(" end-line "," end-column ")"))
+          (file-name) ":"
+          (or (: line ":" column (optional "-" end-column))
+              (: "(" line "," column ")-(" end-line "," end-column ")"))
           ": Error: "
           (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
           line-end))

--- a/test/resources/language/haskell/Warnings.hs
+++ b/test/resources/language/haskell/Warnings.hs
@@ -1,7 +1,8 @@
 module Haskell.Warnings (spam, main)
 where
 
-spam eggs = map lines eggs
+spam eggs =
+  map lines eggs
 
 main :: IO ()
 main = (putStrLn "hello world")


### PR DESCRIPTION
As of Hlint 3.1.4, it can produce multi-line multi-column suggestions:
```
src/Main.hs:(302,3)-(307,87): Warning: Redundant <$>
```
This is in addition to standard one-line comments such as
```
src/Main.hs:402:65-69: Warning: Use fmap
```