### PR TITLE
Fix message truncation for python-mypy due to pretty formatting

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1046,7 +1046,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. note::
 
-         This syntax checker requires mypy 0.580 or newer.
+         This syntax checker requires mypy 0.730 or newer.
 
       .. syntax-checker-config-file:: flycheck-python-mypy-config
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -10828,11 +10828,12 @@ See URL https://github.com/microsoft/pyright."
   :package-version '(flycheck . "32"))
 
 (flycheck-define-checker python-mypy
-  "Mypy syntax and type checker.  Requires mypy>=0.580.
+  "Mypy syntax and type checker.  Requires mypy>=0.730.
 
 See URL `http://mypy-lang.org/'."
   :command ("mypy"
             "--show-column-numbers"
+            "--no-pretty"
             (config-file "--config-file" flycheck-python-mypy-config)
             (option "--cache-dir" flycheck-python-mypy-cache-dir)
             source-original)


### PR DESCRIPTION
If the the user has "pretty = true" in their mypy config it can result in truncation of the messages reported. We invoke mypy with --no-pretty to override this.

Minimum version is bumped to 0.730 (2019-09-26) because this is the version in which --pretty and --no-pretty were added:
https://mypy-lang.blogspot.com/2019/09/mypy-730-released.html

Fixes GH-1983 and closes GH-1983