### PR TITLE
Update list of `error-explainer`s

### DIFF
--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -170,7 +170,8 @@ Explain errors
 
 Flycheck also has the ability to display explanations for errors, provided the
 error checker is capable of producing these explanations.  Currently, only the
-`rust` and `rust-cargo` checkers produce explanations.
+`javascript-eslint `, `nix-linter`, `python-pylint`, `rust`, `rust-cargo`,
+`rust-clippy`, and `sh-shellcheck` checkers produce explanations.
 
 .. define-key:: C-c ! e
                 M-x flycheck-explain-error-at-point


### PR DESCRIPTION
Hadn't been updated since its addition in #1122 (52eb56af)

----

Arguably, the list is long enough that it's not worth listing them individually, and just doing something like "While several checkers produce explanations, the majority do not."  I personally prefer the list for the sake of helpfulness, but ymmv.