### PR TITLE
Add remote support

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -508,6 +508,11 @@ sandboxes."
   :risky t)
 
 (defun file-local-name-pass-nil (file)
+  "Return the local name component of FILE.
+This function is a wrapper for `file-local-name' function.
+if `file-local-name' is available, this function invokes it only if
+FILE is not nil.
+If FILEL is nil or `file-local-name' is not available, returns FILE."
   (if (fboundp 'file-local-name)
       (and file (file-local-name file))
     file))

--- a/flycheck.el
+++ b/flycheck.el
@@ -1468,11 +1468,11 @@ Return t if CHECKER does not use temporary files."
   "Save buffer to temp file returned by TEMP-FILE-FN.
 
 Return the name of the temporary file."
-  (let ((filename (funcall temp-file-fn (buffer-file-local-name))))
+  (let ((filename (funcall temp-file-fn (buffer-file-name))))
     ;; Do not flush short-lived temporary files onto disk
     (let ((write-region-inhibit-fsync t))
       (flycheck-save-buffer-to-file filename))
-    filename))
+    (file-local-name filename)))
 
 (defun flycheck-prepend-with-option (option items &optional prepend-fn)
   "Prepend OPTION to each item in ITEMS, using PREPEND-FN.

--- a/flycheck.el
+++ b/flycheck.el
@@ -8273,7 +8273,8 @@ See URL `http://stylelint.io/'."
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc)
             "--stdin-filename" (eval (or (buffer-file-local-name)
-                                         "style.css")))
+                                         "style.css"))
+            source)
   :standard-input t
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
@@ -9928,7 +9929,8 @@ See URL `http://stylelint.io/'."
             (eval flycheck-stylelint-args)
             "--syntax" "less"
             (option-flag "--quiet" flycheck-stylelint-quiet)
-            (config-file "--config" flycheck-stylelintrc))
+            (config-file "--config" flycheck-stylelintrc)
+            source)
   :standard-input t
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
@@ -11846,7 +11848,8 @@ See URL `http://stylelint.io/'."
             (eval flycheck-stylelint-args)
             "--syntax" "scss"
             (option-flag "--quiet" flycheck-stylelint-quiet)
-            (config-file "--config" flycheck-stylelintrc))
+            (config-file "--config" flycheck-stylelintrc)
+            source)
   :standard-input t
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p

--- a/flycheck.el
+++ b/flycheck.el
@@ -7336,7 +7336,7 @@ set, since checkers often omit redundant end lines (as in
          :checker checker
          :filename (if (or (null filename) (string-empty-p filename))
                        (buffer-file-local-name)
-                     filename)
+                     (file-local-name filename))
          :end-line (or end-line (and end-column line))
          :end-column end-column)))))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -516,6 +516,11 @@ sandboxes."
     args))
 (advice-add 'executable-find :filter-args 'executable-find-add-remote)
 
