### PR TITLE
Use project working-directory for python-ruff (#2068)

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10784,6 +10784,7 @@ See URL `https://beta.ruff.rs/docs/'."
             (id (one-or-more (any alpha)) (one-or-more digit)) " "
             (message (one-or-more not-newline))
             line-end))
+  :working-directory flycheck-python-find-project-root 
   :modes (python-mode python-ts-mode)
   :next-checkers ((warning . python-mypy)))
 


### PR DESCRIPTION
Without having working-directory set to the project root, ruff will be confused about path names.