### PR TITLE
fix(stylelint): remove support for deprecated command line arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ Bugs fixed
 
 - [#2057]: Revert the extraction of ``flycheck-version`` with ``lm-version``.
 
+----------
+Changes
+----------
+
+- **(Breaking)** [#2066]: Remove support for versions of ``stylelint`` older than v14.
+
 34.1 (2024-02-18)
 ======================
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -8235,6 +8235,7 @@ See URL `https://stylelint.io/'."
             (config-file "--config" flycheck-stylelintrc)
             "--stdin-filename" (eval (or (buffer-file-name) "style.css")))
   :standard-input t
+  :verify (lambda (_) (flycheck-stylelint-verify 'css-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (css-mode css-ts-mode)
@@ -9940,6 +9941,7 @@ See URL `https://stylelint.io/'."
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
+  :verify (lambda (_) (flycheck-stylelint-verify 'less-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (less-css-mode))
@@ -12024,6 +12026,25 @@ See URL `https://github.com/brigade/scss-lint'."
                     '(bold error)
                   'success)))))))
 
+(defun flycheck-stylelint-config-exists-p (checker)
+  "Whether there is a valid stylelint config for the current buffer."
+  (eql 0 (flycheck-call-checker-process
+          checker nil nil nil
+          "--print-config" (or buffer-file-name "index.js"))))
+
+(defun flycheck-stylelint-verify (checker)
+  "Verify stylelint setup for CHECKER."
+  (let ((have-config (flycheck-stylelint-config-exists-p checker)))
+    (list
+     (flycheck-verification-result-new
+      :label "configuration available"
+      :message (if have-config "yes" "no config file found")
+      :face (if have-config 'success '(bold error)))
+     (flycheck-verification-result-new
+      :label "stylecheck version"
+      :message (number-to-string (flycheck-stylelint-get-major-version checker))
+      :face 'success))))
+
 (defun flycheck-stylelint-get-major-version (checker)
   "Return major version of stylelint."
   (let ((cb (current-buffer)))
@@ -12047,6 +12068,7 @@ See URL `https://stylelint.io/'."
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
+  :verify (lambda (_) (flycheck-stylelint-verify 'scss-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (scss-mode))

--- a/flycheck.el
+++ b/flycheck.el
@@ -9933,7 +9933,10 @@ See URL `https://lesscss.org'."
 See URL `https://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
-            "--syntax" "less"
+            (eval (when (< (flycheck-stylelint-get-major-version
+                            'less-stylelint)
+                           14)
+                    (list "--syntax" "less")))
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
@@ -12021,13 +12024,26 @@ See URL `https://github.com/brigade/scss-lint'."
                     '(bold error)
                   'success)))))))
 
+(defun flycheck-stylelint-get-major-version (checker)
+  "Return major version of stylelint."
+  (let ((cb (current-buffer)))
+    (with-temp-buffer
+      (let ((temp-buffer (current-buffer)))
+        (with-current-buffer cb
+          (flycheck-call-checker-process
+           checker nil temp-buffer nil "--version"))
+        (string-to-number (car (split-string (buffer-string) "\\.")))))))
+
 (flycheck-define-checker scss-stylelint
   "A SCSS syntax and style checker using stylelint.
 
 See URL `https://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
-            "--syntax" "scss"
+            (eval (when (< (flycheck-stylelint-get-major-version
+                            'scss-stylelint)
+                           14)
+                    (list "--syntax" "scss")))
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t

--- a/flycheck.el
+++ b/flycheck.el
@@ -8235,7 +8235,7 @@ See URL `https://stylelint.io/'."
             (config-file "--config" flycheck-stylelintrc)
             "--stdin-filename" (eval (or (buffer-file-name) "style.css")))
   :standard-input t
-  :verify (lambda (_) (flycheck-stylelint-verify 'css-stylelint))
+  :verify (lambda (_) (flycheck--stylelint-verify 'css-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (css-mode css-ts-mode)
@@ -9937,7 +9937,7 @@ See URL `https://stylelint.io/'."
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
-  :verify (lambda (_) (flycheck-stylelint-verify 'less-stylelint))
+  :verify (lambda (_) (flycheck--stylelint-verify 'less-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (less-css-mode))
@@ -12022,15 +12022,15 @@ See URL `https://github.com/brigade/scss-lint'."
                     '(bold error)
                   'success)))))))
 
-(defun flycheck-stylelint-config-exists-p (checker)
+(defun flycheck--stylelint-config-exists-p (checker)
   "Whether there is a valid stylelint config for the current buffer."
   (eql 0 (flycheck-call-checker-process
           checker nil nil nil
           "--print-config" (or buffer-file-name "index.js"))))
 
-(defun flycheck-stylelint-verify (checker)
+(defun flycheck--stylelint-verify (checker)
   "Verify stylelint setup for CHECKER."
-  (let ((have-config (flycheck-stylelint-config-exists-p checker)))
+  (let ((have-config (flycheck--stylelint-config-exists-p checker)))
     (list
      (flycheck-verification-result-new
       :label "configuration available"
@@ -12038,10 +12038,10 @@ See URL `https://github.com/brigade/scss-lint'."
       :face (if have-config 'success '(bold error)))
      (flycheck-verification-result-new
       :label "stylecheck version"
-      :message (number-to-string (flycheck-stylelint-get-major-version checker))
+      :message (number-to-string (flycheck--stylelint-get-major-version checker))
       :face 'success))))
 
-(defun flycheck-stylelint-get-major-version (checker)
+(defun flycheck--stylelint-get-major-version (checker)
   "Return major version of stylelint."
   (let ((cb (current-buffer)))
     (with-temp-buffer
@@ -12060,7 +12060,7 @@ See URL `https://stylelint.io/'."
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
-  :verify (lambda (_) (flycheck-stylelint-verify 'scss-stylelint))
+  :verify (lambda (_) (flycheck--stylelint-verify 'scss-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (scss-mode))

--- a/flycheck.el
+++ b/flycheck.el
@@ -9934,10 +9934,6 @@ See URL `https://lesscss.org'."
 See URL `https://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
-            (eval (when (< (flycheck-stylelint-get-major-version
-                            'less-stylelint)
-                           14)
-                    (list "--syntax" "less")))
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
@@ -12061,10 +12057,6 @@ See URL `https://github.com/brigade/scss-lint'."
 See URL `https://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
-            (eval (when (< (flycheck-stylelint-get-major-version
-                            'scss-stylelint)
-                           14)
-                    (list "--syntax" "scss")))
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
@@ -12079,10 +12071,10 @@ See URL `https://stylelint.io/'."
 See URL `https://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
-            "--syntax" "sass"
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
   :standard-input t
+  :verify (lambda (_) (flycheck--stylelint-verify 'sass-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
   :modes (sass-mode))


### PR DESCRIPTION
Removes support for versions of stylelint older than 14 by not passing in the `--syntax` argument.

Fixes https://github.com/flycheck/flycheck/issues/1912

I am not sure if this is in good form, and if not, I am happy to close it, but I've forked @Fuco1's [work](https://github.com/flycheck/flycheck/pull/1944) and removed the support for using the major version of stylelint to change the command behavior.