### PR TITLE
Update vhdl-ghdl error-patterns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changes
 ----------
 
 - **(Breaking)** [#2066]: Remove support for versions of ``stylelint`` older than v14.
+- Update error-patterns for ghdl 4.1.0
 
 34.1 (2024-02-18)
 ======================

--- a/flycheck.el
+++ b/flycheck.el
@@ -12701,7 +12701,8 @@ See URL `https://github.com/ghdl/ghdl'."
             (option "--ieee=" flycheck-ghdl-ieee-library concat)
             source)
   :error-patterns
-  ((error line-start (file-name) ":" line ":" column ": " (message) line-end))
+  ((warning line-start (file-name) ":" line ":" column ":warning: " (message) line-end)
+   (error line-start (file-name) ":" line ":" column ":error: " (message) line-end))
   :modes vhdl-mode)
 
 (flycheck-def-option-var flycheck-xml-xmlstarlet-xsd-path nil xml-xmlstarlet


### PR DESCRIPTION
The error message format has changed going from ghdl 4.0.0 to 4.1.0. This also allows differentiating between errors and warnings.