### PR TITLE
Fix ruff error-patterns and error-filter

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10834,12 +10834,20 @@ See URL `https://beta.ruff.rs/docs/'."
             "-")
   :standard-input t
   :error-filter (lambda (errors)
-                  (let ((errors (flycheck-sanitize-errors errors)))
-                    (seq-map #'flycheck-flake8-fix-error-level errors)))
+                  (let* ((errors (flycheck-sanitize-errors errors))
+                         (errors-with-ids (seq-filter #'flycheck-error-id errors)))
+                    (seq-union
+                     (seq-difference errors errors-with-ids)
+                     (seq-map #'flycheck-flake8-fix-error-level errors-with-ids))))
   :error-patterns
-  ((warning line-start
+  ((error line-start
+          (or "-" (file-name)) ":" line ":" (optional column ":") " "
+          "SyntaxError: "
+          (message (one-or-more not-newline))
+          line-end)
+   (warning line-start
             (or "-" (file-name)) ":" line ":" (optional column ":") " "
-            (id (one-or-more (any alpha)) (one-or-more digit)) " "
+            (id (one-or-more (any alpha)) (one-or-more digit) " ")
             (message (one-or-more not-newline))
             line-end))
   :modes (python-mode python-ts-mode)


### PR DESCRIPTION
- Add `error-patterns` for `SyntaxError`
- Fix `error-filter` to return error messages with no IDs.

SyntaxErrors in ruff 0.5.0 has no IDs, which will be filtered out with the existing implementation of error-filter. It is also not surfaced as an error previously. This PR fixes both issues.