### PR TITLE
Add a new checker 'r' for R

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ New Features
 - [#2035]: Added colors to FlyC mode line and updated mode line menu.
 - [#2059]: Enable checkers for new AUCTeX 14 modes.
 - [#1987]: Add a flag ``flycheck-auto-display-errors-after-checking`` control whether to display errors automatically after checking.
+- [#2070]: Add a new syntax checker ``r`` for R with the builtin ``parse`` function.
 
 -----------
 Bugs fixed

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1136,6 +1136,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Linters to use as a string with an R expression which selects the
          linters to use.
 
+   .. syntax-checker:: r
+
+      Check syntax with R's builtin ``parse`` function.
+
 .. supported-language:: Racket
 
    .. syntax-checker:: racket

--- a/flycheck.el
+++ b/flycheck.el
@@ -204,6 +204,7 @@
     python-pyright
     python-mypy
     r-lintr
+    r
     racket
     rpm-rpmlint
     rst-sphinx
@@ -11016,6 +11017,21 @@ See URL `https://github.com/jimhester/lintr'."
                 :label "lintr library"
                 :message (if has-lintr "present" "missing")
                 :face (if has-lintr 'success '(bold error)))))))
+
+(flycheck-define-checker r
+  "An R syntax checker using the builtin `parse' function.
+
+See URL: `https://www.r-project.org/'."
+  :command ("R" "--slave" "--no-restore" "--no-save" "-e"
+            "parse(file=file('stdin'), srcfile='<stdin>')")
+  :standard-input t
+  :error-patterns
+  ((error line-start (zero-or-more space) "<stdin>:" line ":" column ": "
+          (message) line-end))
+  :modes (ess-mode ess-r-mode)
+  :predicate
+  ;; Don't check ESS files which do not contain R
+  (lambda () (equal ess-language "S")))
 
 (defun flycheck-racket-has-expand-p (checker)
   "Whether the executable of CHECKER provides the `expand' command."

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4365,6 +4365,12 @@ Perhaps:
      '(4 6 warning "Do not use absolute paths." :checker r-lintr)
      '(7 5 error "unexpected end of input" :checker r-lintr))))
 
+(flycheck-ert-def-checker-test r r nil
+  (let ((flycheck-disabled-checkers '(r-lintr)))
+    (flycheck-ert-should-syntax-check
+     "language/r.R" 'R-mode
+     '(8 0 error "unexpected end of input" :checker r))))
+
 (flycheck-ert-def-checker-test racket racket nil
   (skip-unless (funcall (flycheck-checker-get 'racket 'predicate)))
   (let ((inhibit-message t))


### PR DESCRIPTION
This is a rather rudimentary checker using the builtin `parse` function of R. It can only report syntax/parsing errors, but it does not depend on any third-party libraries. So hopefully this checker would still be useful.

As for testing, I saw: https://github.com/flycheck/flycheck/blob/1cc041503deb31e16819a1bdda342820c38ef5f8/doc/contributor/contributing.rst?plain=1#L93-L95

However, it seems that tests for the `r-lintr` checker are still written with ERT in `flycheck-test.el`, so I again added an ERT test for this checker. Please let me know if this is not good.

Thanks!