### PR TITLE
Enable JSON checkers for `js-json-mode` as well

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9915,7 +9915,7 @@ See URL `https://github.com/zaach/jsonlint'."
   :error-filter
   (lambda (errors)
     (flycheck-sanitize-errors (flycheck-increment-error-columns errors)))
-  :modes json-mode)
+  :modes (json-mode js-json-mode))
 
 (flycheck-define-checker json-python-json
   "A JSON syntax checker using Python json.tool module.
@@ -9930,7 +9930,7 @@ See URL `https://docs.python.org/3.5/library/json.html#command-line-interface'."
           ;; Ignore the rest of the line which shows the char position.
           (one-or-more not-newline)
           line-end))
-  :modes json-mode
+  :modes (json-mode js-json-mode)
   ;; The JSON parser chokes if the buffer is empty and has no JSON inside
   :predicate flycheck-buffer-nonempty-p)
 
@@ -9949,7 +9949,7 @@ See URL `https://stedolan.github.io/jq/'."
           (optional "parse error: ")
           (message) "at line " line ", column " column
           (zero-or-more not-newline) line-end))
-  :modes json-mode)
+  :modes (json-mode js-json-mode))
 
 (flycheck-define-checker jsonnet
   "A Jsonnet syntax checker using the jsonnet binary.


### PR DESCRIPTION
Emacs 29 defines a new major mode for editing JSON: `js-json-mode`.

From [NEWS](https://github.com/emacs-mirror/emacs/blob/56706c6946c4f8800fac0f2a5c3516273b01d8eb/etc/NEWS#L2811-L2813) file:
```
** New mode 'js-json-mode'.
This is a lightweight variant of 'js-mode' that is used by default
when visiting JSON files.
```

This change updates checkers intended for `json-mode` to also work for `js-json-mode`.