### PR TITLE
Update nix and terraform checkers for recent versions

### DIFF
--- a/Cask.24
+++ b/Cask.24
@@ -16,7 +16,7 @@
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")
  (depends-on "cwl-mode")
- (depends-on "d-mode")
+ ;; (depends-on "d-mode")          ; requires Emacs 25.1+
  (depends-on "dockerfile-mode")
  (depends-on "erlang")
  ;; Latest ess requires `project' from Emacs 25+.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10881,6 +10881,10 @@ See URL `https://nixos.org/nix/manual/#sec-nix-instantiate'."
   :standard-input t
   :error-patterns
   ((error line-start
+          "at: (" line ":" column ") from stdin"
+          (one-or-more "\n" (zero-or-more space (one-or-more not-newline)))
+          (message) line-end)
+   (error line-start
           "error: " (message) " at " (file-name) ":" line ":" column
           line-end))
   :error-filter

--- a/flycheck.el
+++ b/flycheck.el
@@ -11964,6 +11964,11 @@ See URL `https://www.terraform.io/docs/commands/fmt.html'."
   :standard-input t
   :error-patterns
   ((error line-start "Error: " (one-or-more not-newline)
+          "\n\n  on <stdin> line " line ", in terraform:"
+          (one-or-more "\n" (zero-or-more space (one-or-more not-newline)))
+          (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
+          line-end)
+   (error line-start "Error: " (one-or-more not-newline)
           "\n\n  on <stdin> line " line ":\n  (source code not available)\n\n"
           (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
           line-end))

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4324,8 +4324,6 @@ Why not:
           :id "inconsistent-return-statements" :checker python-pylint)
      '(12 5 warning "Method could be a function"
           :id "no-self-use" :checker python-pylint)
-     '(12 30 info "No space allowed around keyword argument assignment"
-          :id "bad-whitespace" :checker python-pylint)
      '(14 16 error "Module 'sys' has no 'python_version' member" :id "no-member"
           :checker python-pylint)
      '(22 1 error "Undefined variable 'antigravity'" :id "undefined-variable"
@@ -4355,8 +4353,6 @@ Why not:
           :id "R1710" :checker python-pylint)
      '(12 5 warning "Method could be a function"
           :id "R0201" :checker python-pylint)
-     '(12 30 info "No space allowed around keyword argument assignment"
-          :id "C0326" :checker python-pylint)
      '(14 16 error "Module 'sys' has no 'python_version' member" :id "E1101"
           :checker python-pylint)
      '(22 1 error "Undefined variable 'antigravity'" :id "E0602"


### PR DESCRIPTION
+ Terraform 0.13 introduces a new error message format.
+ Nix 3.x introduces a new format for the error messages. Fixes https://github.com/flycheck/flycheck/issues/1823 cc: @endgame
+ Fix pylint checker tests.