+(defun buffer-file-local-name (&optional buffer)
+  "Return the local file-name of the current buffer or BUFFER when specified."
+  (let ((file-name (buffer-file-name (or buffer (current-buffer)))))
+    (when file-name (file-local-name file-name))))
+
 (defun flycheck-default-executable-find (executable)
   "Resolve EXECUTABLE to a full path.
 
@@ -1462,7 +1467,7 @@ Return t if CHECKER does not use temporary files."
   "Save buffer to temp file returned by TEMP-FILE-FN.
 
 Return the name of the temporary file."
-  (let ((filename (funcall temp-file-fn (buffer-file-name))))
+  (let ((filename (funcall temp-file-fn (buffer-file-local-name))))
     ;; Do not flush short-lived temporary files onto disk
     (let ((write-region-inhibit-fsync t))
       (flycheck-save-buffer-to-file filename))
@@ -1630,7 +1635,7 @@ Return nil, if the currently loaded file cannot be determined."
   (-when-let* ((this-file (cond
                            (load-in-progress load-file-name)
                            ((bound-and-true-p byte-compile-current-file))
-                           (t (buffer-file-name))))
+                           (t (buffer-file-local-name))))
                ;; A best guess for the source file of a compiled library. Works
                ;; well in most cases, and especially for ELPA packages
                (source-file (concat (file-name-sans-extension this-file)
@@ -1654,7 +1659,7 @@ along each part of MODULE.
 If the MODULE name does not match the directory hierarchy upwards
 from FILE-NAME, return the directory containing FILE-NAME.  When
 FILE-NAME is nil, return `default-directory'."
-  (let ((file-name (or file-name (buffer-file-name)))
+  (let ((file-name (or file-name (buffer-file-local-name)))
         (module-components (if (stringp module)
                                (split-string module (rx "."))
                              (copy-sequence module))))
@@ -2677,7 +2682,7 @@ is applicable from Emacs Lisp code.  Use
 
   ;; Save the buffer to make sure that all predicates are good
   ;; FIXME: this may be surprising to users, with unintended side-effects.
-  (when (and (buffer-file-name) (buffer-modified-p))
+  (when (and (buffer-file-local-name) (buffer-modified-p))
     (save-buffer))
 
   (let ((buffer (current-buffer)))
@@ -2705,7 +2710,7 @@ possible problems are shown."
   (interactive)
   ;; Save to make sure checkers that only work on saved buffers will pass the
   ;; verification
-  (when (and (buffer-file-name) (buffer-modified-p))
+  (when (and (buffer-file-local-name) (buffer-modified-p))
     (save-buffer))
 
   (let* ((buffer (current-buffer))
@@ -2791,7 +2796,7 @@ current buffer as BUFFER.
 
 Return non-nil if the BUFFER is backed by a file, and not
 modified, or nil otherwise."
-  (let ((file-name (buffer-file-name buffer)))
+  (let ((file-name (buffer-file-local-name buffer)))
     (and file-name (file-exists-p file-name) (not (buffer-modified-p buffer)))))
 
 
@@ -3632,14 +3637,14 @@ non-nil, then only do this and skip per-buffer teardown.)"
                  column
                  &optional level message
                  &key end-line end-column checker id group
-                 (filename (buffer-file-name)) (buffer (current-buffer))
+                 (filename (buffer-file-local-name)) (buffer (current-buffer))
                  &aux (-end-line end-line) (-end-column end-column)))
                (:constructor
                 flycheck-error-new-at-pos
                 (pos
                  &optional level message
                  &key end-pos checker id group
-                 (filename (buffer-file-name)) (buffer (current-buffer))
+                 (filename (buffer-file-local-name)) (buffer (current-buffer))
                  &aux
                  ((line . column)
                   (if pos (flycheck-line-column-at-pos pos)
@@ -3882,7 +3887,8 @@ determined if the error contains a full span, not just a
 beginning position)."
   (let* ((id (flycheck-error-id err))
          (fname (flycheck-error-filename err))
-         (other-file-p (and fname (not (equal fname (buffer-file-name))))))
+         (other-file-p (and fname
+                            (not (equal fname (buffer-file-local-name))))))
     (concat (and other-file-p (format "In %S:\n" (file-relative-name fname)))
             (and include-snippet
                  (-when-let* ((snippet (flycheck-error-format-snippet err)))
@@ -4009,7 +4015,7 @@ Return ERRORS, modified in-place."
             (setf (flycheck-error-filename err)
                   (-if-let (filename (flycheck-error-filename err))
                       (expand-file-name filename directory)
-                    (buffer-file-name))))
+                    (buffer-file-local-name))))
           errors)
   errors)
 
@@ -6067,7 +6073,7 @@ are substituted within the body of cells!"
     (`(source-inplace ,suffix)
      (list (flycheck-save-buffer-to-temp
             (lambda (filename) (flycheck-temp-file-inplace filename suffix)))))
-    (`source-original (list (or (buffer-file-name) "")))
+    (`source-original (list (or (buffer-file-local-name) "")))
     (`temporary-directory (list (flycheck-temp-dir-system)))
     (`temporary-file-name
      (let ((directory (flycheck-temp-dir-system)))
@@ -6557,7 +6563,7 @@ directory of the current buffer and all ancestors thereof (see
 absolute path.  Otherwise return nil.
 
 _CHECKER is ignored."
-  (-when-let* ((basefile (buffer-file-name))
+  (-when-let* ((basefile (buffer-file-local-name))
                (directory (locate-dominating-file basefile filename)))
     (expand-file-name filename directory)))
 
@@ -6733,15 +6739,14 @@ shell execution."
     (if (flycheck-checker-get checker 'standard-input)
         ;; If the syntax checker expects the source from standard input add an
         ;; appropriate shell redirection
-        (concat command " < " (shell-quote-argument
-                               (file-local-name (buffer-file-name))))
+        (concat command " < " (shell-quote-argument (buffer-file-local-name)))
       command)))
 
 (defun flycheck-compile-name (_name)
   "Get a name for a Flycheck compilation buffer.
 
 _NAME is ignored."
-  (format "*Flycheck %s*" (buffer-file-name)))
+  (format "*Flycheck %s*" (buffer-file-local-name)))
 
 (defun flycheck-compile (checker)
   "Run CHECKER via `compile'.
@@ -6760,7 +6765,7 @@ tool, just like `compile' (\\[compile])."
                                   'command))))
   (unless (flycheck-valid-checker-p checker)
     (user-error "%S is not a valid syntax checker" checker))
-  (unless (buffer-file-name)
+  (unless (buffer-file-local-name)
     (user-error "Cannot compile a buffer without a backing file"))
   (unless (flycheck-may-use-checker checker)
     (user-error "Cannot use syntax checker %S in this buffer" checker))
@@ -7334,7 +7339,7 @@ set, since checkers often omit redundant end lines (as in
          :id (unless (string-empty-p id) id)
          :checker checker
          :filename (if (or (null filename) (string-empty-p filename))
-                       (buffer-file-name)
+                       (buffer-file-local-name)
                      filename)
          :end-line (or end-line (and end-column line))
          :end-column end-column)))))
@@ -7723,7 +7728,7 @@ explicitly determine the directory for quoted includes.
 
 This function determines the directory by looking at function
 `buffer-file-name', or if that is nil, at `default-directory'."
-  (-if-let (fn (buffer-file-name))
+  (-if-let (fn (buffer-file-local-name))
       (file-name-directory fn)
     ;; If the buffer has no file name, fall back to its default directory
     default-directory))
@@ -8201,7 +8206,7 @@ If the CHECKER throws an Error it returns an Error message with a stacktrace."
               :id (match-string 5 output)
               :checker checker
               :buffer buffer
-              :filename (buffer-file-name buffer)))))))
+              :filename (buffer-file-local-name buffer)))))))
 
 (defun flycheck-parse-stylelint-json (output checker buffer)
   "Parse stylelint JSON errors from OUTPUT.
@@ -8216,7 +8221,7 @@ about the JSON format of stylelint."
     ;; stylelint returns a vector of result objects
     ;; Since we only passed one file, the first element is enough
     (let* ((stylelint-output (elt (json-read-from-string output) 0))
-           (filename (buffer-file-name buffer))
+           (filename (buffer-file-local-name buffer))
 
            ;; Turn all deprecations into warnings
            (deprecations
@@ -8270,7 +8275,8 @@ See URL `http://stylelint.io/'."
             (eval flycheck-stylelint-args)
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc)
-            "--stdin-filename" (eval (or (buffer-file-name) "style.css")))
+            "--stdin-filename" (eval (or (buffer-file-local-name)
+                                         "style.css")))
   :standard-input t
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
@@ -8366,7 +8372,7 @@ See URL `https://www.commonwl.org/v1.0/SchemaSalad.html'."
 
 (defun flycheck-d-base-directory ()
   "Get the relative base directory path for this module."
-  (let* ((file-name (buffer-file-name))
+  (let* ((file-name (buffer-file-local-name))
          (module-file (if (and file-name
                                (string= (file-name-nondirectory file-name)
                                         "package.d"))
@@ -8639,8 +8645,8 @@ This variable has no effect, if
     (flycheck-autoloads-file-p)
     ;; Cask/Carton and dir-locals files contain data, not code, and don't need
     ;; to follow Checkdoc conventions either.
-    (and (buffer-file-name)
-         (member (file-name-nondirectory (buffer-file-name))
+    (and (buffer-file-local-name)
+         (member (file-name-nondirectory (buffer-file-local-name))
                  '("Cask" "Carton" ".dir-locals.el" ".dir-locals-2.el"))))))
 
 (defun flycheck--emacs-lisp-checkdoc-enabled-p ()
@@ -8796,7 +8802,7 @@ the BUFFER that was checked respectively."
                :id .rule
                :checker checker
                :buffer buffer
-               :filename (buffer-file-name buffer))))
+               :filename (buffer-file-local-name buffer))))
           (cdr (car (car (flycheck-parse-json output))))))
 
 (flycheck-def-config-file-var flycheck-ember-template-lintrc
@@ -8849,7 +8855,7 @@ See URL `http://www.erlang.org/'."
   ((warning line-start (file-name) ":" line ": Warning:" (message) line-end)
    (error line-start (file-name) ":" line ": " (message) line-end))
   :modes erlang-mode
-  :enabled (lambda () (string-suffix-p ".erl" (buffer-file-name))))
+  :enabled (lambda () (string-suffix-p ".erl" (buffer-file-local-name))))
 
 (defun flycheck--contains-rebar-config (dir-name)
   "Return DIR-NAME if rebar config file exists in DIR-NAME, nil otherwise."
@@ -9220,7 +9226,8 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
   :modes go-mode
   :predicate (lambda ()
                (and (flycheck-buffer-saved-p)
-                    (not (string-suffix-p "_test.go" (buffer-file-name)))))
+                    (not (string-suffix-p "_test.go"
+                                          (buffer-file-local-name)))))
   :next-checkers ((warning . go-errcheck)
                   (warning . go-unconvert)
                   (warning . go-staticcheck)))
@@ -9242,7 +9249,7 @@ Requires Go 1.6 or newer.  See URL `https://golang.org/cmd/go'."
   :modes go-mode
   :predicate
   (lambda () (and (flycheck-buffer-saved-p)
-                  (string-suffix-p "_test.go" (buffer-file-name))))
+                  (string-suffix-p "_test.go" (buffer-file-local-name))))
   :next-checkers ((warning . go-errcheck)
                   (warning . go-unconvert)
                   (warning . go-staticcheck)))
@@ -9352,8 +9359,8 @@ See URL `http://handlebarsjs.com/'."
         ;; non-canonical engine name
         (let* ((regexp-alist (bound-and-true-p web-mode-engine-file-regexps))
                (pattern (cdr (assoc "handlebars" regexp-alist))))
-          (and pattern (buffer-file-name)
-               (string-match-p pattern (buffer-file-name))))
+          (and pattern (buffer-file-local-name)
+               (string-match-p pattern (buffer-file-local-name))))
       t)))
 
 (defconst flycheck-haskell-module-re
@@ -9454,9 +9461,9 @@ containing a file that matches REGEXP."
 Return a parent directory with a stack*.y[a]ml file, or the
 directory returned by \"stack path --project-root\"."
   (or
-   (when (buffer-file-name)
+   (when (buffer-file-local-name)
      (flycheck--locate-dominating-file-matching
-      (file-name-directory (buffer-file-name))
+      (file-name-directory (buffer-file-local-name))
       (rx "stack" (* any) "." (or "yml" "yaml") eos)))
    (-when-let* ((stack (funcall flycheck-executable-find "stack"))
                 (output (ignore-errors
@@ -9468,9 +9475,9 @@ directory returned by \"stack path --project-root\"."
 
 (defun flycheck-haskell--ghc-find-default-directory (_checker)
   "Find a parent directory containing a cabal or package.yaml file."
-  (when (buffer-file-name)
+  (when (buffer-file-local-name)
     (flycheck--locate-dominating-file-matching
-     (file-name-directory (buffer-file-name))
+     (file-name-directory (buffer-file-local-name))
      "\\.cabal\\'\\|\\`package\\.yaml\\'")))
 
 (flycheck-define-checker haskell-stack-ghc
@@ -9749,7 +9756,7 @@ See URL `https://eslint.org' for more information about ESLint."
                :id .ruleId
                :checker checker
                :buffer buffer
-               :filename (buffer-file-name buffer)
+               :filename (buffer-file-local-name buffer)
                :end-line .endLine
                :end-column .endColumn)))
           (let-alist (caar (flycheck-parse-json output))
@@ -10189,8 +10196,8 @@ See URL `http://pear.php.net/package/PHP_CodeSniffer/'."
             ;; Pass original file name to phpcs.  We need to concat explicitly
             ;; here, because phpcs really insists to get option and argument as
             ;; a single command line argument :|
-            (eval (when (buffer-file-name)
-                    (concat "--stdin-path=" (buffer-file-name))))
+            (eval (when (buffer-file-local-name)
+                    (concat "--stdin-path=" (buffer-file-local-name))))
             ;; Read from standard input
             "-")
   :standard-input t
@@ -10211,7 +10218,8 @@ See https://github.com/processing/processing/wiki/Command-Line"
   :command ("processing-java" "--force"
             ;; Don't change the order of these arguments, processing is pretty
             ;; picky
-            (eval (concat "--sketch=" (file-name-directory (buffer-file-name))))
+            (eval (concat "--sketch=" (file-name-directory
+                                       (buffer-file-local-name))))
             (eval (concat "--output=" (flycheck-temp-dir-system)))
             "--build")
   :error-patterns
@@ -10219,7 +10227,7 @@ See https://github.com/processing/processing/wiki/Command-Line"
           (zero-or-more (or digit ":")) (message) line-end))
   :modes processing-mode
   ;; This syntax checker needs a file name
-  :predicate (lambda () (buffer-file-name)))
+  :predicate (lambda () (buffer-file-local-name)))
 
 (defun flycheck-proselint-parse-errors (output checker buffer)
   "Parse proselint json output errors from OUTPUT.
@@ -10274,7 +10282,7 @@ See URL `https://developers.google.com/protocol-buffers/'."
             (eval (concat "--java_out=" (flycheck-temp-dir-system)))
             ;; Add the current directory to resolve imports
             (eval (concat "--proto_path="
-                          (file-name-directory (buffer-file-name))))
+                          (file-name-directory (buffer-file-local-name))))
             ;; Add other import paths; this needs to be after the current
             ;; directory to produce the right output.  See URL
             ;; `https://github.com/flycheck/flycheck/pull/1655'
@@ -10289,7 +10297,7 @@ See URL `https://developers.google.com/protocol-buffers/'."
           (message "In file included from") " " (file-name) ":" line ":"
           column ":" line-end))
   :modes protobuf-mode
-  :predicate (lambda () (buffer-file-name)))
+  :predicate (lambda () (buffer-file-local-name)))
 
 (defun flycheck-prototool-project-root (&optional _checker)
   "Return the nearest directory holding the prototool.yaml configuration."
@@ -10311,7 +10319,7 @@ See URL `https://github.com/uber/prototool'."
   "A Pug syntax checker using the pug compiler.
 
 See URL `https://pugjs.org/'."
-  :command ("pug" "-p" (eval (expand-file-name (buffer-file-name))))
+  :command ("pug" "-p" (eval (expand-file-name (buffer-file-local-name))))
   :standard-input t
   :error-patterns
   ;; errors with includes/extends (e.g. missing files)
@@ -10719,7 +10727,7 @@ the BUFFER that was checked respectively."
         :end-column (+ 1 .range.end.character)
         :checker checker
         :buffer buffer
-        :filename (buffer-file-name buffer))))
+        :filename (buffer-file-local-name buffer))))
    (cdr (nth 2 (car (flycheck-parse-json output))))))
 
 (flycheck-define-checker python-pyright
@@ -11038,7 +11046,7 @@ information about nix-linter."
                :id .offense
                :checker checker
                :buffer buffer
-               :filename (buffer-file-name buffer)
+               :filename (buffer-file-local-name buffer)
                :end-line .pos.spanEnd.sourceLine
                :end-column .pos.spanEnd.sourceColumn)))
           (flycheck-parse-json output)))
@@ -11062,7 +11070,7 @@ See URL `https://github.com/Synthetica9/nix-linter'."
 
 Return the source directory, or nil, if the current buffer is not
 part of a Sphinx project."
-  (-when-let* ((filename (buffer-file-name))
+  (-when-let* ((filename (buffer-file-local-name))
                (dir (locate-dominating-file filename "conf.py")))
     (expand-file-name dir)))
 
@@ -11791,7 +11799,7 @@ missing checkstyle reporter from SCSS-Lint."
 Please run gem install scss_lint_reporter_checkstyle"
              :checker checker
              :buffer buffer
-             :filename (buffer-file-name buffer)))
+             :filename (buffer-file-local-name buffer)))
     (flycheck-parse-checkstyle output checker buffer)))
 
 (flycheck-def-config-file-var flycheck-scss-lintrc scss-lint ".scss-lint.yml"
@@ -12135,7 +12143,7 @@ information about tflint."
                :id .rule.name
                :checker checker
                :buffer buffer
-               :filename (buffer-file-name buffer))))
+               :filename (buffer-file-local-name buffer))))
           (cdr (assq 'issues (car (flycheck-parse-json output))))))
 
 (flycheck-define-checker terraform-tflint

--- a/flycheck.el
+++ b/flycheck.el
@@ -522,7 +522,7 @@ sandboxes."
 (defun buffer-file-local-name (&optional buffer)
   "Return the local file-name of the current buffer or BUFFER when specified."
   (let ((file-name (buffer-file-name (or buffer (current-buffer)))))
-    (when file-name (file-local-name file-name))))
+    (when file-name (file-local-name-pass-nil file-name))))
 
 (defun flycheck-default-executable-find (executable)
   "Resolve EXECUTABLE to a full path.
@@ -1475,7 +1475,7 @@ Return the name of the temporary file."
     ;; Do not flush short-lived temporary files onto disk
     (let ((write-region-inhibit-fsync t))
       (flycheck-save-buffer-to-file filename))
-    (file-local-name filename)))
+    (file-local-name-pass-nil filename)))
 
 (defun flycheck-prepend-with-option (option items &optional prepend-fn)
   "Prepend OPTION to each item in ITEMS, using PREPEND-FN.
@@ -4018,7 +4018,8 @@ Return ERRORS, modified in-place."
   (seq-do (lambda (err)
             (setf (flycheck-error-filename err)
                   (-if-let (filename (flycheck-error-filename err))
-                      (file-local-name (expand-file-name filename directory))
+                      (file-local-name-pass-nil
+                       (expand-file-name filename directory))
                     (buffer-file-local-name))))
           errors)
   errors)
