### PR TITLE
Add support for pymarkdown for markdown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ New Features
   - [#2052]: Sass with Stylelint
   - [#2013]: Nix with ``statix``
   - [#1935]: Chef (Ruby) with ``cookstyle``
+  - [#1915]: Markdown with ``pymarkdown``
 
 - [#1873]: Add error explainer to ``perl-perlcritic``.
 - [#1875]: Add error-explainer to ``css-stylelint``.

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -840,6 +840,13 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. syntax-checker-config-file:: flycheck-markdown-mdl-style
 
+   .. syntax-checker:: markdown-pymarkdown
+
+      Check Markdown with `PyMarkdown
+      <https://pypi.org/project/pymarkdownlnt/>`_.
+
+      .. syntax-checker-config-file:: flycheck-markdown-pymarkdown-config
+
 .. supported-language:: Nix
 
    .. syntax-checker:: nix

--- a/flycheck.el
+++ b/flycheck.el
@@ -180,6 +180,7 @@
     lua
     markdown-markdownlint-cli
     markdown-mdl
+    markdown-pymarkdown
     nix
     nix-linter
     opam
@@ -11051,6 +11052,29 @@ See URL `https://github.com/markdownlint/markdownlint'."
   (lambda (errors)
     (flycheck-sanitize-errors
      (flycheck-remove-error-file-names "(stdin)" errors)))
+  :modes (markdown-mode gfm-mode))
+
+(flycheck-def-config-file-var flycheck-markdown-pymarkdown-config
+    markdown-pymarkdown nil
+  :package-version '(flycheck . "34"))
+
+(flycheck-define-checker markdown-pymarkdown
+  "Markdown checker using PyMarkdown.
+
+See URL `https://pypi.org/project/pymarkdownlnt/'."
+  :command ("pymarkdown"
+            (config-file "--config" flycheck-markdown-markdownlint-cli-config)
+            "scan"
+            source)
+  :error-patterns
+  ((error line-start
+          (file-name) ":" line
+          (? ":" column) ": " (id (one-or-more alnum))
+          ": " (message) line-end))
+  :error-filter
+  (lambda (errors)
+    (flycheck-sanitize-errors
+     (flycheck-remove-error-file-names "(string)" errors)))
   :modes (markdown-mode gfm-mode))
 
 (flycheck-define-checker nix

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4130,7 +4130,7 @@ Perhaps:
   ;; because Click, used by ProseLint, when running with python 3 will refuse to
   ;; work unless an Unicode locale is exported. See:
   ;; http://click.pocoo.org/5/python3/#python-3-surrogate-handling
-  (let ((flycheck-disabled-checkers '(markdown-markdownlint-cli markdown-mdl)))
+  (let ((flycheck-disabled-checkers '(markdown-markdownlint-cli markdown-mdl markdown-pymarkdown)))
     (flycheck-ert-with-env '(("LC_ALL" . nil))
       (flycheck-ert-should-syntax-check
        "language/text/text.txt" '(text-mode markdown-mode)
@@ -4424,7 +4424,7 @@ Perhaps:
        :id "MD009/no-trailing-spaces" :checker markdown-markdownlint-cli)))
 
 (flycheck-ert-def-checker-test markdown-mdl markdown nil
-  (let ((flycheck-disabled-checkers '(markdown-markdownlint-cli)))
+  (let ((flycheck-disabled-checkers '(markdown-markdownlint-cli markdown-pymarkdown)))
     (flycheck-ert-should-syntax-check
      "language/markdown.md" 'markdown-mode
      '(1 nil error "First header should be a top level header"
@@ -4433,6 +4433,19 @@ Perhaps:
          :id "MD012" :checker markdown-mdl)
      '(4 nil error "Trailing spaces"
          :id "MD009" :checker markdown-mdl))))
+
+(flycheck-ert-def-checker-test markdown-pymarkdown markdown nil
+  (let ((flycheck-disabled-checkers '(markdown-markdownlint-cli markdown-mdl)))
+    (flycheck-ert-should-syntax-check
+     "language/markdown.md" 'markdown-mode
+     '(1 nil error "Headings should be surrounded by blank lines. [Expected: 1; Actual: 2; Below] (blanks-around-headings,blanks-around-headers)"
+         :id "MD022" :checker markdown-pymarkdown)
+     '(1 nil error "First line in file should be a top level heading (first-line-heading,first-line-h1)"
+         :id "MD041" :checker markdown-pymarkdown)
+     '(3 nil error "Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)"
+         :id "MD012" :checker markdown-pymarkdown)
+     '(4 nil error "Trailing spaces [Expected: 0 or 2; Actual: 7] (no-trailing-spaces)"
+         :id "MD009" :checker markdown-pymarkdown))))
 
 (flycheck-ert-def-checker-test nix nix nil
   (flycheck-ert-should-syntax-check


### PR DESCRIPTION
Tests are untested and I noticed https://www.flycheck.org/en/latest/contributor/contributing.html#the-build-system only after working on this, so they might not be up to current standards here. I hope someone who knows what they're doing with the tests could beat them into shape here :)