### PR TITLE
Add salt-lint as new flycheck checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ New Features
 - [#2059]: Enable checkers for new AUCTeX 14 modes.
 - [#2067]: Handle correctly GHC 9.6 error output format.
 - [#2070]: Add a new syntax checker ``r`` for R with the builtin ``parse`` function.
+- [#2073]: Add new syntax checker ``salt-lint`` for the salt infrastructure-as-code language.
 
 -----------
 Bugs fixed

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1345,6 +1345,14 @@ to view the docstring of the syntax checker.  Likewise, you may use
          A list of additional library directories. Relative paths are relative
          to the buffer being checked.
 
+.. supported-language:: SaltStack
+
+   .. syntax-checker:: salt-lint
+
+      Flycheck checks SaltStack YAML files with SALT-Lint_.
+
+      .. _SALT-Lint: https://salt-lint.readthedocs.io/en/latest/
+
 .. supported-language:: Sass/SCSS
 
    Flycheck checks SASS with `sass/scss-sass-lint` or

--- a/flycheck.el
+++ b/flycheck.el
@@ -11911,7 +11911,6 @@ The arguments CHECKER and BUFFER are only passed through."
              (json-object-type 'plist)
             (filename (buffer-file-name buffer))
             (errors (json-read-from-string output)))
-        ;(message "%s errors in  %s" errors filename)
         (mapcar (lambda (e)
                   (flycheck-error-new
                    :checker checker


### PR DESCRIPTION
This pull-request adds [`salt-lint`](https://salt-lint.readthedocs.io/en/latest/) as 
a syntax checker for SaltStack YAML files.

I'm eager to help if anything is missing. 