@@ -6065,28 +6066,34 @@ are substituted within the body of cells!"
   (pcase arg
     ((pred stringp) (list arg))
     (`source
-     (list (file-local-name (flycheck-save-buffer-to-temp #'flycheck-temp-file-system))))
+     (list (file-local-name-pass-nil
+            (flycheck-save-buffer-to-temp #'flycheck-temp-file-system))))
     (`source-inplace
      (list (flycheck-save-buffer-to-temp #'flycheck-temp-file-inplace)))
     (`(source ,suffix)
      (list (flycheck-save-buffer-to-temp
-            (lambda (filename) (file-local-name (flycheck-temp-file-system filename suffix))))))
+            (lambda (filename) (file-local-name-pass-nil
+                                (flycheck-temp-file-system filename suffix))))))
     (`(source-inplace ,suffix)
      (list (flycheck-save-buffer-to-temp
             (lambda (filename) (flycheck-temp-file-inplace filename suffix)))))
     (`source-original (list (or (buffer-file-local-name) "")))
-    (`temporary-directory (list (file-local-name (flycheck-temp-dir-system))))
+    (`temporary-directory
+     (list (file-local-name-pass-nil (flycheck-temp-dir-system))))
     (`temporary-file-name
      (let ((directory (flycheck-temp-dir-system)))
-       (list (file-local-name (make-temp-name (expand-file-name "flycheck" directory))))))
+       (list (file-local-name-pass-nil
+              (make-temp-name (expand-file-name "flycheck" directory))))))
     (`null-device (list null-device))
     (`(config-file ,option-name ,file-name-var)
      (-when-let* ((value (symbol-value file-name-var))
-                  (file-name (file-local-name (flycheck-locate-config-file value checker))))
+                  (file-name (file-local-name-pass-nil
+                              (flycheck-locate-config-file value checker))))
        (flycheck-prepend-with-option option-name (list file-name))))
     (`(config-file ,option-name ,file-name-var ,prepend-fn)
      (-when-let* ((value (symbol-value file-name-var))
-                  (file-name (file-local-name (flycheck-locate-config-file value checker))))
+                  (file-name (file-local-name-pass-nil
+                              (flycheck-locate-config-file value checker))))
        (flycheck-prepend-with-option option-name (list file-name) prepend-fn)))
     (`(option ,option-name ,variable)
      (-when-let (value (symbol-value variable))
@@ -7340,7 +7347,7 @@ set, since checkers often omit redundant end lines (as in
          :checker checker
          :filename (if (or (null filename) (string-empty-p filename))
                        (buffer-file-local-name)
-                     (file-local-name filename))
+                     (file-local-name-pass-nil filename))
          :end-line (or end-line (and end-column line))
          :end-column end-column)))))
 
