### PR TITLE
Fix a bunch of "reference to free variable" warnings

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11196,23 +11196,22 @@ information about statix."
                     end-column .at.to.column))
 
             (let-alist err
-              (let ((diagnostic (car .diagnostics)))
-                (flycheck-error-new-at
-                 start-line
-                 start-column
-                 (pcase .severity ("Error" 'error)
-                        ("Warn" 'warning)
-                        (_ 'warning))
-                 (format "%s: %s" .note message)
-                 :id (format "%s%02d" (pcase .severity
-                                        ("Error" "E")
-                                        ("Warn" "W")
-                                        (_ "")) .code)
-                 :checker checker
-                 :buffer buffer
-                 :filename (buffer-file-name buffer)
-                 :end-line end-line
-                 :end-column end-column))))
+              (flycheck-error-new-at
+               start-line
+               start-column
+               (pcase .severity ("Error" 'error)
+                      ("Warn" 'warning)
+                      (_ 'warning))
+               (format "%s: %s" .note message)
+               :id (format "%s%02d" (pcase .severity
+                                      ("Error" "E")
+                                      ("Warn" "W")
+                                      (_ "")) .code)
+               :checker checker
+               :buffer buffer
+               :filename (buffer-file-name buffer)
+               :end-line end-line
+               :end-column end-column)))
           (alist-get 'report (car (flycheck-parse-json output)))))
 
 (flycheck-define-checker statix

--- a/flycheck.el
+++ b/flycheck.el
@@ -11187,31 +11187,30 @@ See URL `https://github.com/nerdypepper/statix' for more
 information about statix."
   (mapcar (lambda (err)
             ;; Diagnostic information is a (seemingly always) 1 element array.
-            ;; Set the values here to avoid nesting `let-alist'.
             (let-alist (car (alist-get 'diagnostics err))
-              (setf message .message
-                    start-line .at.from.line
-                    start-column .at.from.column
-                    end-line .at.to.line
-                    end-column .at.to.column))
+              (let ((message .message)
+                    (start-line .at.from.line)
+                    (start-column .at.from.column)
+                    (end-line .at.to.line)
+                    (end-column .at.to.column))
 
-            (let-alist err
-              (flycheck-error-new-at
-               start-line
-               start-column
-               (pcase .severity ("Error" 'error)
-                      ("Warn" 'warning)
-                      (_ 'warning))
-               (format "%s: %s" .note message)
-               :id (format "%s%02d" (pcase .severity
-                                      ("Error" "E")
-                                      ("Warn" "W")
-                                      (_ "")) .code)
-               :checker checker
-               :buffer buffer
-               :filename (buffer-file-name buffer)
-               :end-line end-line
-               :end-column end-column)))
+                (let-alist err
+                  (flycheck-error-new-at
+                   start-line
+                   start-column
+                   (pcase .severity ("Error" 'error)
+                          ("Warn" 'warning)
+                          (_ 'warning))
+                   (format "%s: %s" .note message)
+                   :id (format "%s%02d" (pcase .severity
+                                          ("Error" "E")
+                                          ("Warn" "W")
+                                          (_ "")) .code)
+                   :checker checker
+                   :buffer buffer
+                   :filename (buffer-file-name buffer)
+                   :end-line end-line
+                   :end-column end-column)))))
           (alist-get 'report (car (flycheck-parse-json output)))))
 
 (flycheck-define-checker statix


### PR DESCRIPTION
These two commits are pretty simple, but they fix 11 warnings, which is a lot. Most of the existing warnings in flycheck come from that single function.

I did not runtime-test that though as I don't have/don't know anything about that "statix" app, so testing is appreciated.