### PR TITLE
Add flycheck-chktex-extra-flags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ New Features
 - [#2071]: Add a new checker ``perl-perlimports``, for cleaning up Perl import statements.
 - [#1972]: New defcustom ``flycheck-clear-displayed-errors-function`` to
   customize how error messages are to be cleared.
+- [#2075]: Add the ``flycheck-chktex-extra-flags`` option to the ``tex-chktex`` checker.
 
 -----------
 Bugs fixed

--- a/flycheck.el
+++ b/flycheck.el
@@ -12602,12 +12602,25 @@ See URL `https://github.com/terraform-linters/tflint'."
   :predicate flycheck-buffer-saved-p
   :modes terraform-mode)
 
+(flycheck-def-option-var flycheck-chktex-extra-flags nil tex-chktex
+  "A list of extra arguments to give to chktex.
+This variable works the same way as `tex-chktex-extra-flags': its value
+is a list of strings, where each string is an argument added to chktex.
+
+For example, to ignore warnings 8 and 18, you would set this option to
+
+  '(\"-n8\" \"-n18\")."
+  :type '(repeat string)
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "35"))
+
 (flycheck-define-checker tex-chktex
   "A TeX and LaTeX syntax and style checker using chktex.
 
 See URL `https://www.nongnu.org/chktex/'."
   :command ("chktex"
             (config-file "--localrc" flycheck-chktexrc)
+            (option-list "" flycheck-chktex-extra-flags concat)
             ;; Compact error messages, and no version information, and execute
             ;; \input statements
             "--verbosity=0" "--quiet" "--inputfiles")


### PR DESCRIPTION
Add an option for the user to customise which options `chktex` is being called with. This can be used to, for example, disable certain checkers. It's essentially a duplicate of `tex-chktex-extra-flags` (which I would much rather use directly, but the consensus seems to be to create `flycheck-*` variables instead).

#### Commit summary

##### [Add flycheck-chktex-extra-flags](https://github.com/flycheck/flycheck/commit/9a5a6456b91ad979ae47b6ad2e601b6fce52851c)

> This works like tex-chktex-extra-flags in that the user may specify arbitrary flags to be passed to chktex.