### PR TITLE
Fix arrows directions

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -2163,7 +2163,7 @@ Signal an error, if any property has an invalid value."
                 (lambda ()
                   ;; Run predicate in the checker's default directory
                   (let ((default-directory
-                          (flycheck-compute-working-directory symbol)))
+                         (flycheck-compute-working-directory symbol)))
                     (funcall predicate)))))
           (real-enabled
            (lambda ()
@@ -2171,7 +2171,7 @@ Signal an error, if any property has an invalid value."
                  (or (null enabled)
                      ;; Run enabled in the checker's default directory
                      (let ((default-directory
-                             (flycheck-compute-working-directory symbol)))
+                            (flycheck-compute-working-directory symbol)))
                        (funcall enabled)))
                (lwarn 'flycheck
                       :warning "%S is no valid Flycheck syntax checker.
@@ -2873,7 +2873,7 @@ Slots:
   "Start a SYNTAX-CHECK with CALLBACK."
   (let ((checker (flycheck-syntax-check-checker syntax-check))
         (default-directory
-          (flycheck-syntax-check-working-directory syntax-check)))
+         (flycheck-syntax-check-working-directory syntax-check)))
     (setf (flycheck-syntax-check-context syntax-check)
           (funcall (flycheck-checker-get checker 'start) checker callback))))
 
@@ -4140,7 +4140,11 @@ Returns MARGIN-STR with FACE applied."
   (propertize margin-str 'face `(,face default)))
 
 (defconst flycheck-default-margin-str "»"
-  "String used to indicate errors in the margins.")
+  "String used to indicate errors in the margins pointing right.")
+
+(defconst flycheck-default-margin-str-left "«"
+  "String used to indicate errors in the margins pointing left.")
+
 
 (defconst flycheck-default-margin-continuation-str "⋮"
   "String used to indicate continuation lines in the margins.")
@@ -4402,12 +4406,18 @@ margins (MARGIN-STR, a string) or the bitmap drawn in the
 fringes (FRINGE-BITMAP, a fringe bitmap symbol or a cons of such
 symbols, as in `flycheck-define-error-level')."
   (unless margin-str
-    (setq margin-str flycheck-default-margin-str))
+    (setq margin-str
+          (if (string-equal flycheck-indication-mode "left-margin")
+              (setq margin-str flycheck-default-margin-str)
+            (setq margin-str flycheck-default-margin-str-left))))
 
   (unless fringe-bitmap
     (setq fringe-bitmap
-          (cons 'flycheck-fringe-bitmap-double-arrow
-                'flycheck-fringe-bitmap-double-arrow-hi-res)))
+          (if (string-equal flycheck-indication-mode "left-fringe")
+              (cons 'flycheck-fringe-bitmap-double-arrow
+                    'flycheck-fringe-bitmap-double-arrow-hi-res)
+            (cons 'flycheck-fringe-bitmap-double-left-arrow
+                  'flycheck-fringe-bitmap-double-left-arrow-hi-res))))
 
   (setf (get 'flycheck-error-overlay 'face) 'flycheck-error)
   (setf (get 'flycheck-error-overlay 'priority) 110)
@@ -5196,7 +5206,7 @@ See `flycheck-error-level-<'."
 (defvar flycheck-error-list-mode-line-map
   (let ((map (make-sparse-keymap)))
     (define-key map [mode-line mouse-1]
-      #'flycheck-error-list-mouse-switch-to-source)
+                #'flycheck-error-list-mouse-switch-to-source)
     map)
   "Keymap for error list mode line.")
 
@@ -9867,7 +9877,7 @@ See URL `https://eslint.org/'."
   :verify
   (lambda (_)
     (let* ((default-directory
-             (flycheck-compute-working-directory 'javascript-eslint))
+            (flycheck-compute-working-directory 'javascript-eslint))
            (have-config (flycheck-eslint-config-exists-p)))
       (list
        (flycheck-verification-result-new
@@ -11555,9 +11565,9 @@ versions inferior to 1.25)."
 Execute `cargo --list' to find out whether COMMAND is present."
   (let ((cargo (funcall flycheck-executable-find "cargo")))
     (member command
-      (mapcar (lambda (line)
-                (replace-regexp-in-string "\\s-*\\(\\S-+\\).*\\'" "\\1" line))
-              (ignore-errors (process-lines cargo "--list"))))))
+            (mapcar (lambda (line)
+                      (replace-regexp-in-string "\\s-*\\(\\S-+\\).*\\'" "\\1" line))
+                    (ignore-errors (process-lines cargo "--list"))))))
 
 (defun flycheck-rust-valid-crate-type-p (crate-type)
   "Whether CRATE-TYPE is a valid target type for Cargo.

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -1655,11 +1655,11 @@
 (ert-deftest flycheck-error-format-position ()
   :tags '(error-api)
   (cl-flet ((fmt
-             (l c el ec)
-             (flycheck-error-format-position
-              (flycheck-error-new-at
-               l c 'error "err" :end-line el :end-column ec
-               :checker 'emacs-lisp))))
+              (l c el ec)
+              (flycheck-error-format-position
+               (flycheck-error-new-at
+                l c 'error "err" :end-line el :end-column ec
+                :checker 'emacs-lisp))))
     (should (string= (fmt 14 nil nil nil) "14"))
     (should (string= (fmt 14 nil nil 1)   "14"))
     (should (string= (fmt 14 nil 14  nil) "14"))


### PR DESCRIPTION
When setting fringe or border to 'right', the provided marker kept pointing right.

This aims to change the default behaviour of
`flycheck-redefine-standard-error-levels` to make into account the selected `flycheck-indication-mode`.

So if the left-margin or left-fringe is set, everything stays the same, buf if they're set to the right-margin or rigt-fringe an arrow pointing to the left will be used.

Diff may show other little fixes, this was done by `make format`, I thought there's nothing bad about it and kept it on this commit.

On macOS eask was trickie to set up, it required an ignore since the `shut-up` package keeps telling the ls of macOS has no --dired (even tough it could be smarter and point to gls (gnu ls)). 

The docker image also gave me an error:
```
docker build --build-arg EMACS_VERSION=26.2 --tag tools-and-emacs:26.2 -f .travis/tools-and-emacs .
[+] Building 0.0s (1/2)                                                                                                                       
 => ERROR [internal] load build definition from tools-and-emacs                                                                          0.0s
 => => transferring dockerfile: 54B                                                                                                      0.0s
------
 > [internal] load build definition from tools-and-emacs:
------
failed to solve with frontend dockerfile.v0: failed to read dockerfile: error from sender: resolve : lstat .travis: no such file or directory
```

In order to test it I manually byte compiled flycheck, moved the .elc to my .emacs.d/ and messed with:
```
(setq-default flycheck-indication-mode 'right-margin)
(add-hook 'flycheck-mode-hook #'flycheck-set-indication-mode)
```

Cycling trough left-margin, right-margin, left-fringe, right-fringe and opening a toy file in python-mode:

right-margin:
![image](https://user-images.githubusercontent.com/16169950/226157017-e2a6420c-eb92-4791-ae15-c352c6f8d1d3.png)

left-margin:
![image](https://user-images.githubusercontent.com/16169950/226156815-a4fbfde6-d972-4a25-8138-6f9ebe57c820.png)

left-fringe:
![image](https://user-images.githubusercontent.com/16169950/226156845-2bec29e4-2428-44e6-9cae-b5a6ecd6c3e2.png)

right-fringe:
![image](https://user-images.githubusercontent.com/16169950/226156873-44b264d4-01b8-4d4e-b1de-39571373d803.png)

Also nicely working on terminal Emacs on margin modes:
![image](https://user-images.githubusercontent.com/16169950/226157119-1eb43aa5-ae11-47fa-b4eb-82722bc0e127.png)

This aims to complete the issue #2010 