### PR TITLE
docstrings should not exceed 80 characters in width

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8120,8 +8120,9 @@ See URL `https://github.com/CSSLint/csslint'."
 (defconst flycheck-stylelint-args '("--formatter" "json")
   "Common arguments to stylelint invocations.")
 
-(flycheck-def-config-file-var flycheck-stylelintrc
-    (css-stylelint scss-stylelint sass-stylelint less-stylelint) nil)
+(let ((print-length 3))
+  (flycheck-def-config-file-var flycheck-stylelintrc
+      (css-stylelint scss-stylelint sass-stylelint less-stylelint) nil))
 
 (flycheck-def-option-var flycheck-stylelint-quiet
     nil (css-stylelint scss-stylelint sass-stylelint less-stylelint)
@@ -8285,7 +8286,8 @@ function from a __device__ function."
 (flycheck-def-option-var flycheck-cuda-extended-lambda nil cuda-nvcc
   "Enable annotating lambda functions with __host__ or __device__.
 
-When non-nil, enable experimental compilation of __host__ and __device__ lambda functions."
+When non-nil, enable experimental compilation of __host__ and
+__device__ lambda functions."
   :type 'boolean
   :safe #'booleanp
   :package-version '(flycheck . "35"))

--- a/flycheck.el
+++ b/flycheck.el
@@ -8120,6 +8120,9 @@ See URL `https://github.com/CSSLint/csslint'."
 (defconst flycheck-stylelint-args '("--formatter" "json")
   "Common arguments to stylelint invocations.")
 
+;; Limit the length of the generated docstring by including only the first three
+;; checker symbols, otherwise emacs will complain about the docstring length
+;; and may refuse to compile the package.
 (let ((print-length 3))
   (flycheck-def-config-file-var flycheck-stylelintrc
       (css-stylelint scss-stylelint sass-stylelint less-stylelint) nil))


### PR DESCRIPTION
The docstring generated for flycheck-stylelintrc includes each of its checkers, ending up 87 characters long.  I restricted its definition to print only the first three (of 4) checkers, which is enough to fix it, though we might want to consider putting this limit in the macro that generates the docstring.

Separately, the docstring for flycheck-cuda-extended-lambda included an overly-long line, which I wrapped.