### PR TITLE
Fix(lintr): make user-defined lintr-linters can be correctly passed to the R process.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10772,8 +10772,8 @@ disables caching in case there are problems."
 (flycheck-def-option-var flycheck-lintr-linters "default_linters" r-lintr
   "Linters to use with lintr.
 
-The value of this variable is a string containing an R
-expression, which selects linters for lintr."
+The value of this variable is a string which is the argument `linters = `
+passing to the lintr::lint() function,"
   :type 'string
   :risky t
   :package-version '(flycheck . "0.23"))
@@ -10794,7 +10794,7 @@ See URL `https://github.com/jimhester/lintr'."
                    "library(lintr);"
                    "try(lint(commandArgs(TRUE)"
                    ", cache=" (if flycheck-lintr-caching "TRUE" "FALSE")
-                   ", " flycheck-lintr-linters
+                   ", linters=" flycheck-lintr-linters
                    "))"))
             "--args" source)
   :error-patterns


### PR DESCRIPTION
if user directly calls

```elisp
(setq flycheck-lintr-linters
      "linters = with_defaults(line_length_linter=line_length_linter(200),commented_code_linter = NULL)")

```

with something like this in their config

in deed this will have no effect.

Explicitly specifying`"linters=" flycheck-lintr-linters` makes things changed