### PR TITLE
FIX: flycheck-rust processes an error record with nil code

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7222,9 +7222,10 @@ machine_message.rs at URL `https://git.io/vh24R'."
         ;; Errors and warnings from rustc are wrapped by cargo, so we filter and
         ;; unwrap them, and delegate the actual construction of `flycheck-error'
         ;; objects to `flycheck-parse-rustc-diagnostic'.
-        ;; Check whether the code is non-nil because Rust≥1.44 includes the
-        ;; warning count upon completion.
-        (when (and .message.code (string= .reason "compiler-message"))
+        ;; We put the error record with nil code since flycheck regards
+        ;; the case of nonzero return code without any error report
+        ;; as abnormal result.
+        (when (string= .reason "compiler-message")
           (push (flycheck-parse-rustc-diagnostic .message checker buffer)
                 errors))))
     (apply #'nconc errors)))


### PR DESCRIPTION
Hi, all.

When I checked a simple rust src file, flycheck failed.
flycheck does not report error cases with null rust error code, but
it can happen that all error cases have null error code  and
it happed at the very first try.

I suppose it has valid reasons to filter out null error code cases, but
it's frustrating for most users to get a `suspicious state..` message,
who installed an up-to-date rust toolchain and flycheck package.

So this PR suggests processing rust error records without error code.

I'd be happy if you take a look at this PR.
Best regards,

Chul-Woong

----

We put the error record with nil code since flycheck regards
the case of return code 101 without any error report
as abnormal.

--

```
$ cargo new hello

$ cat hello/src/main.rs
THIS_CAUSES_AN_COMPILATION_ERROR

fn main() {
    println!("Hello, world!");
}

$ rustc hello/src/main.rs
error: expected one of `!` or `::`, found keyword `fn`
 --> hello/src/main.rs:3:1
  |
1 | THIS_CAUSES_AN_COMPILATION_ERROR
  |                                 - expected one of `!` or `::`
2 |
3 | fn main() {
  | ^^ unexpected token

error: aborting due to previous error
```
--
*Messages* buffer when we run flycheck to the above code:

```
Suspicious state from syntax checker rust-cargo: Flycheck checker rust-cargo returned 101, but its output contained no errors:    Compiling hello v0.1.0 (/home/cwyang/hello)
{"reason":"compiler-message","package_id":"hello 0.1.0 (path+file:///home/cwyang/hello)","target":{"kind":["bin"],"crate_types":["bin"],"name":"hello","src_path":"/home/cwyang/hello/src/main\
.rs","edition":"2018","doctest":false,"test":true},"message":{"rendered":"error: expected one of `!` or `::`, found keyword `fn`\n --> src/main.rs:3:1\n  |\n1 | THIS_CAUSES_AN_COMPILATION_ER\
ROR\n  |                                 - expected one of `!` or `::`\n2 |     \n3 | fn main() {\n  | ^^ unexpected token\n\n","children":[],"code":null,"level":"error","message":"expected \
one of `!` or `::`, found keyword `fn`","spans":[{"byte_end":32,"byte_start":32,"column_end":33,"column_start":33,"expansion":null,"file_name":"src/main.rs","is_primary":false,"label":"expec\
ted one of `!` or `::`","line_end":1,"line_start":1,"suggested_replacement":null,"suggestion_applicability":null,"text":[{"highlight_end":33,"highlight_start":33,"text":"THIS_CAUSES_AN_COMPI\
LATION_ERROR"}]},{"byte_end":40,"byte_start":38,"column_end":3,"column_start":1,"expansion":null,"file_name":"src/main.rs","is_primary":true,"label":"unexpected token","line_end":3,"line_sta\
rt":3,"suggested_replacement":null,"suggestion_applicability":null,"text":[{"highlight_end":3,"highlight_start":1,"text":"fn main() {"}]}]}}
{"reason":"compiler-message","package_id":"hello 0.1.0 (path+file:///home/cwyang/hello)","target":{"kind":["bin"],"crate_types":["bin"],"name":"hello","src_path":"/home/cwyang/hello/src/main\
.rs","edition":"2018","doctest":false,"test":true},"message":{"rendered":"error: aborting due to previous error\n\n","children":[],"code":null,"level":"error","message":"aborting due to prev\
ious error","spans":[]}}
{"reason":"build-finished","success":false}
error: could not compile `hello`.

To learn more, run the command again with --verbose.

Try installing a more recent version of rust-cargo, and please open a bug report if the issue persists in the latest release.  Thanks!
```