### PR TITLE
Add support for library search paths, external variables to jsonnet

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9859,11 +9859,27 @@ See URL `https://stedolan.github.io/jq/'."
           (zero-or-more not-newline) line-end))
   :modes json-mode)
 
+(flycheck-def-option-var flycheck-jsonnet-library-search-paths nil jsonnet
+  "A list of directories to use as jsonnet library search paths."
+  :type '(repeat (directory :tag "Library search path"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "32"))
+
+(flycheck-def-option-var flycheck-jsonnet-external-code-files nil jsonnet
+  "A list of `var=file' mappings. The contents of `file' is
+assigned to the variable `var'."
+  :type '(repeat (directory :tag "var=file"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "32"))
+
 (flycheck-define-checker jsonnet
   "A Jsonnet syntax checker using the jsonnet binary.
 
 See URL `https://jsonnet.org'."
-  :command ("jsonnet" source-inplace)
+  :command ("jsonnet"
+            (option-list "-J" flycheck-jsonnet-library-search-paths)
+            (option-list "--ext-code-file" flycheck-jsonnet-external-code-files)
+            source-inplace)
   :error-patterns
   ((error line-start "STATIC ERROR: " (file-name) ":"
           (or (seq line ":" column (zero-or-one (seq "-" end-column)))


### PR DESCRIPTION
This PR adds two new options to the jsonnet checker, one for setting library search paths and one for setting external code files.

I was unable to get the integration tests to run (described in https://www.flycheck.org/en/latest/contributor/contributing.html), but have tested the changes locally.