### PR TITLE
Fix `ember-template-lint` args

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8878,7 +8878,7 @@ the BUFFER that was checked respectively."
   :command ("ember-template-lint"
             (config-file "--config-path" flycheck-ember-template-lintrc)
             "--filename" source-original
-            "--json")
+            "--format=json")
   :standard-input t
   :error-parser flycheck-ember-template--parse-error
   :modes web-mode


### PR DESCRIPTION
The argument for JSON output for `ember-template-lint` has changed from `--json` to `--format=json`.

[Reference](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/workflow.md) from `README`

```
Output errors as pretty-printed JSON string

ember-template-lint "app/templates/application.hbs" --format=json
```

Options from `ember-template-lint` help

```
ember-template-lint [options] [files..]

Options:
  --config-path                    Define a custom config path (default: .templa
                                   te-lintrc.js)                        [string]
  --config                         Define a custom configuration to be used - (
                                   e.g. '{ "rules": { "no-implicit-this": "erro
                                   r" } }')                             [string]
  --quiet                          Ignore warnings and only show errors[boolean]
  --rule                           Specify a rule and its severity to add that r
                                   ule to loaded rules - (e.g. `no-implicit-this
                                   :error` or `rule:["error", { "allow": ["some-
                                   helper"] }]`)                        [string]
  --filename                       Used to indicate the filename to be assumed f
                                   or contents from STDIN               [string]
  --fix                            Fix any errors that are reported as fixable
                                                      [boolean] [default: false]
  --format                         Specify format to be used in printing output
                                                    [string] [default: "pretty"]
```