### PR TITLE
Escape single quote in flycheck-chktex-extra-flags docstring.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12610,7 +12610,7 @@ is a list of strings, where each string is an argument added to chktex.
 
 For example, to ignore warnings 8 and 18, you would set this option to
 
-  '(\"-n8\" \"-n18\")."
+  \\='(\"-n8\" \"-n18\")."
   :type '(repeat string)
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "35"))


### PR DESCRIPTION
Without the escape, byte compilation emits the following error:

  Error: custom-declare-variable `flycheck-chktex-extra-flags' docstring has
         wrong usage of unescaped single quotes (use \= or different quoting)