### PR TITLE
Fix dependency on bazel.el.

### DIFF
--- a/Cask
+++ b/Cask
@@ -12,7 +12,7 @@
 
  ;; Various modes for use in the unit tests
  (depends-on "adoc-mode")
- (depends-on "bazel-mode")
+ (depends-on "bazel")
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")
  (depends-on "cwl-mode")

--- a/Cask.24
+++ b/Cask.24
@@ -12,7 +12,7 @@
 
  ;; Various modes for use in the unit tests
  (depends-on "adoc-mode")
- ;; (depends-on "bazel-mode")      ; requires Emacs 26+
+ ;; (depends-on "bazel")      ; requires Emacs 27+
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")
  (depends-on "cwl-mode")

--- a/Cask.25
+++ b/Cask.25
@@ -12,7 +12,7 @@
 
  ;; Various modes for use in the unit tests
  (depends-on "adoc-mode")
- ;; (depends-on "bazel-mode")      ; requires Emacs 26+
+ ;; (depends-on "bazel")      ; requires Emacs 27+
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")
  (depends-on "cwl-mode")


### PR DESCRIPTION
The library has been renamed to just ‘bazel’, and it now requires at least
Emacs 27.