### PR TITLE
Add --expt-relaxed-constexpr to nvcc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``master`` (unreleased)
 ======================
 
+------------
+New Features
+------------
+
+- [#1975]: Add support for --expt-relaxed-constexpr flag to ``cuda`` checker.
+
 34.1 (2024-02-18)
 ======================
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -292,6 +292,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Additional preprocessor definitions for nvcc. Is passed unaltered to both
          GPU compiler and underlying C/C++ compiler.
 
+      .. defcustom:: flycheck-cuda-relaxed-constexpr
+
+         Enable calling host constexpr from device function for nvcc.
+
 .. supported-language:: CWL
 
    .. syntax-checker:: cwl

--- a/flycheck.el
+++ b/flycheck.el
@@ -8272,6 +8272,15 @@ A list of strings to pass to cuda, a la flycheck-clang"
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "32"))
 
+(flycheck-def-option-var flycheck-cuda-relaxed-constexpr nil cuda-nvcc
+  "Enable calling host constexpr from device function for nvcc.
+
+When non-nil, enable experimental calling of a constexpr __host__
+function from a __device__ function."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "35"))
+
 (flycheck-define-checker cuda-nvcc
   "A CUDA C/C++ syntax checker using nvcc.
 
@@ -8282,6 +8291,7 @@ See URL `https://developer.nvidia.com/cuda-llvm-compiler'."
             "--x=cu" ;; explicitly specify it's a CUDA language file
             "-rdc=true" ;; Allow linking with external cuda funcions
             (option "-std=" flycheck-cuda-language-standard concat)
+            (option-flag "--expt-relaxed-constexpr" flycheck-cuda-relaxed-constexpr)
             (option-list "-include" flycheck-cuda-includes)
             (option-list "-gencode" flycheck-cuda-gencodes)
             (option-list "-D" flycheck-cuda-definitions concat)


### PR DESCRIPTION
Calling a `__host__ constexpr` function from a `__device__` function is experimentally allowed by providing this argument to nvcc.  This fixes errors that look like this:

```
include/cuco/detail/static_map.inl(400): error: calling a constexpr __host__ function("is_packable") from a __device__ function("operator()") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
```