### PR TITLE
Don't break python2 yet.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9829,7 +9829,7 @@ See URL `https://github.com/zaach/jsonlint'."
   "A JSON syntax checker using Python json.tool module.
 
 See URL `https://docs.python.org/3.5/library/json.html#command-line-interface'."
-  :command ("python3" "-m" "json.tool" source
+  :command ("python" "-m" "json.tool" source
             ;; Send the pretty-printed output to the null device
             null-device)
   :error-patterns
@@ -10564,7 +10564,7 @@ Requires Flake8 3.0 or newer. See URL
 `https://flake8.readthedocs.io/'."
   ;; Not calling flake8 directly makes it easier to switch between different
   ;; Python versions; see https://github.com/flycheck/flycheck/issues/1055.
-  :command ("python3"
+  :command ("python"
             (eval (flycheck-python-module-args 'python-flake8 "flake8"))
             "--format=default"
             (config-file "--append-config" flycheck-flake8rc)
@@ -10640,7 +10640,7 @@ See URL `https://www.pylint.org/'."
   ;; --reports=n disables the scoring report.
   ;; Not calling pylint directly makes it easier to switch between different
   ;; Python versions; see https://github.com/flycheck/flycheck/issues/1055.
-  :command ("python3"
+  :command ("python"
             (eval (flycheck-python-module-args 'python-pylint "pylint"))
             "--reports=n"
             "--output-format=json"
@@ -10669,7 +10669,7 @@ See URL `https://www.pylint.org/'."
   "A Python syntax checker using Python's builtin compiler.
 
 See URL `https://docs.python.org/3.4/library/py_compile.html'."
-  :command ("python3" "-m" "py_compile" source)
+  :command ("python" "-m" "py_compile" source)
   :error-patterns
   ;; Python 2.7
   ((error line-start "  File \"" (file-name) "\", line " line "\n"


### PR DESCRIPTION
Last commit to these lines changed the command from `python` to `python3`
because Python2 was EOL. And that's right, but it doesn't mean it is not used :)

Every major distribution still uses `python` to refer to whatever version it has
installed, either 3 or 2. Plus, pyenv shims do work with `python` to select
whatever the current version may be.

Also, whenever we get Python 4, I am sure `python` will point to it.