### PR TITLE
Add error-explainer to css-stylelint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8252,7 +8252,12 @@ See URL `http://stylelint.io/'."
   :standard-input t
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
-  :modes (css-mode css-ts-mode))
+  :modes (css-mode css-ts-mode)
+  :error-explainer
+  (lambda (err)
+    (let ((error-code (flycheck-error-id err))
+          (url "https://stylelint.io/user-guide/rules/%s"))
+      (and error-code `(url . ,(format url error-code))))))
 
 (flycheck-def-option-var flycheck-cuda-language-standard nil cuda-nvcc
   "Our CUDA Language Standard."


### PR DESCRIPTION
(Initially) Opened as a draft since I'm not really sure if this should be added to the `scss-stylelint` and `less-stylelint` checkers as well.  I think maybe?  Based off <https://stylelint.io/user-guide/usage/options#syntax> it's separate from the `scss` plugin and so on, but I've no experience with scss or less.