### PR TITLE
Add error-explainer documentation for URLs

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2052,6 +2052,17 @@ are mandatory.
        be found online at URL.
      - nil if there is no explanation for this error.
 
+     If URL is provided by the checker, and cannot be composed
+     from other elements in the `flycheck-error' object, consider
+     passing the URL via text properties:
+
+       ;; During the error object creation
+       (put-text-property 0 1 'explainer-url .url .check_id)
+
+       ;; In the error-explainer FUNCTION
+       (let ((id (flycheck-error-id err)))
+         (and id `(url . ,(get-text-property 0 'explainer-url id))))
+
      This property is optional.
 
 `:next-checkers NEXT-CHECKERS'


### PR DESCRIPTION
Since the flycheck-error structure does not have a slot for
error-explainer data, document a technique by which URLs can be
passed to the error-explainer function via text properties.

Addresses GH-1864