### PR TITLE
Put global-flycheck-mode in 'flycheck group instead of 'flycheck-faces

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -3581,13 +3581,7 @@ Command `flycheck-mode' is only enabled if
 (define-globalized-minor-mode global-flycheck-mode flycheck-mode
   flycheck-mode-on-safe
   :init-value nil
-  ;; Do not expose Global Flycheck Mode on customize interface, because the
-  ;; interaction between package.el and customize is currently broken.  See
-  ;; https://github.com/flycheck/flycheck/issues/595
-
-  ;; :require 'flycheck :group
-  ;; 'flycheck
-  )
+  :group 'flycheck)
 
 (defun flycheck-global-teardown (&optional ignore-local)
   "Teardown Flycheck in all buffers.


### PR DESCRIPTION
I haven't seen #595 for quite a number of years now, this PR puts `global-flycheck-mode` back to the right group.

Before:
<img width="601" alt="Screen Shot 2022-08-15 at 8 12 19 pm" src="https://user-images.githubusercontent.com/160028/184701458-3ff5b9c9-2547-41ea-a4c2-54d53b93c258.png">

After:
<img width="601" alt="Screen Shot 2022-08-15 at 8 13 22 pm" src="https://user-images.githubusercontent.com/160028/184701481-4f1e194c-4ae6-43a1-b773-f19faefde2c0.png">