@@ -10222,7 +10229,8 @@ See https://github.com/processing/processing/wiki/Command-Line"
             ;; picky
             (eval (concat "--sketch=" (file-name-directory
                                        (buffer-file-local-name))))
-            (eval (concat "--output=" (file-local-name (flycheck-temp-dir-system))))
+            (eval (concat "--output=" (file-local-name-pass-nil
+                                       (flycheck-temp-dir-system))))
             "--build")
   :error-patterns
   ((error line-start (file-name) ":" line ":" column
@@ -10281,7 +10289,8 @@ are relative to the file being checked."
 
 See URL `https://developers.google.com/protocol-buffers/'."
   :command ("protoc" "--error_format" "gcc"
-            (eval (concat "--java_out=" (file-local-name (flycheck-temp-dir-system))))
+            (eval (concat "--java_out=" (file-local-name-pass-nil
+                                         (flycheck-temp-dir-system))))
             ;; Add the current directory to resolve imports
             (eval (concat "--proto_path="
                           (file-name-directory (buffer-file-local-name))))

--- a/flycheck.el
+++ b/flycheck.el
@@ -1388,7 +1388,8 @@ Use `flycheck-temp-prefix' as prefix, and add the directory to
 `flycheck-temporaries'.
 
 Return the path of the directory"
-  (let* ((tempdir (make-temp-file flycheck-temp-prefix 'directory)))
+  (let* ((temporary-file-directory (temporary-file-directory))
+         (tempdir (make-temp-file flycheck-temp-prefix 'directory)))
     (push tempdir flycheck-temporaries)
     tempdir))
 
@@ -6061,20 +6062,20 @@ are substituted within the body of cells!"
   (pcase arg
     ((pred stringp) (list arg))
     (`source
-     (list (flycheck-save-buffer-to-temp #'flycheck-temp-file-system)))
+     (list (file-local-name (flycheck-save-buffer-to-temp #'flycheck-temp-file-system))))
     (`source-inplace
      (list (flycheck-save-buffer-to-temp #'flycheck-temp-file-inplace)))
     (`(source ,suffix)
      (list (flycheck-save-buffer-to-temp
-            (lambda (filename) (flycheck-temp-file-system filename suffix)))))
+            (lambda (filename) (file-local-name (flycheck-temp-file-system filename suffix))))))
     (`(source-inplace ,suffix)
      (list (flycheck-save-buffer-to-temp
             (lambda (filename) (flycheck-temp-file-inplace filename suffix)))))
     (`source-original (list (or (buffer-file-local-name) "")))
-    (`temporary-directory (list (flycheck-temp-dir-system)))
+    (`temporary-directory (list (file-local-name (flycheck-temp-dir-system))))
     (`temporary-file-name
      (let ((directory (flycheck-temp-dir-system)))
-       (list (make-temp-name (expand-file-name "flycheck" directory)))))
+       (list (file-local-name (make-temp-name (expand-file-name "flycheck" directory))))))
     (`null-device (list null-device))
     (`(config-file ,option-name ,file-name-var)
      (-when-let* ((value (symbol-value file-name-var))
@@ -10215,7 +10216,7 @@ See https://github.com/processing/processing/wiki/Command-Line"
             ;; picky
             (eval (concat "--sketch=" (file-name-directory
                                        (buffer-file-local-name))))
-            (eval (concat "--output=" (flycheck-temp-dir-system)))
+            (eval (concat "--output=" (file-local-name (flycheck-temp-dir-system))))
             "--build")
   :error-patterns
   ((error line-start (file-name) ":" line ":" column
@@ -10274,7 +10275,7 @@ are relative to the file being checked."
 
 See URL `https://developers.google.com/protocol-buffers/'."
   :command ("protoc" "--error_format" "gcc"
-            (eval (concat "--java_out=" (flycheck-temp-dir-system)))
+            (eval (concat "--java_out=" (file-local-name (flycheck-temp-dir-system))))
             ;; Add the current directory to resolve imports
             (eval (concat "--proto_path="
                           (file-name-directory (buffer-file-local-name))))

--- a/flycheck.el
+++ b/flycheck.el
@@ -507,6 +507,9 @@ sandboxes."
   :package-version '(flycheck . "32")
   :risky t)
 
+(defun file-local-name-pass-nil (file)
+  (and file (file-local-name file)))
+
 ;; This can be removed when Emacs 27.1 is the oldest supported version.
 ;; See https://github.com/flycheck/flycheck/pull/1842
 (defun executable-find-add-remote (args)

--- a/flycheck.el
+++ b/flycheck.el
@@ -4015,7 +4015,7 @@ Return ERRORS, modified in-place."
   (seq-do (lambda (err)
             (setf (flycheck-error-filename err)
                   (-if-let (filename (flycheck-error-filename err))
-                      (expand-file-name filename directory)
+                      (file-local-name (expand-file-name filename directory))
                     (buffer-file-local-name))))
           errors)
   errors)

--- a/flycheck.el
+++ b/flycheck.el
@@ -4025,7 +4025,7 @@ Return ERRORS, modified in-place."
     (and file-name
          flycheck-relevant-error-other-file-show
          (or (null buffer-file-name)
-             (not (flycheck-same-files-p buffer-file-name file-name)))
+             (not (flycheck-same-files-p (buffer-file-local-name) file-name)))
          (<= (flycheck-error-level-severity
               flycheck-relevant-error-other-file-minimum-level)
              (flycheck-error-level-severity (flycheck-error-level err))))))
@@ -4044,7 +4044,7 @@ otherwise."
         (and (not file-name) (not buffer-file-name))
         ;; Both have files, and they match
         (and buffer-file-name file-name
-             (flycheck-same-files-p file-name buffer-file-name))
+             (flycheck-same-files-p file-name (buffer-file-local-name)))
         ;; This is a significant error from another file
         (flycheck-relevant-error-other-file-p err))
        message
