### PR TITLE
Add yamllint to YAML checker chain

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12376,8 +12376,7 @@ See URL `http://www.ruby-doc.org/stdlib-2.0.0/libdoc/yaml/rdoc/YAML.html'."
   ((error line-start "stdin:" (zero-or-more not-newline) ":" (message)
           "at line " line " column " column line-end))
   :modes yaml-mode
-  :next-checkers ((warning . yaml-jsyaml)
-                  (warning . yaml-yamllint)
+  :next-checkers ((warning . yaml-yamllint)
                   (warning . cwl)))
 
 (flycheck-def-config-file-var flycheck-yamllintrc yaml-yamllint ".yamllint")

--- a/flycheck.el
+++ b/flycheck.el
@@ -12356,7 +12356,8 @@ See URL `https://github.com/nodeca/js-yaml'."
           (message) " at line " line ", column " column ":"
           line-end))
   :modes yaml-mode
-  :next-checkers ((warning . cwl)))
+  :next-checkers ((warning . yaml-yamllint)
+                  (warning . cwl)))
 
 (flycheck-define-checker yaml-ruby
   "A YAML syntax checker using Ruby's YAML parser.
@@ -12375,7 +12376,9 @@ See URL `http://www.ruby-doc.org/stdlib-2.0.0/libdoc/yaml/rdoc/YAML.html'."
   ((error line-start "stdin:" (zero-or-more not-newline) ":" (message)
           "at line " line " column " column line-end))
   :modes yaml-mode
-  :next-checkers ((warning . cwl)))
+  :next-checkers ((warning . yaml-jsyaml)
+                  (warning . yaml-yamllint)
+                  (warning . cwl)))
 
 (flycheck-def-config-file-var flycheck-yamllintrc yaml-yamllint ".yamllint")
 
@@ -12390,7 +12393,8 @@ See URL `https://github.com/adrienverge/yamllint'."
           "stdin:" line ":" column ": [error] " (message) line-end)
    (warning line-start
             "stdin:" line ":" column ": [warning] " (message) line-end))
-  :modes yaml-mode)
+  :modes yaml-mode
+  :next-checkers ((warning . cwl)))
 
 (provide 'flycheck)
 


### PR DESCRIPTION
I saw that [yamllint](https://github.com/adrienverge/yamllint) wasn't a part of the YAML checker chain, so this patch adds it. It also structures the chain assuming that you have one of the two main YAML implementations supported (Ruby or JS) run first, then the linter runs, then CWL. It assumes that you would want to run only one of Ruby or JS, not both.