### PR TITLE
Update `haskell-hlint` checker to HLint-3.0

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9527,7 +9527,7 @@ See URL `https://www.haskell.org/ghc/'."
   :next-checkers ((warning . haskell-hlint))
   :working-directory flycheck-haskell--ghc-find-default-directory)
 
-(flycheck-def-config-file-var flycheck-hlintrc haskell-hlint "HLint.hs")
+(flycheck-def-config-file-var flycheck-hlintrc haskell-hlint ".hlint.yaml")
 
 (flycheck-def-args-var flycheck-hlint-args haskell-hlint
   :package-version '(flycheck . "0.25"))
@@ -9569,6 +9569,7 @@ string is a default hint package (e.g. (\"Generalise\"
 
 See URL `https://github.com/ndmitchell/hlint'."
   :command ("hlint"
+            "--no-exit-code"
             (option-list "-X" flycheck-hlint-language-extensions concat)
             (option-list "-i=" flycheck-hlint-ignore-rules concat)
             (option-list "-h" flycheck-hlint-hint-packages concat)


### PR DESCRIPTION
HLint v3.0 has been recently [released](https://neilmitchell.blogspot.com/2020/05/hlint-30.html).

- Now `.hlint.yaml` is the default configuration file. (I think this was already supported in the latest releases of 2.0).
- When there is a suggestion or warning it returns a `1` exit code by default. We have to pass `--no-exit-code` to avoid it.