@@ -5309,7 +5309,9 @@ POS defaults to `point'."
   (let* ((error-copy (copy-flycheck-error error))
          (filename (flycheck-error-filename error))
          (other-file-error (flycheck-relevant-error-other-file-p error))
-         (buffer (if filename
+         (remote (file-remote-p (buffer-file-name
+                                 (flycheck-error-buffer error))))
+         (buffer (if (and filename (not remote))
                      (find-file-noselect filename)
                    (flycheck-error-buffer error))))
     (when (buffer-live-p buffer)
@@ -9734,7 +9736,7 @@ for more information about the custom directories."
   "Whether there is a valid eslint config for the current buffer."
   (eql 0 (flycheck-call-checker-process
           'javascript-eslint nil nil nil
-          "--print-config" (or buffer-file-name "index.js"))))
+          "--print-config" (or (buffer-file-local-name) "index.js"))))
 
 (defun flycheck-parse-eslint (output checker buffer)
   "Parse ESLint errors/warnings from JSON OUTPUT.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6079,11 +6079,11 @@ are substituted within the body of cells!"
     (`null-device (list null-device))
     (`(config-file ,option-name ,file-name-var)
      (-when-let* ((value (symbol-value file-name-var))
-                  (file-name (flycheck-locate-config-file value checker)))
+                  (file-name (file-local-name (flycheck-locate-config-file value checker))))
        (flycheck-prepend-with-option option-name (list file-name))))
     (`(config-file ,option-name ,file-name-var ,prepend-fn)
      (-when-let* ((value (symbol-value file-name-var))
-                  (file-name (flycheck-locate-config-file value checker)))
+                  (file-name (file-local-name (flycheck-locate-config-file value checker))))
        (flycheck-prepend-with-option option-name (list file-name) prepend-fn)))
     (`(option ,option-name ,variable)
      (-when-let (value (symbol-value variable))
@@ -6559,7 +6559,7 @@ directory of the current buffer and all ancestors thereof (see
 absolute path.  Otherwise return nil.
 
 _CHECKER is ignored."
-  (-when-let* ((basefile (buffer-file-local-name))
+  (-when-let* ((basefile (buffer-file-name))
                (directory (locate-dominating-file basefile filename)))
     (expand-file-name filename directory)))
 
@@ -6568,7 +6568,8 @@ _CHECKER is ignored."
 
 Return the absolute path, if FILENAME exists in the user's home
 directory, or nil otherwise."
-  (let ((path (expand-file-name filename "~")))
+  (let* ((home (or (file-remote-p (buffer-file-name)) "~"))
+         (path (expand-file-name filename home)))
     (when (file-exists-p path)
       path)))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -6578,7 +6578,8 @@ _CHECKER is ignored."
 
 Return the absolute path, if FILENAME exists in the user's home
 directory, or nil otherwise."
-  (let* ((home (or (file-remote-p (buffer-file-name)) "~"))
+  (let* ((home (or (and (buffer-file-name) (file-remote-p (buffer-file-name)))
+                   "~"))
          (path (expand-file-name filename home)))
     (when (file-exists-p path)
       path)))

--- a/flycheck.el
+++ b/flycheck.el
@@ -5898,18 +5898,13 @@ Return nil (or raise an error if ERROR is non-nil) when CHECKER's
 executable cannot be found, and return a numeric exit status or a
 signal description string otherwise.  CHECKER's input is taken
 from INFILE, and its output is sent to DESTINATION, as in
-`start-file-process'."
+`call-process'."
   (-if-let (executable (flycheck-find-checker-executable checker))
       (condition-case err
-          ;; `start-file-process' runs synchronously, like `call-process',
-          ;; when let bound.`start-file-process' is required to support remote
-          ;; processes. See https://github.com/flycheck/flycheck/pull/1842
-          (let ((rc (apply #'start-file-process
-                           executable infile destination nil args)))
-            rc)
+          (apply #'process-file executable infile destination nil args)
         (error (when error (signal (car err) (cdr err)))))
     (when error
-      (user-error "Cannot find `%s' using `flycheck-find-checker-executable'"
+      (user-error "Cannot find `%s' using `flycheck-executable-find'"
                   (flycheck-checker-executable checker)))))
 
 (defun flycheck-call-checker-process-for-output
@@ -6226,12 +6221,10 @@ and rely on Emacs' own buffering and chunking."
           ;; See https://github.com/flycheck/flycheck/issues/298 for an
           ;; example for such a conflict.
           ;;
-          ;; `start-file-process' runs synchronously, like `call-process',
-          ;; when let bound.`start-file-process' is required to support remote
-          ;; processes. See https://github.com/flycheck/flycheck/pull/1842
-          (let ((rc (apply 'start-file-process
-                           (format "flycheck-%s" checker) nil command)))
-            (setq process rc))
+          ;; Use `start-file-process' instead of `start-process' to run the
+          ;; process in a remote directory.
+          (setq process (apply 'start-file-process
+                               (format "flycheck-%s" checker) nil command))
           ;; Process sentinels can be called while sending input to the process.
           ;; We want to record errors raised by process-send before calling
           ;; `flycheck-handle-signal', so initially just accumulate events.

--- a/flycheck.el
+++ b/flycheck.el
@@ -508,7 +508,9 @@ sandboxes."
   :risky t)
 
 (defun file-local-name-pass-nil (file)
-  (and file (file-local-name file)))
+  (if (fboundp 'file-local-name)
+      (and file (file-local-name file))
+    file))
 
 ;; This can be removed when Emacs 27.1 is the oldest supported version.
 ;; See https://github.com/flycheck/flycheck/pull/1842
@@ -1391,7 +1393,10 @@ Use `flycheck-temp-prefix' as prefix, and add the directory to
 `flycheck-temporaries'.
 
 Return the path of the directory"
-  (let* ((temporary-file-directory (temporary-file-directory))
+  (let* ((temporary-file-directory
+          (if (fboundp 'temporary-file-directory)
+              (temporary-file-directory)
+            temporary-file-directory))
          (tempdir (make-temp-file flycheck-temp-prefix 'directory)))
     (push tempdir flycheck-temporaries)
     tempdir))

--- a/flycheck.el
+++ b/flycheck.el
@@ -507,6 +507,15 @@ sandboxes."
   :package-version '(flycheck . "32")
   :risky t)
 
+;; This can be removed when Emacs 27.1 is the oldest supported version.
+;; See https://github.com/flycheck/flycheck/pull/1842
+(defun executable-find-add-remote (args)
+  "Add optional remote argument t to ARGS when supported."
+  (if (and (not (version< emacs-version "27.1")) (= (length args) 1))
+      (append args '(t))
+    args))
+(advice-add 'executable-find :filter-args 'executable-find-add-remote)
+
 (defun flycheck-default-executable-find (executable)
   "Resolve EXECUTABLE to a full path.
 
@@ -5881,13 +5890,18 @@ Return nil (or raise an error if ERROR is non-nil) when CHECKER's
 executable cannot be found, and return a numeric exit status or a
 signal description string otherwise.  CHECKER's input is taken
 from INFILE, and its output is sent to DESTINATION, as in
-`call-process'."
+`start-file-process'."
   (-if-let (executable (flycheck-find-checker-executable checker))
       (condition-case err
-          (apply #'call-process executable infile destination nil args)
+          ;; `start-file-process' runs synchronously, like `call-process',
+          ;; when let bound.`start-file-process' is required to support remote
+          ;; processes. See https://github.com/flycheck/flycheck/pull/1842
+          (let ((rc (apply #'start-file-process
+                           executable infile destination nil args)))
+            rc)
         (error (when error (signal (car err) (cdr err)))))
     (when error
-      (user-error "Cannot find `%s' using `flycheck-executable-find'"
+      (user-error "Cannot find `%s' using `flycheck-find-checker-executable'"
                   (flycheck-checker-executable checker)))))
 
 (defun flycheck-call-checker-process-for-output
@@ -6195,7 +6209,7 @@ and rely on Emacs' own buffering and chunking."
                ;; can easily use pipes.
                (process-connection-type nil))
           ;; We pass do not associate the process with any buffer, by
