### PR TITLE
ci(docs.yml): Push built site files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,3 +29,16 @@ jobs:
       run: |
         pip install -r doc/requirements.txt
         make -C doc SPHINXOPTS=-n html
+
+    # TODO: Generate better commit message
+    - name: Publish doc artifacts
+      if: github.ref == 'refs/heads/master'
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -F- <<-_UBLT_COMMIT_MSG_
+        auto: ${{ github.event.head_commit.message }}
+        SourceCommit: https://github.com/flycheck/flycheck/commit/${{ github.sha }}
+        _UBLT_COMMIT_MSG_
+        git push


### PR DESCRIPTION
For #2004. Add a step to push the site files back to this repo.

Does Travis CI generate commits and push back to GitHub? I didn't see any related commits in this repo. 🤔 

*References: https://github.com/emacs-eask/emacs-eask.github.io/commits/master (all commits are from `github-actions`)*

cc @cpitclaudel 