### PR TITLE
Fix typo adds 't' to 'no'

### DIFF
--- a/doc/developer/developing.rst
+++ b/doc/developer/developing.rst
@@ -284,7 +284,7 @@ for transforming Flycheck checker options into flags for the command.  See the
 docstring for `flycheck-substitute-argument` for more info, and look at other
 checkers for examples.
 
-The ``shellcheck`` checker does no use ``source`` nor ``source-inplace``:
+The ``shellcheck`` checker does not use ``source`` nor ``source-inplace``:
 instead, it passes the buffer contents on standard input, using
 ``:standard-input t``.
 


### PR DESCRIPTION
Although I read [Writing documentation](https://www.flycheck.org/en/latest/contributor/contributing.html#writing-documentation) I did not rebuild the documentation because this is a minor change of one character.