### PR TITLE
Support org lint

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10134,6 +10134,16 @@ string is a module to `use' in Perl."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "32"))
 
+  (flycheck-define-checker org-lint
+    "Org buffer checker using `org-lint'."
+    :command ("emacs" (eval flycheck-emacs-args)
+              "--eval" (eval flycheck-org-lint-form)
+              "--" source)
+    :error-patterns
+    ((error line-start line ": " (message) line-end))
+    :modes (org-mode))
+
+
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -10172,24 +10172,12 @@ See URL `https://orgmode.org/'."
       org-attach-use-inheritance
       org-attach-id-to-path-function-list)
     "Variables inherited by the org-lint subprocess.")
-  (defun flycheck-org-lint-variables-form ()
+
+(defun flycheck-org-lint-variables-form ()
     (require 'org-attach)  ; Needed to make variables available
     `(progn
        ,@(seq-map (lambda (opt) `(setq-default ,opt ',(symbol-value opt)))
                   (seq-filter #'boundp flycheck-org-lint-variables))))
-  (flycheck-define-checker org-lint
-    "Org buffer checker using `org-lint'."
-    :command ("emacs" (eval flycheck-emacs-args)
-              "--eval" (eval (concat "(add-to-list 'load-path \""
-                                     (file-name-directory (locate-library "org"))
-                                     "\")"))
-              "--eval" (eval (flycheck-sexp-to-string
-                              (flycheck-org-lint-variables-form)))
-              "--eval" (eval flycheck-org-lint-form)
-              "--" source)
-    :error-patterns
-    ((error line-start line ": " (message) line-end))
-    :modes (org-mode))
 
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10145,6 +10145,50 @@ See URL `https://orgmode.org/'."
     ((error line-start line ": " (message) line-end))
     :modes (org-mode))
 
+  (defconst flycheck-org-lint-form
+    (flycheck-prepare-emacs-lisp-form
+      (require 'org)
+      (require 'org-attach)
+      (let ((source (car command-line-args-left))
+            (process-default-directory default-directory))
+        (with-temp-buffer
+          (insert-file-contents source 'visit)
+          (setq buffer-file-name source)
+          (setq default-directory process-default-directory)
+          (delay-mode-hooks (org-mode))
+          (setq delayed-mode-hooks nil)
+          (dolist (err (org-lint))
+            (let ((inf (cl-second err)))
+              (princ (elt inf 0))
+              (princ ": ")
+              (princ (elt inf 2))
+              (terpri)))))))
+  (defconst flycheck-org-lint-variables
+    '(org-directory
+      org-id-locations
+      org-id-locations-file
+      org-attach-id-dir
+      org-attach-use-inheritance
+      org-attach-id-to-path-function-list)
+    "Variables inherited by the org-lint subprocess.")
+  (defun flycheck-org-lint-variables-form ()
+    (require 'org-attach)  ; Needed to make variables available
+    `(progn
+       ,@(seq-map (lambda (opt) `(setq-default ,opt ',(symbol-value opt)))
+                  (seq-filter #'boundp flycheck-org-lint-variables))))
+  (flycheck-define-checker org-lint
+    "Org buffer checker using `org-lint'."
+    :command ("emacs" (eval flycheck-emacs-args)
+              "--eval" (eval (concat "(add-to-list 'load-path \""
+                                     (file-name-directory (locate-library "org"))
+                                     "\")"))
+              "--eval" (eval (flycheck-sexp-to-string
+                              (flycheck-org-lint-variables-form)))
+              "--eval" (eval flycheck-org-lint-form)
+              "--" source)
+    :error-patterns
+    ((error line-start line ": " (message) line-end))
+    :modes (org-mode))
 
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10164,7 +10164,8 @@ See URL `https://orgmode.org/'."
               (princ ": ")
               (princ (elt inf 2))
               (terpri)))))))
-  (defconst flycheck-org-lint-variables
+
+(defconst flycheck-org-lint-variables
     '(org-directory
       org-id-locations
       org-id-locations-file

--- a/flycheck.el
+++ b/flycheck.el
@@ -10180,7 +10180,8 @@ See URL `https://orgmode.org/'."
               "--" source)
   :error-patterns
   ((error line-start line ": " (message) line-end))
-  :modes (org-mode))
+  :modes (org-mode)
+  :next-checkers (proselint))
 
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10135,7 +10135,9 @@ string is a module to `use' in Perl."
   :package-version '(flycheck . "32"))
 
   (flycheck-define-checker org-lint
-    "Org buffer checker using `org-lint'."
+    "Org buffer checker using `org-lint'.
+
+See URL `https://orgmode.org/'."
     :command ("emacs" (eval flycheck-emacs-args)
               "--eval" (eval flycheck-org-lint-form)
               "--" source)

--- a/flycheck.el
+++ b/flycheck.el
@@ -10146,24 +10146,24 @@ See URL `https://orgmode.org/'."
   ((error line-start line ": " (message) line-end))
   :modes (org-mode))
 
