### PR TITLE
Add --expt-extended-lambda to nvcc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ New Features
 ------------
 
 - [#1975]: Add support for --expt-relaxed-constexpr flag to ``cuda`` checker.
+- [#2055]: Add support for --expt-extended-lambda flag to ``cuda`` checker.
 
 34.1 (2024-02-18)
 ======================

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -296,6 +296,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          Enable calling host constexpr from device function for nvcc.
 
+      .. defcustom:: flycheck-cuda-extended-lambda
+
+        Allows for ``__host__ __device__`` lambdas as described (`here <https://developer.nvidia.com/blog/new-compiler-features-cuda-8/>`_).
+
 .. supported-language:: CWL
 
    .. syntax-checker:: cwl

--- a/flycheck.el
+++ b/flycheck.el
@@ -8281,6 +8281,14 @@ function from a __device__ function."
   :safe #'booleanp
   :package-version '(flycheck . "35"))
 
+(flycheck-def-option-var flycheck-cuda-extended-lambda nil cuda-nvcc
+  "Enable annotating lambda functions with __host__ or __device__.
+
+When non-nil, enable experimental compilation of __host__ and __device__ lambda functions."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "35"))
+
 (flycheck-define-checker cuda-nvcc
   "A CUDA C/C++ syntax checker using nvcc.
 
@@ -8292,6 +8300,7 @@ See URL `https://developer.nvidia.com/cuda-llvm-compiler'."
             "-rdc=true" ;; Allow linking with external cuda funcions
             (option "-std=" flycheck-cuda-language-standard concat)
             (option-flag "--expt-relaxed-constexpr" flycheck-cuda-relaxed-constexpr)
+            (option-flag "--expt-extended-lambda" flycheck-cuda-extended-lambda)
             (option-list "-include" flycheck-cuda-includes)
             (option-list "-gencode" flycheck-cuda-gencodes)
             (option-list "-D" flycheck-cuda-definitions concat)


### PR DESCRIPTION
Allows for `__host__ __device__` lambdas as described [here](https://developer.nvidia.com/blog/new-compiler-features-cuda-8/).
