### PR TITLE
Fix flycheck-may-enable-checker

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2222,6 +2222,8 @@ Return non-nil if CHECKER may be used for the current buffer, and
 nil otherwise.  The result of the `:enabled' check, if any, is
 cached."
   (and
+   ;; May only enable valid checkers
+   (flycheck-valid-checker-p checker)
    ;; Don't run the :enabled check if the checker is already disabled…
    (not (flycheck-disabled-checker-p checker))
    (or

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -822,6 +822,7 @@
   (flycheck-ert-with-resource-buffer "language/emacs-lisp/warnings.el"
     (emacs-lisp-mode)
     (should (flycheck-may-enable-checker 'emacs-lisp))
+    (should-not (flycheck-may-enable-checker 'gibberish))
     (should (equal '(emacs-lisp) flycheck--automatically-enabled-checkers))))
 
 (ert-deftest flycheck-may-enable-checker/respects-cache ()


### PR DESCRIPTION
The function flycheck-may-enable-checker returns wrong answer on gibberish input / non-existing checkers. See my issue https://github.com/flycheck/flycheck/issues/1844 

This PR adds a check that the checker is valid.

Fixes #1844 