-          ;; passing nil for the BUFFER argument of `start-process'.
+          ;; passing nil for the BUFFER argument of `start-file-process'.
           ;; Instead, we just remember the buffer being checked in a
           ;; process property (see below).  This neatly avoids all
           ;; side-effects implied by attached a process to a buffer, which
@@ -6203,8 +6217,13 @@ and rely on Emacs' own buffering and chunking."
           ;;
           ;; See https://github.com/flycheck/flycheck/issues/298 for an
           ;; example for such a conflict.
-          (setq process (apply 'start-process (format "flycheck-%s" checker)
-                               nil command))
+          ;;
+          ;; `start-file-process' runs synchronously, like `call-process',
+          ;; when let bound.`start-file-process' is required to support remote
+          ;; processes. See https://github.com/flycheck/flycheck/pull/1842
+          (let ((rc (apply 'start-file-process
+                           (format "flycheck-%s" checker) nil command)))
+            (setq process rc))
           ;; Process sentinels can be called while sending input to the process.
           ;; We want to record errors raised by process-send before calling
           ;; `flycheck-handle-signal', so initially just accumulate events.
@@ -6705,22 +6724,17 @@ shell execution."
   (let* ((args (flycheck--checker-substituted-shell-command-arguments checker))
          (program
           (or (flycheck-find-checker-executable checker)
-              (user-error "Cannot find `%s' using `flycheck-executable-find'"
-                          (flycheck-checker-executable checker))))
+              (user-error
+               "Cannot find `%s' using `flycheck-find-checker-executable'"
+               (flycheck-checker-executable checker))))
          (wrapped (flycheck--wrap-command program args))
