### PR TITLE
Add phpcs-changed support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@
     which they were returned by checkers.  In previous versions of Flycheck,
     this list was sorted by error position and severity. [GH-1749]
 
+- New syntax checkers:
+
+  - PHP with ``phpcs-changed`` [GH-2015]
+
 32 (frozen on May 3rd, 2020, released Mar 28, 2022)
 ===================================================
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -912,7 +912,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
 .. supported-language:: PHP
 
-   Flycheck checks PHP with `php`, `php-phpmd` and `php-phpcs`.
+   Flycheck checks PHP with `php`, `php-phpmd`, `php-phpcs` and `php-phpcs-changed`.
 
    .. syntax-checker:: php
 
@@ -938,6 +938,22 @@ to view the docstring of the syntax checker.  Likewise, you may use
          This syntax checker requires PHP Code Sniffer 2.6 or newer.
 
       .. _PHP Code Sniffer: http://pear.php.net/package/PHP_CodeSniffer
+
+      .. defcustom:: flycheck-phpcs-standard
+
+         The coding standard, either as name of a built-in standard, or as path
+         to a standard specification.
+
+   .. syntax-checker:: php-phpcs-changed
+
+      Check style with `PHPCS Changed`_.
+
+      .. note::
+
+         This syntax checker requires PHP Code Sniffer 2.6 or newer.
+
+      .. _PHP Code Sniffer: http://pear.php.net/package/PHP_CodeSniffer
+      .. _PHPCS-Changed: https://github.com/sirbrillig/phpcs-changed
 
       .. defcustom:: flycheck-phpcs-standard
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -235,6 +235,7 @@ attention to case differences."
     php
     php-phpmd
     php-phpcs
+    php-phpcs-changed
     processing
     proselint
     protobuf-protoc
@@ -10272,6 +10273,28 @@ See URL `http://pear.php.net/package/PHP_CodeSniffer/'."
                     (concat "--stdin-path=" (buffer-file-name))))
             ;; Read from standard input
             "-")
+  :standard-input t
+  :error-parser flycheck-parse-checkstyle
+  :error-filter
+  (lambda (errors)
+    (flycheck-sanitize-errors
+     (flycheck-remove-error-file-names "STDIN" errors)))
+  :modes (php-mode php+-mode)
+  ;; phpcs seems to choke on empty standard input, hence skip phpcs if the
+  ;; buffer is empty, see https://github.com/flycheck/flycheck/issues/907
+  :predicate flycheck-buffer-nonempty-p)
+
+(flycheck-define-checker php-phpcs-changed
+  "A PHP style checker using PHPCS-Changed.
+   Needs PHP Code Sniffer 2.6 or newer.
+   See `https://github.com/sirbrillig/phpcs-changed'."
+  :command ("phpcs-changed"
+            "--git"
+            "--git-base trunk"
+            "--git-unstaged"
+            (option "--standard=" flycheck-phpcs-standard concat)
+            (eval (buffer-file-name))
+            )
   :standard-input t
   :error-parser flycheck-parse-checkstyle
   :error-filter


### PR DESCRIPTION
Add [phpcs-changed](https://github.com/sirbrillig/phpcs-changed) php checker

Needs a bit of trickery to get the underlying phpcs call to use the following options:

```
phpcs --report=checkstyle -q --extensions=php --stdin=<(buffer-file-name)>
```

Alternatively, the implementation of a parser that can handle it's json output would make it work out of the box.