### PR TITLE
When works with erb on web-mode, enable eruby checker.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8919,7 +8919,7 @@ See URL `http://www.kuwata-lab.com/erubis/'."
   :command ("erubis" "-z" source)
   :error-patterns
   ((error line-start (file-name) ":" line ": " (message) line-end))
-  :modes (html-erb-mode rhtml-mode)
+  :modes (html-erb-mode rhtml-mode web-mode)
   :next-checkers ((warning . eruby-ruumba)))
 
 (flycheck-def-config-file-var flycheck-ruumbarc eruby-ruumba ".ruumba.yml")
@@ -8960,7 +8960,7 @@ See URL `https://github.com/ericqweinstein/ruumba'."
    (error line-start (file-name) ":" line ":" column ": " (or "E" "F") ": "
           (optional (id (one-or-more (not (any ":")))) ": ") (message)
           line-end))
-  :modes (html-erb-mode rhtml-mode))
+  :modes (html-erb-mode rhtml-mode web-mode))
 
 (flycheck-def-args-var flycheck-gfortran-args fortran-gfortran
   :package-version '(flycheck . "0.22"))


### PR DESCRIPTION
When open a erb file use web-mode, eruby check not enabled default, this PR fix this.

![image](https://user-images.githubusercontent.com/549126/130043472-d17763f2-6b6f-4591-9820-5f596e79e47c.png)
