### PR TITLE
Refine flycheck-display-errors lifecycle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,12 +14,15 @@ New Features
 - [#2070]: Add a new syntax checker ``r`` for R with the builtin ``parse`` function.
 - [#2073]: Add new syntax checker ``salt-lint`` for the salt infrastructure-as-code language.
 - [#2071]: Add a new checker ``perl-perlimports``, for cleaning up Perl import statements.
+- [#1972]: New defcustom ``flycheck-clear-displayed-errors-function`` to
+  customize how error messages are to be cleared.
 
 -----------
 Bugs fixed
 -----------
 
 - [#2057]: Revert the extraction of ``flycheck-version`` with ``lm-version``.
+- [#1972]: Refine flycheck-display-errors lifecycle so error messages can be cleared.
 
 ----------
 Changes

--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -134,6 +134,24 @@ Flycheck provides two built-in functions for this option:
       (setq flycheck-display-errors-function
             #'flycheck-display-error-messages-unless-error-list)
 
+Along the same vein, Flycheck provides a way to customise how a error message is
+cleared, this is especially useful if you use a Flycheck extension to display
+error messages differently from the default.
+
+.. defcustom:: flycheck-clear-displayed-errors-function
+
+   Function to hide error message displayed by `flycheck-display-errors-function`.
+
+   If set to a function, it will be called with no arguments to
+   clear all displayed errors at point.
+
+By default, Flycheck only provides `flycheck-clear-displayed-error-messages` to
+clear the last Flycheck error message from the minibuffer:
+
+.. defun:: flycheck-clear-displayed-error-messages
+
+   Clear error messages displayed by `flycheck-display-error-messages`.
+
 .. seealso::
 
    :flyc:`flycheck-pos-tip`


### PR DESCRIPTION
This PR fixes a 7-8 year-old bug where the `flycheck-display-error-at-point-timer` has been calling `flycheck-display-errors-function` with error overlays marked for deletion, so even when an error has been fixed, this particular code path will still display the fixed error in the echo area.

Reproduction:

0. Install flycheck, do not configure it at all.
1. Turn on `flycheck-mode` on any elisp buffer.
2. Make a syntax error such as
    ```elisp
    (de |fun foo ())
    ```
3. Observe flycheck has highlighted `de` and `fun` and there's a `reference to free variable 'fun'` message displayed in the echo area.
4. Press backspace to fix the error so it becomes `(defun foo ())`
5. Observe the highlighting on  is gone on the symbol, but the message is being displayed in the echo area.

Expectation:

After the error has been fixed, the stale error message should not continue to display in the echo area.