### PR TITLE
fix(stylelint): stylelint v14 uses incompatible cli arguments

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10001,7 +10001,10 @@ See URL `http://lesscss.org'."
 See URL `http://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
-            "--syntax" "less"
+            (eval (when (< (flycheck-stylelint-get-major-version
+                            'less-stylelint)
+                           14)
+                    (list "--syntax" "less")))
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
@@ -11916,13 +11919,26 @@ See URL `https://github.com/brigade/scss-lint'."
                     '(bold error)
                   'success)))))))
 
+(defun flycheck-stylelint-get-major-version (checker)
+  "Return major version of stylelint."
+  (let ((cb (current-buffer)))
+    (with-temp-buffer
+      (let ((temp-buffer (current-buffer)))
+        (with-current-buffer cb
+          (flycheck-call-checker-process
+           checker nil temp-buffer nil "--version"))
+        (string-to-number (car (split-string (buffer-string) "\\.")))))))
+
 (flycheck-define-checker scss-stylelint
   "A SCSS syntax and style checker using stylelint.
 
 See URL `http://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
-            "--syntax" "scss"
+            (eval (when (< (flycheck-stylelint-get-major-version
+                            'scss-stylelint)
+                           14)
+                    (list "--syntax" "scss")))
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t

--- a/flycheck.el
+++ b/flycheck.el
@@ -8332,6 +8332,7 @@ See URL `http://stylelint.io/'."
             (config-file "--config" flycheck-stylelintrc)
             "--stdin-filename" (eval (or (buffer-file-name) "style.css")))
   :standard-input t
+  :verify (lambda (_) (flycheck-stylelint-verify 'css-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (css-mode css-ts-mode))
@@ -10008,6 +10009,7 @@ See URL `http://stylelint.io/'."
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
+  :verify (lambda (_) (flycheck-stylelint-verify 'less-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (less-css-mode))
@@ -11919,6 +11921,25 @@ See URL `https://github.com/brigade/scss-lint'."
                     '(bold error)
                   'success)))))))
 
+(defun flycheck-stylelint-config-exists-p (checker)
+  "Whether there is a valid stylelint config for the current buffer."
+  (eql 0 (flycheck-call-checker-process
+          checker nil nil nil
+          "--print-config" (or buffer-file-name "index.js"))))
+
+(defun flycheck-stylelint-verify (checker)
+  "Verify stylelint setup for CHECKER."
+  (let ((have-config (flycheck-stylelint-config-exists-p checker)))
+    (list
+     (flycheck-verification-result-new
+      :label "configuration available"
+      :message (if have-config "yes" "no config file found")
+      :face (if have-config 'success '(bold error)))
+     (flycheck-verification-result-new
+      :label "stylecheck version"
+      :message (number-to-string (flycheck-stylelint-get-major-version checker))
+      :face 'success))))
+
 (defun flycheck-stylelint-get-major-version (checker)
   "Return major version of stylelint."
   (let ((cb (current-buffer)))
@@ -11942,6 +11963,7 @@ See URL `http://stylelint.io/'."
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
+  :verify (lambda (_) (flycheck-stylelint-verify 'scss-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (scss-mode))


### PR DESCRIPTION
Detect the major version of stylelint, and for verion 14 don't pass
the --syntax argument.

Fixes #1912