-  (defconst flycheck-org-lint-form
-    (flycheck-prepare-emacs-lisp-form
-      (require 'org)
-      (require 'org-attach)
-      (let ((source (car command-line-args-left))
-            (process-default-directory default-directory))
-        (with-temp-buffer
-          (insert-file-contents source 'visit)
-          (setq buffer-file-name source)
-          (setq default-directory process-default-directory)
-          (delay-mode-hooks (org-mode))
-          (setq delayed-mode-hooks nil)
-          (dolist (err (org-lint))
-            (let ((inf (cl-second err)))
-              (princ (elt inf 0))
-              (princ ": ")
-              (princ (elt inf 2))
-              (terpri)))))))
+(defconst flycheck-org-lint-form
+  (flycheck-prepare-emacs-lisp-form
+   (require 'org)
+   (require 'org-attach)
+   (let ((source (car command-line-args-left))
+   (process-default-directory default-directory))
+   (with-temp-buffer
+   (insert-file-contents source 'visit)
+   (setq buffer-file-name source)
+   (setq default-directory process-default-directory)
+   (delay-mode-hooks (org-mode))
+   (setq delayed-mode-hooks nil)
+   (dolist (err (org-lint))
+   (let ((inf (cl-second err)))
+   (princ (elt inf 0))
+   (princ ": ")
+   (princ (elt inf 2))
+   (terpri)))))))
 
 (defconst flycheck-org-lint-variables
     '(org-directory

--- a/flycheck.el
+++ b/flycheck.el
@@ -230,6 +230,7 @@ attention to case differences."
     nix
     nix-linter
     opam
+    org-lint
     perl
     perl-perlcritic
     php

--- a/flycheck.el
+++ b/flycheck.el
@@ -10135,7 +10135,7 @@ string is a module to `use' in Perl."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "32"))
 
-  (flycheck-define-checker org-lint
+(flycheck-define-checker org-lint
     "Org buffer checker using `org-lint'.
 
 See URL `https://orgmode.org/'."
@@ -10175,7 +10175,8 @@ See URL `https://orgmode.org/'."
     "Variables inherited by the org-lint subprocess.")
 
 (defun flycheck-org-lint-variables-form ()
-    (require 'org-attach)  ; Needed to make variables available
+  "Make org-lint availables available."
+    (require 'org-attach)
     `(progn
        ,@(seq-map (lambda (opt) `(setq-default ,opt ',(symbol-value opt)))
                   (seq-filter #'boundp flycheck-org-lint-variables))))

--- a/flycheck.el
+++ b/flycheck.el
@@ -10136,15 +10136,15 @@ string is a module to `use' in Perl."
   :package-version '(flycheck . "32"))
 
 (flycheck-define-checker org-lint
-    "Org buffer checker using `org-lint'.
+  "Org buffer checker using `org-lint'.
 
 See URL `https://orgmode.org/'."
-    :command ("emacs" (eval flycheck-emacs-args)
+  :command ("emacs" (eval flycheck-emacs-args)
               "--eval" (eval flycheck-org-lint-form)
               "--" source)
-    :error-patterns
-    ((error line-start line ": " (message) line-end))
-    :modes (org-mode))
+  :error-patterns
+  ((error line-start line ": " (message) line-end))
+  :modes (org-mode))
 
   (defconst flycheck-org-lint-form
     (flycheck-prepare-emacs-lisp-form

--- a/flycheck.el
+++ b/flycheck.el
@@ -10135,16 +10135,6 @@ string is a module to `use' in Perl."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "32"))
 
-(flycheck-define-checker org-lint
-  "Org buffer checker using `org-lint'.
-
-See URL `https://orgmode.org/'."
-  :command ("emacs" (eval flycheck-emacs-args)
-              "--eval" (eval flycheck-org-lint-form)
-              "--" source)
-  :error-patterns
-  ((error line-start line ": " (message) line-end))
-  :modes (org-mode))
 
 (defconst flycheck-org-lint-form
   (flycheck-prepare-emacs-lisp-form
@@ -10180,6 +10170,17 @@ See URL `https://orgmode.org/'."
     `(progn
        ,@(seq-map (lambda (opt) `(setq-default ,opt ',(symbol-value opt)))
                   (seq-filter #'boundp flycheck-org-lint-variables))))
+
+(flycheck-define-checker org-lint
+  "Org buffer checker using `org-lint'.
+
+See URL `https://orgmode.org/'."
+  :command ("emacs" (eval flycheck-emacs-args)
+              "--eval" (eval flycheck-org-lint-form)
+              "--" source)
+  :error-patterns
+  ((error line-start line ": " (message) line-end))
+  :modes (org-mode))
 
 (flycheck-define-checker perl
   "A Perl syntax checker using the Perl interpreter.


### PR DESCRIPTION
Adding a pull request to support org-lint. The code was originally written by @ several years ago @czikus  and proposed by @zoechi, see https://github.com/flycheck/flycheck/issues/1757

CI/CD and make specs fails with `(seq-difference flycheck-checkers checkers)' to be `equal' to `nil', but instead it was `(org-lint)' which does not match because: (different-types (org-lint) nil). I'm having a hard time understanding why this is happening. From what I can tell, my style and definition matches spec. I've spent a few hours trying to figure this out, but need to move on. Will try to get on gitter, but seems a bit dead. Also, I'm on liberachat #emacs under RickAstley.  Apologies for a premature pull, but I need some help and am a noob.
