### PR TITLE
Add support for pyright as a python type checker

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1029,6 +1029,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. syntax-checker-config-file:: flycheck-flake8rc
 
+   .. syntax-checker:: python-pyright
+
+      Type check python with  `pyright <https://github.com/microsoft/pyright>`_.
+
+      .. note::
+
+         This syntax checker requires pyright.
+
    .. syntax-checker:: python-mypy
 
       Type check python with  `mypy <http://www.mypy-lang.org/>`_.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4292,6 +4292,16 @@ Why not:
      '(22 1 error "undefined name 'antigravity'" :id "F821"
           :checker python-flake8))))
 
+(flycheck-ert-def-checker-test python-pyright python nil
+  (let ((flycheck-disabled-checkers '(python-mypy))
+        (flycheck-checkers '(python-pyright)))
+    (flycheck-ert-should-syntax-check
+     "language/python/invalid_type.py" 'python-mode
+     '(2 12 error "Expression of type \"str\" cannot be assigned to return type \"int\"\n  \"str\" is incompatible with \"int\""
+         :checker python-pyright
+         :end-line 2
+         :end-column 13))))
+
 (flycheck-ert-def-checker-test python-mypy python nil
   (let ((flycheck-disabled-checkers '(python-flake8))
         (flycheck-checkers '(python-mypy))


### PR DESCRIPTION
I have run the basic checks like is decribed in contributor's guide and also make a PR adding pyright as a tool in docker-tools for CI tests - https://github.com/flycheck/docker-tools/pull/7

I have tested it on my setup when developing some python app and it seems okay for me :) 

Any feedback is welcomed since this is my first contribution to flycheck.