### PR TITLE
Fix(Haskell): Correctly Handle GHC 9.6 Error Output Format

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9541,6 +9541,7 @@ See URL `https://github.com/commercialhaskell/stack'."
                            (one-or-more (not (any ?\n ?|)))))
             line-end)
    (error line-start (file-name) ":" line ":" column ":" (optional " error:")
+          (optional " " "[" (id (one-or-more not-newline)) "]")
           (or (message (one-or-more not-newline))
               (and "\n"
                    (message
@@ -9600,6 +9601,7 @@ See URL `https://www.haskell.org/ghc/'."
                            (one-or-more (not (any ?\n ?|)))))
             line-end)
    (error line-start (file-name) ":" line ":" column ":" (optional " error:")
+          (optional " " "[" (id (one-or-more not-newline)) "]")
           (or (message (one-or-more not-newline))
               (and "\n"
                    (message


### PR DESCRIPTION
This PR addresses an issue with the `haskell-stack-ghc` and `haskell-ghc` checkers in flycheck. Currently, these checkers are unable to correctly parse error output from  ghc 9.6. Instead of displaying the full error message, they would only display the error code (`[GHC-xxxxx]`).

<img width="798" alt="截屏2024-03-26 13 02 56" src="https://github.com/flycheck/flycheck/assets/44194981/d1eb9a6c-1202-46ee-bfe7-0f13c714d517">

This issue arose due to changes in GHC's error output format introduced in version 9.6. The [Release notes](https://downloads.haskell.org/ghc/9.6.1/docs/users_guide/release-notes.html) of GHC 9.6.1 mentions:

> Error messages are now assigned unique error codes, of the form [GHC-12345].

For example, error message in GHC 9.4.7 is:

```
❯ stack ghc a.hs

a.hs:1:8: error: parse error on input ‘a’
  |
1 | module a where
  |
```

And for GHC 9.6.3:

```
❯ stack ghc a.hs

a.hs:1:8: error: [GHC-58481] parse error on input ‘a’
  |
1 | module a where
  | 
```

Flycheck's checkers had not been updated to handle this new format, leading to incomplete error messages. After changing the regex to handle error, flycheck can now handle error message in this form:

<img width="949" alt="截屏2024-03-26 13 12 17" src="https://github.com/flycheck/flycheck/assets/44194981/6d9473c4-e9af-404f-a977-3cafca9ecd44">

The changes in this PR add handling for the new error output format, allowing flycheck to display full error messages once again. This should improve the user experience for developers using GHC 9.6 and later.
