### PR TITLE
Change rubocop url

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1138,7 +1138,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
    .. syntax-checker:: ruby-rubocop
 
-      Check syntax and lint with `RuboCop <http://batsov.com/rubocop/>`_.
+      Check syntax and lint with `RuboCop <https://rubocop.org/>`_.
 
       .. note::
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -11062,7 +11062,7 @@ report style issues as well."
 
 You need at least RuboCop 0.34 for this syntax checker.
 
-See URL `http://batsov.com/rubocop/'."
+See URL `https://rubocop.org/'."
   ;; ruby-standard is defined based on this checker
   :command '("rubocop"
              "--display-cop-names"


### PR DESCRIPTION
The rubocop webpage is in another url https://rubocop.org/