-         (abs-prog
-          ;; The executable path returned by `flycheck-command-wrapper-function'
-          ;; may not be absolute, so expand it here.  See URL
-          ;; `https://github.com/flycheck/flycheck/issues/1461'.
-          (or (executable-find (car wrapped))
-              (user-error "Cannot find `%s' using `executable-find'"
-                          (car wrapped))))
          (command (mapconcat #'shell-quote-argument
-                             (cons abs-prog (cdr wrapped)) " ")))
+                             (cons program (cdr wrapped)) " ")))
     (if (flycheck-checker-get checker 'standard-input)
         ;; If the syntax checker expects the source from standard input add an
         ;; appropriate shell redirection
-        (concat command " < " (shell-quote-argument (buffer-file-name)))
+        (concat command " < " (shell-quote-argument
+                               (file-local-name (buffer-file-name))))
       command)))
 
 (defun flycheck-compile-name (_name)


### PR DESCRIPTION
Add support for remote hosts via TRAMP.

In response to #1816,
based on #1842

Enable the following checkers to work on remote files:
- python-pycompile
- python-pylint
- python-flake8
- javascript-eslint
- scss-stylelint
- css-stylelint

Probably further additional changes may be necessary for some (or majority) of the others checkers.

Remote support works only with Emacs >=27.1.

One function is added: file-local-name-pass-nil.
It is not prefixed with "flycheck-" as with the other functions added in #1842.


Travis CI may pass with the following modification:
- Update ca-certificates
  Access to repository (and thus cask installation) fail.
  https://github.com/yfyyfy/flycheck/commit/09271d2afc29d4d6d7d192baae66cf421fcc29f9
- Omit bazel-mode
  Installation of bazel-mode by cask fails.
  https://github.com/yfyyfy/flycheck/commit/4dc94e240607e773e6900c929566b55c91394038
- Disable scheme-chicken test
  It prompts for "Scheme implementation" and fails in Travis CI.
  https://github.com/yfyyfy/flycheck/commit/9faddc00e15f78291eddda06b04cc79c5771d7c4

(The above references are the last three commits of https://github.com/yfyyfy/flycheck/tree/add-remote-support-tweak-test)
