### PR TITLE
Add variable for temp file suffix

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -868,6 +868,12 @@ function."
   :package-version '(flycheck . "0.19")
   :risky t)
 
+(defcustom flycheck-temp-suffix "flycheck"
+  "Sufffix for temporary files created by Flycheck."
+  :group 'flycheck
+  :type 'string
+  :risky t)
+
 (defcustom flycheck-mode-hook nil
   "Hooks to run after command `flycheck-mode' is toggled."
   :group 'flycheck
@@ -1410,9 +1416,10 @@ the specified SUFFIX.
 
 Return the path of the file."
   (if filename
-      (let* ((tempname (format "%s_%s"
+      (let* ((tempname (format "%s_%s%s"
                                flycheck-temp-prefix
-                               (file-name-nondirectory filename)))
+                               (file-name-nondirectory filename)
+                               flycheck-temp-suffix))
              (tempfile (convert-standard-filename
                         (expand-file-name tempname
                                           (file-name-directory filename)))))


### PR DESCRIPTION
Added `flycheck-temp-suffix` for the temporary file created by flycheck.

Coding in python seems to require such temporary file (because of pylint?). When coding with frameworks like Flask, which is quiet popular, the debug mode of such framework automatically reload on python source file changes. This can happen also with some javascript tools.

There is no work around with Flask for instance to avoid reloading when flycheck temporary file are generated (no configuration possible).

Appending `.temp` on the temporary file for instance will not trigger the auto reload mechanism (extension sensitive) while still being valid for the linter. This change is just adding an option for user to fix the issue while only adding 7 lines of code.