### PR TITLE
markdownlint-cli: Add default config file names and rule selection in args

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -834,6 +834,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. syntax-checker-config-file:: flycheck-markdown-markdownlint-cli-config
 
+      .. defcustom:: flycheck-markdown-markdownlint-cli-disable-rules
+
+         A list of disabled rules.
+
+      .. defcustom:: flycheck-markdown-markdownlint-cli-enable-rules
+
+         A list of enabled rules.
+
    .. syntax-checker:: markdown-mdl
 
       Check Markdown with `markdownlint <https://github.com/markdownlint/markdownlint/>`_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -11011,8 +11011,9 @@ See URL `https://github.com/rpm-software-management/rpmlint'."
                             (eq sh-shell 'rpm))))
 
 (flycheck-def-config-file-var flycheck-markdown-markdownlint-cli-config
-    markdown-markdownlint-cli nil
-  :package-version '(flycheck . "32"))
+    markdown-markdownlint-cli
+    '(".markdownlint.json" ".markdownlint.jsonc" ".markdownlint.yaml")
+  :package-version '(flycheck . "33"))
 
 (flycheck-define-checker markdown-markdownlint-cli
   "Markdown checker using markdownlint-cli.

--- a/flycheck.el
+++ b/flycheck.el
@@ -11017,7 +11017,7 @@ See URL `https://github.com/rpm-software-management/rpmlint'."
 (flycheck-define-checker markdown-markdownlint-cli
   "Markdown checker using markdownlint-cli.
 
-See URL `https://github.com/igorshubovych/markdownlint-cli'."
+See URL `https://github.com/DavidAnson/markdownlint-cli'."
   :command ("markdownlint"
             (config-file "--config" flycheck-markdown-markdownlint-cli-config)
             source)

--- a/flycheck.el
+++ b/flycheck.el
@@ -11015,12 +11015,31 @@ See URL `https://github.com/rpm-software-management/rpmlint'."
     '(".markdownlint.json" ".markdownlint.jsonc" ".markdownlint.yaml")
   :package-version '(flycheck . "33"))
 
+(flycheck-def-option-var flycheck-markdown-markdownlint-cli-disable-rules
+    nil markdown-markdownlint-cli
+  "Rules to disable for markdownlint-cli."
+  :type '(repeat :tag "Disabled rule"
+                 (string :tag "Rule name"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "33"))
+
+(flycheck-def-option-var flycheck-markdown-markdownlint-cli-enable-rules
+    nil markdown-markdownlint-cli
+  "Rules to enable for markdownlint-cli."
+  :type '(repeat :tag "Enabled rule"
+                 (string :tag "Rule name"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "33"))
+
 (flycheck-define-checker markdown-markdownlint-cli
   "Markdown checker using markdownlint-cli.
 
 See URL `https://github.com/DavidAnson/markdownlint-cli'."
   :command ("markdownlint"
             (config-file "--config" flycheck-markdown-markdownlint-cli-config)
+            (option-list "--disable" flycheck-markdown-markdownlint-cli-disable-rules)
+            (option-list "--enable" flycheck-markdown-markdownlint-cli-enable-rules)
+            "--"
             source)
   :error-patterns
   ((error line-start


### PR DESCRIPTION
* The default configuration filenames are taken from the project readme.
* `--enable` and `--disable` allow specifying names of rules without putting them in a configuration file.

Please let me know if you'd like this tested.