### PR TITLE
Fix Terraform error pattern

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12003,7 +12003,7 @@ See URL `https://www.terraform.io/docs/commands/fmt.html'."
   :standard-input t
   :error-patterns
   ((error line-start "Error: " (one-or-more not-newline)
-          "\n\n  on <stdin> line " line ", in terraform:"
+          "\n\n  on <stdin> line " line ", in " (one-or-more not-newline) ":"
           (one-or-more "\n" (zero-or-more space (one-or-more not-newline)))
           (message (one-or-more (and (one-or-more (not (any ?\n))) ?\n)))
           line-end)


### PR DESCRIPTION
Hi,

This PR updates the error pattern for the `terraform` checker to fix an issue I observed using Terraform 0.13.4 and 0.13.5: the checker errors when `terraform fmt` outputs a message containing a line like this:

`  on <stdin> line 57, in resource "kubernetes_deployment" "znc":`

AFAICT most or all of the error messages from `terraform fmt` take this form. Terraform 0.13.5 is the latest version.

Thanks!