### PR TITLE
FIX: detect cargo sub-commands

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11433,9 +11433,12 @@ versions inferior to 1.25)."
   "Whether Cargo has COMMAND in its list of commands.
 
 Execute `cargo --list' to find out whether COMMAND is present."
-  (let ((cargo (funcall flycheck-executable-find "cargo")))
-    (member command (mapcar #'string-trim-left
-                            (ignore-errors (process-lines cargo "--list"))))))
+  (let ((cargo (funcall flycheck-executable-find "cargo"))
+        (sub-command-pat (rx (seq (zero-or-more space) (group (one-or-more (or ?- word)))))))
+    (member command (mapcar
+                     (lambda (str) (if (string-match sub-command-pat str) (match-string 1 str)))
+                     ;; skip `Installed Commands:` header
+                     (cdr (ignore-errors (process-lines cargo "--list")))))))
 
 (defun flycheck-rust-valid-crate-type-p (crate-type)
   "Whether CRATE-TYPE is a valid target type for Cargo.


### PR DESCRIPTION
Looks like ` flycheck-rust-cargo-has-command-p` was failed with current `cargo --list` output due to optional extra comments line per each sub-command. My output of `cargo --list` contains the following line:
```
    clippy               Checks a package to catch common mistakes and improve your Rust code.
```

  
  
Now it's fixed. Flycheck detects `clippy` and works correctly with `rust-clippy` checker.
<img width="878" alt="Screen Shot 2022-06-09 at 17 53 23" src="https://user-images.githubusercontent.com/3259009/172878852-3d6ba626-5f2d-48b5-82e9-a23297d49549.png">

