### PR TITLE
Fix Erlang/OTP 24 which added columns to output

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8905,9 +8905,10 @@ directory name is \"test\" or \"eqc\", or else \"default\"."
   :command ("rebar3" "as" (eval (flycheck-erlang-rebar3-get-profile)) "compile")
   :error-parser flycheck-parse-with-patterns-without-color
   :error-patterns
-  ((warning line-start
-            (file-name) ":" line ":" column ": Warning:" (message) line-end)
-   (error line-start (file-name) ":" line ":" column ": " (message) line-end))
+  ((warning line-start (file-name) ":" line ":" (optional column ":")
+            " Warning:" (message) line-end)
+   (error line-start (file-name) ":" line ":" (optional column ":") " "
+          (message) line-end))
   :modes erlang-mode
   :enabled flycheck-rebar3-project-root
   :predicate flycheck-buffer-saved-p

--- a/flycheck.el
+++ b/flycheck.el
@@ -8832,8 +8832,10 @@ See URL `http://www.erlang.org/'."
             "-Wall"
             source)
   :error-patterns
-  ((warning line-start (file-name) ":" line ": Warning:" (message) line-end)
-   (error line-start (file-name) ":" line ": " (message) line-end))
+  ((warning line-start (file-name) ":" line ":" (optional column ":")
+            " Warning:" (message) line-end)
+   (error line-start (file-name) ":" line ":" (optional column ":") " "
+          (message) line-end))
   :modes erlang-mode
   :enabled (lambda () (string-suffix-p ".erl" (buffer-file-name))))
 

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3589,11 +3589,14 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
    "language/ember-template-lint/ember-template-lint/warning.hbs" 'web-mode
    '(1 nil warning "Non-translated string used" :id "no-bare-strings" :checker ember-template)))
 
-(defun flycheck-ert-erlang-shows-column ()
+(defun flycheck-ert-erlang-shows-column (mode-sym)
   ;; erl -version shows the version of the "erts" application in the current otp
   ;; release. This is the "Erlang RunTime System" and has nothing to do with
   ;; flycheck-ert!
-  (let* ((erts-version (string-trim (shell-command-to-string "erl -version")))
+  (let* ((cmd (cond ((eq mode-sym 'erlang) "erl -version")
+                    ((eq mode-sym 'erlang-rebar3) "rebar3 version")
+                    (t (error "unknown erlang mode symbol"))))
+         (erts-version (string-trim (shell-command-to-string cmd)))
          (version-string (car (last (split-string erts-version))))
          (major-version-str (car (split-string version-string "\\.")))
          (major-version (string-to-number major-version-str)))
@@ -3604,7 +3607,7 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
       (error "failed to check the version of erlang's erts application"))))
 
 (flycheck-ert-def-checker-test erlang erlang error
-  (let ((col (flycheck-ert-erlang-shows-column)))
+  (let ((col (flycheck-ert-erlang-shows-column 'erlang)))
     (shut-up
       (flycheck-ert-should-syntax-check
        "language/erlang/erlang/error.erl" 'erlang-mode
@@ -3612,21 +3615,21 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
        '(7 (when col 1) error "head mismatch" :checker erlang)))))
 
 (flycheck-ert-def-checker-test erlang erlang warning
-  (let ((col (flycheck-ert-erlang-shows-column)))
+  (let ((col (flycheck-ert-erlang-shows-column 'erlang)))
     (flycheck-ert-should-syntax-check
      "language/erlang/erlang/warning.erl" 'erlang-mode
      '(3 (when col 2) warning "export_all flag enabled - all functions will be exported" :checker erlang)
      '(6 (when col 37) warning "wrong number of arguments in format call" :checker erlang)))
 
 (flycheck-ert-def-checker-test erlang-rebar3 erlang error
-  (let ((col (flycheck-ert-erlang-shows-column)))
+  (let ((col (flycheck-ert-erlang-shows-column 'erlang-rebar3)))
     (flycheck-ert-should-syntax-check
      "language/erlang/rebar3/src/erlang-error.erl" 'erlang-mode
      '(3 (when col 2) warning "export_all flag enabled - all functions will be exported" :checker erlang-rebar3)
      '(7 (when col 1) error "head mismatch" :checker erlang-rebar3)))
 
 (flycheck-ert-def-checker-test erlang-rebar3 erlang build
-  (let ((col (flycheck-ert-erlang-shows-column)))
+  (let ((col (flycheck-ert-erlang-shows-column 'erlang-rebar3)))
     (shut-up
       (flycheck-ert-should-syntax-check
        "language/erlang/rebar3/_checkouts/dependency/src/dependency.erl" 'erlang-mode

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -3597,14 +3597,10 @@ See https://github.com/flycheck/flycheck/issues/531 and Emacs bug #19206"))
                     ((eq mode-sym 'erlang-rebar3) "rebar3 version")
                     (t (error "unknown erlang mode symbol"))))
          (erts-version (string-trim (shell-command-to-string cmd)))
-         (version-string (car (last (split-string erts-version))))
-         (major-version-str (car (split-string version-string "\\.")))
-         (major-version (string-to-number major-version-str)))
-    (if (> major-version 0)
-        ;; The version of erts released with OTP 24 is 12.1.0. This is the first
-        ;; time columns were added to compile warnings/errors.
-        (>= major-version 12)
-      (error "failed to check the version of erlang's erts application"))))
+         (version-string (car (last (split-string erts-version)))))
+    ;; The version of erts released with OTP 24 is 12.0. This is the first
+    ;; time columns were added to compile warnings/errors.
+    (version<= "12" version-string)))
 
 (flycheck-ert-def-checker-test erlang erlang error
   (let ((col (flycheck-ert-erlang-shows-column 'erlang)))


### PR DESCRIPTION
Column numbers were added to warnings and errors. This breaks the
pattern matching for Erlang 24.0 and later. Column numbers are optional
in the pattern so that earlier versions of Erlang will still match
properly.

Fixes GitHub issue #1913.