### PR TITLE
yamllint: update possible locations for configuration file

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12568,7 +12568,12 @@ See URL `http://www.ruby-doc.org/stdlib-2.0.0/libdoc/yaml/rdoc/YAML.html'."
   :next-checkers ((warning . yaml-yamllint)
                   (warning . cwl)))
 
-(flycheck-def-config-file-var flycheck-yamllintrc yaml-yamllint ".yamllint")
+(flycheck-def-config-file-var flycheck-yamllintrc
+    yaml-yamllint
+    '(".yamllint"
+      ".yamllint.yaml"
+      ".yamllint.yml"
+      "~/.config/yamllint/config"))
 
 (flycheck-define-checker yaml-yamllint
   "A YAML syntax checker using YAMLLint.


### PR DESCRIPTION
These are all the possible names and locations according to https://yamllint.readthedocs.io/en/stable/configuration.html except for the ones at `$YAMLLINT_CONFIG_FILE` and `$XDG_CONFIG_HOME/yamllint/config`.  I'd like to support those too, but I don't know the best way of handling them yet, but I won't let that hold these changes back.