### PR TITLE
Set destination to nil in racket checker feature test (#1848).

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10755,7 +10755,7 @@ See URL `https://github.com/jimhester/lintr'."
 
 (defun flycheck-racket-has-expand-p (checker)
   "Whether the executable of CHECKER provides the `expand' command."
-  (eql 0 (flycheck-call-checker-process checker nil t nil "expand")))
+  (eql 0 (flycheck-call-checker-process checker nil nil nil "expand")))
 
 (flycheck-define-checker racket
   "A Racket syntax checker with `raco expand'.


### PR DESCRIPTION
This PR fixes #1848.

Sometimes `raco` command will issue a harmless warning to standard
error (eg. when a racket package is installed both in system directory and user
directory). If `destination` is set to `t` in `flycheck-call-checker-process`,
this warning would be improperly redirected to current buffer, causing file
change and syntax error. Then flycheck will call `raco` to check the buffer, and
the warning will be inserted to current buffer again, leading to an infinite
loop.

Setting `destination` to nil avoids problems. Because when
`flycheck-racket-has-expand-p` is called, we don't need `raco`'s output.