### PR TITLE
Set run_name to __main__ when running python modules

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10547,7 +10547,7 @@ Otherwise, return a list starting with -c (-m is not enough
 because it adds the current directory to Python's path)."
   (when (flycheck-python-needs-module-p checker)
     `("-c" ,(concat "import sys;sys.path.pop(0);import runpy;"
-                    (format "runpy.run_module(%S)" module-name)))))
+                    (format "runpy.run_module(%S, run_name='__main__')" module-name )))))
 
 (defcustom flycheck-python-project-files
   '("pyproject.toml" "setup.cfg" "mypy.ini" "pyrightconfig.json")


### PR DESCRIPTION
By default run_name is set to package.__main__ when running a python
package with runpy.

This causes issues with libraries checking "if __name__ ==
'__main__':" in their __main__.py file (flake8 5 is such an example).

Setting run_name to '__main__' is more similar to running the package
with "python -m ...", check also "_run_module_as_main" in runpy .