### PR TITLE
Use .reek.yml as conf filename for flycheck-reek

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11109,8 +11109,7 @@ See URL `https://github.com/testdouble/standard' for more information."
   :next-checkers '((warning . ruby-reek)
                    (warning . ruby-rubylint)))
 
-;; Default to `nil' to let Reek find its configuration file by itself
-(flycheck-def-config-file-var flycheck-reekrc ruby-reek nil
+(flycheck-def-config-file-var flycheck-reekrc ruby-reek ".reek.yml"
   :safe #'string-or-null-p
   :package-version '(flycheck . "30"))
 


### PR DESCRIPTION
This matches the name that reek looks for per [their documentation](https://github.com/troessner/reek#configuration-file). Passing in `nil` means that you do not want to use a configuration file AFIAK.