### PR TITLE
Adapt to new AUCTeX mode names

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12361,7 +12361,7 @@ See URL `https://www.nongnu.org/chktex/'."
   :error-filter
   (lambda (errors)
     (flycheck-sanitize-errors (flycheck-increment-error-columns errors)))
-  :modes (latex-mode plain-tex-mode))
+  :modes (latex-mode LaTeX-mode plain-tex-mode plain-TeX-mode))
 
 (flycheck-define-checker tex-lacheck
   "A LaTeX syntax and style checker using lacheck.
@@ -12372,7 +12372,7 @@ See URL `https://www.ctan.org/pkg/lacheck'."
   ((warning line-start
             "\"" (file-name) "\", line " line ": " (message)
             line-end))
-  :modes latex-mode)
+  :modes (latex-mode LaTeX-mode))
 
 (flycheck-define-checker texinfo
   "A Texinfo syntax checker using makeinfo.
@@ -12387,7 +12387,7 @@ See URL `https://www.gnu.org/software/texinfo/'."
    (error line-start
           "-:" line (optional ":" column) ": " (message)
           line-end))
-  :modes texinfo-mode)
+  :modes (texinfo-mode Texinfo-mode))
 
 (flycheck-def-config-file-var flycheck-textlint-config
     textlint "textlintrc.json")
@@ -12441,7 +12441,7 @@ See URL `https://textlint.github.io/'."
   ;; `flycheck-textlint-plugin-alist'.
   :modes
   (text-mode markdown-mode gfm-mode message-mode adoc-mode
-             mhtml-mode latex-mode org-mode rst-mode)
+             mhtml-mode latex-mode LaTeX-mode org-mode rst-mode)
   :enabled
   (lambda () (flycheck--textlint-get-plugin))
   :verify


### PR DESCRIPTION
Hi!

In the AUCTeX 14.1 release, major modes are renamed, as shown in the change log file [(doc/changes.texi)](https://git.savannah.gnu.org/cgit/auctex.git/tree/doc/changes.texi):

```texi
@heading News in 14.1

@itemize @bullet
@item
@AUCTeX{} changes major mode names.  Its primary purpose is to avoid
conflicts with Emacs built-in @TeX{} major modes.  It also improves
consistency of the source code.

@itemize @minus
@item
The overview of the former names and new names are:

@multitable {@code{japanese-plain-tex-mode}} {@code{japanese-plain-TeX-mode}}
@headitem Former name @tab New name
@item @code{plain-tex-mode} @tab @code{plain-TeX-mode}
@item @code{latex-mode} @tab @code{LaTeX-mode}
@item @code{doctex-mode} @tab @code{docTeX-mode}
@item @code{context-mode} @tab @code{ConTeXt-mode}
@item @code{texinfo-mode} @tab @code{Texinfo-mode}
@item @code{ams-tex-mode} @tab @code{AmSTeX-mode}
@item @code{japanese-plain-tex-mode} @tab @code{japanese-plain-TeX-mode}
@item @code{japanese-latex-mode} @tab @code{japanese-LaTeX-mode}
@end multitable
```

So I think we need to add those new modes to the relevant checkers (`tex-chktex`, `tex-lacheck`, `texinfo`, and `textlint`).

Thanks!