### PR TITLE
Fix #1931 give hadolint the source

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8490,7 +8490,7 @@ Requires DMD 2.066 or newer.  See URL `https://dlang.org/'."
   "A Dockerfile syntax checker using the hadolint.
 
 See URL `http://github.com/hadolint/hadolint/'."
-  :command ("hadolint" "--no-color" "-")
+  :command ("hadolint" "--no-color" source)
   :standard-input t
   :error-patterns
   ((error line-start


### PR DESCRIPTION
Fix problem with hadolint checker not being able to send more than 1 error at a time if the source file is not supplied as a command line argument.