### PR TITLE
ruff: --output-format=text replaced with --output-format=concise

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10767,7 +10767,7 @@ Requires Flake8 3.0 or newer. See URL
 To override the path to the ruff executable, set
 `flycheck-python-ruff-executable'.
 
-See URL `https://beta.ruff.rs/docs/'."
+See URL `https://docs.astral.sh/ruff/'."
   :command ("ruff"
             "check"
             (config-file "--config" flycheck-python-ruff-config)

--- a/flycheck.el
+++ b/flycheck.el
@@ -10771,7 +10771,7 @@ See URL `https://beta.ruff.rs/docs/'."
   :command ("ruff"
             "check"
             (config-file "--config" flycheck-python-ruff-config)
-            "--output-format=text"
+            "--output-format=concise"
             "--stdin-filename" source-original
             "-")
   :standard-input t


### PR DESCRIPTION
ruff 0.5.0 changed this flag in https://github.com/astral-sh/ruff/pull/12010.