### PR TITLE
Linters should be stateless and efficient (fixing call to R linter)

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10779,14 +10779,14 @@ expression, which selects linters for lintr."
   "Whether CHECKER (R) has installed the `lintr' library."
   (eql 0 (flycheck-call-checker-process
           checker nil nil nil
-          "--slave" "--restore" "--no-save" "-e"
+          "--slave" "--no-restore" "--no-save" "-e"
           "library('lintr')")))
 
 (flycheck-define-checker r-lintr
   "An R style and syntax checker using the lintr package.
 
 See URL `https://github.com/jimhester/lintr'."
-  :command ("R" "--slave" "--restore" "--no-save" "-e"
+  :command ("R" "--slave" "--no-restore" "--no-save" "-e"
             (eval (concat
                    "library(lintr);"
                    "try(lint(commandArgs(TRUE)"


### PR DESCRIPTION
The call to R should respect `inferior-R-args` variable. If not, then at least please do not call the R slave session with `--restore`, which would try to load `./RData`, and depending on what `PWD` is, that could try to load gigabytes of workspace image into the lint, including variables and functions. That introduces unacceptable lag (every keystore requires over 10s of wait time whenever the linter is invoked then killed off, loading gigabytes of image). What's worse is that a linter should start stateless and thus be predictable; loading arbitrary images from a "current directory or from a default fallback location" is a very bad behavior for a linter.