### PR TITLE
Add flycheck-python-mypy-python-executable

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1061,6 +1061,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Set to ``null-device`` to disable writing cache directories
          entirely.
 
+      .. defcustom:: flycheck-python-mypy-python-executable
+
+         Python executable to collect the type information from PEP 561
+         compliant packages.
+
    .. syntax-checker:: python-pylint
 
       Check syntax and lint with `Pylint <https://pylint.org/>`_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10828,6 +10828,13 @@ See URL https://github.com/microsoft/pyright."
   :safe #'flycheck-string-or-nil-p
   :package-version '(flycheck . "32"))
 
+(flycheck-def-option-var flycheck-python-mypy-python-executable nil python-mypy
+  "Python executable to find the installed PEP 561 packages."
+  :type '(choice (const :tag "Same as mypy's" nil)
+                 (string :tag "Path"))
+  :safe #'flycheck-string-or-nil-p
+  :package-version '(flycheck . "33"))
+
 (flycheck-define-checker python-mypy
   "Mypy syntax and type checker.  Requires mypy>=0.730.
 
@@ -10837,6 +10844,7 @@ See URL `http://mypy-lang.org/'."
             "--no-pretty"
             (config-file "--config-file" flycheck-python-mypy-config)
             (option "--cache-dir" flycheck-python-mypy-cache-dir)
+            (option "--python-executable" flycheck-python-mypy-python-executable)
             source-original)
   :error-patterns
   ((error line-start (file-name) ":" line (optional ":" column)


### PR DESCRIPTION
If mypy is installed globally in an isolated virtualenv, such is the case for `pre-commit` or `pipx` installed mypy, mypy will not be able to discover the installed packages in your project, even if working-directory is set, because the virtualenv for the project present in the working directory may very well be completely different.

Due to this complication, hardcoding `python_executable` in mypy's configuration is not feasible either, because it often needs to be discovered dynamically by invoking something like `poetry run which python`, so it needs to be supplied on the command line.

This PR allows users of flycheck to configure the python executable to perform mypy import discovery as they see fit.