### PR TITLE
Add new error pattern for nix unstable

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10960,6 +10960,10 @@ See URL `https://nixos.org/nix/manual/#sec-nix-instantiate'."
   :standard-input t
   :error-patterns
   ((error line-start
+          "error: " (message)
+          (one-or-more "\n")
+          (zero-or-more space) "at «stdin»:" line ":" column ":" line-end)
+   (error line-start
           "at: (" line ":" column ") from stdin"
           (one-or-more "\n" (zero-or-more space (one-or-more not-newline)))
           (message) line-end)


### PR DESCRIPTION
With NixOS/nix#4467 unstable branch of nix changed its error formatting (you're not having deja-vu, this has happened before and was adressed in #1826). This patch adds a new pattern to match the new format.

The pattern added in #1826 is kept in this patch but there may be a case for removing it, it is now only ever used by unreleased nix versions.