### PR TITLE
fix tflint invocation

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12255,7 +12255,8 @@ information about tflint."
 See URL `https://github.com/terraform-linters/tflint'."
   :command ("tflint" "--format=json"
             (option-list "--var-file=" flycheck-tflint-variable-files concat)
-            (option-list "--chdir=" source-directory concat))
+            (option-list "--chdir=" source-directory concat)
+            (option-list "--filter=" source-original concat))
   :error-parser flycheck-parse-tflint-linter
   :predicate flycheck-buffer-saved-p
   :modes terraform-mode)

--- a/flycheck.el
+++ b/flycheck.el
@@ -12253,10 +12253,8 @@ information about tflint."
   "A Terraform checker using tflint.
 
 See URL `https://github.com/terraform-linters/tflint'."
-  :command ("tflint" "--format=json"
-            (option-list "--var-file=" flycheck-tflint-variable-files concat)
-            (option-list "--chdir=" source-directory concat)
-            (option-list "--filter=" source-original concat))
+  :command ("tflint" "--format=json" "--force"
+            (option-list "--var-file=" flycheck-tflint-variable-files concat))
   :error-parser flycheck-parse-tflint-linter
   :predicate flycheck-buffer-saved-p
   :modes terraform-mode)

--- a/flycheck.el
+++ b/flycheck.el
@@ -12255,7 +12255,7 @@ information about tflint."
 See URL `https://github.com/terraform-linters/tflint'."
   :command ("tflint" "--format=json"
             (option-list "--var-file=" flycheck-tflint-variable-files concat)
-            source-original)
+            (option-list "--chdir=" source-directory concat))
   :error-parser flycheck-parse-tflint-linter
   :predicate flycheck-buffer-saved-p
   :modes terraform-mode)


### PR DESCRIPTION
Closes: #2024

tflint can no longer be run on individual files. With this commit, tflint is run on all files of the directory of the buffer file.
