### PR TITLE
Fix Buttercup tests on Emacs 28.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1,6 +1,6 @@
 ;;; flycheck.el --- On-the-fly syntax checking -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2017-2020 Flycheck contributors
+;; Copyright (C) 2017-2021 Flycheck contributors
 ;; Copyright (C) 2012-2016 Sebastian Wiesner and Flycheck contributors
 ;; Copyright (C) 2013, 2014 Free Software Foundation, Inc.
 ;;
@@ -8722,7 +8722,7 @@ See Info Node `(elisp)Byte Compilation'."
             (kill-buffer)))))))
 
 (defconst flycheck-emacs-lisp-checkdoc-variables
-  '(checkdoc-symbol-words
+  `(checkdoc-symbol-words
     checkdoc-arguments-in-order-flag
     checkdoc-force-history-flag
     checkdoc-permit-comma-termination-flag
@@ -8731,7 +8731,9 @@ See Info Node `(elisp)Byte Compilation'."
     checkdoc-spellcheck-documentation-flag
     checkdoc-verb-check-experimental-flag
     checkdoc-max-keyref-before-warn
-    sentence-end-double-space)
+    sentence-end-double-space
+    ,@(and (>= emacs-major-version 28)
+           '(checkdoc-column-zero-backslash-before-paren)))
   "Variables inherited by the checkdoc subprocess.")
 
 (defun flycheck-emacs-lisp-checkdoc-variables-form ()

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -1,6 +1,6 @@
 ;;; test-error-list.el --- Flycheck Specs: Error List  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2013-2016 Sebastian Wiesner and Flycheck contributors
+;; Copyright (C) 2013-2016, 2021 Sebastian Wiesner and Flycheck contributors
 
 ;; Author: Sebastian Wiesner <swiesner@lunaryorn.com>
 
@@ -68,7 +68,9 @@
     (it "has a local header line"
       (flycheck/with-error-list-buffer
         (expect header-line-format
-                :to-equal " File  Line Col Level ID Message (Checker) ")
+                :to-equal (if (< emacs-major-version 28)
+                              " File  Line Col Level ID Message (Checker) "
+                            " File Line ▼ Col Level ID Message (Checker) "))
         (expect 'header-line-format :to-be-local))))
 
   (describe "Columns"


### PR DESCRIPTION
- On Emacs 28, Checkdoc has a new customization option
  ‘checkdoc-column-zero-backslash-before-paren’.

- The header line format is slightly different.