### PR TITLE
Drop outdated integration testing instructions

### DIFF
--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -106,36 +106,6 @@ Run ``make help`` to see a list of all available targets.  Some common ones are:
 .. _Eask: https://emacs-eask.github.io/
 .. _Buttercup: https://github.com/jorgenschaefer/emacs-buttercup
 
-Running all the integration tests
-=================================
-
-To run all the integration tests, you need to have all the syntax checkers
-installed.  As that can be tedious work, and since your locally installed tools
-can have different versions than the tools used on the CI, we have created a
-Docker image with most of the supported checkers.  To use the Docker image
-locally and replicate the integration tests that are run on the CI, first you
-need to build the image::
-
-  cd flycheck
-  docker pull flycheck/emacs-cask:26.2
-  docker pull flycheck/all-tools:latest
-  docker build --build-arg EMACS_VERSION=26.2 --tag tools-and-emacs:26.2 -f .travis/tools-and-emacs .
-
-Replace ``26.2`` by the Emacs version you want to test.  See the available
-versions on `docker hub`_.
-
-Once the image is built, you can use it to run the integration tests::
-
-  docker run --rm -it -v `pwd`:/flycheck --workdir /flycheck tools-and-emacs:26.2 /bin/bash -c "make integ"
-
-Note that the ``all-tools`` image is rebuilt each month, so the versions of the
-its syntax checkers will change accordingly.  You can check the version of each
-installed tool by running the ``check-tools`` script in the image::
-
-  docker run --rm -it -v `pwd`:/flycheck --workdir /flycheck tools-and-emacs:26.2 check-tools
-
-.. _docker hub: https://hub.docker.com/r/flycheck/emacs-cask/tags
-
 Pull requests
 =============
 


### PR DESCRIPTION
These instructions can’t be followed, because they refer to a Travis-related Dockerfile that no-longer exists, building on container images “rebuilt each month” that actually haven’t been updated for years.