### PR TITLE
isolate the snippet of source code used in formatted error messages

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3864,6 +3864,14 @@ most.  It defaults to 20."
            "\\s-+" " " (buffer-substring beg (min end (point-max))))
           (or max-length 20) nil nil t))))))
 
+;; use isolates and direction markers to make it less likely for text
+;; taken from the source to render the error message unreable
+;; (sdrawkcab).
+(defconst flycheck--format-snippet
+  (concat "`\N{LEFT-TO-RIGHT MARK}\N{FIRST STRONG ISOLATE}"
+          "%s\N{POP DIRECTIONAL ISOLATE}\N{LEFT-TO-RIGHT MARK}': ")
+  "Format string to use on a snippet of source code related to the error.")
+
 (defun flycheck-error-format-message-and-id (err &optional include-snippet)
   "Format the message and id of ERR as human-readable string.
 
@@ -3877,7 +3885,7 @@ beginning position)."
     (concat (and other-file-p (format "In %S:\n" (file-relative-name fname)))
             (and include-snippet
                  (-when-let* ((snippet (flycheck-error-format-snippet err)))
-                   (flycheck--format-message "`%s': " snippet)))
+                   (flycheck--format-message flycheck--format-snippet snippet)))
             (or (flycheck-error-message err)
                 (format "Unknown %S" (flycheck-error-level err)))
             (and id (format " [%s]" id)))))


### PR DESCRIPTION
lest bidi formatting characters cause the error message to be rendered
sdrawkcab. In principle we should probably do this to the filename and
even the error message, since those could be suspect as well. As
ordinary RTL text doesn’t cause any problem, it is in practice not so
important. Note also that if flycheck is to be localized, this format
string must be localized as well (or the localization system must
support such substitutions directly).

Fixes #1919.