### PR TITLE
yaml-actionlint: only allow inside GitHub workflows dir

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9234,7 +9234,11 @@ Uses GCC's Fortran compiler gfortran.  See URL
 See URL https://github.com/rhysd/actionlint/."
   :command ("actionlint" "-oneline" source)
   :error-patterns ((error line-start (file-name) ":" line ":" column ": " (message) line-end))
-  :modes (yaml-mode yaml-ts-mode))
+  :modes (yaml-mode yaml-ts-mode)
+  :predicate (lambda ()
+               (string-match-p
+                (rx (or ".github/workflows" ".github\\workflows"))
+                (buffer-file-name))))
 
 (flycheck-define-checker go-gofmt
   "A Go syntax and style checker using the gofmt utility.


### PR DESCRIPTION
Right now, with the default chain and priority setup, the `yaml-actionlint` checker is running first for all YAML files.  For anything outside of a repository's `.github/workflows` (not `.github`!) directory, this checker doesn't make sense.

Without modifying the YAML checker chain, this patch stops `actionlint` from running on files outside this directory.  I also tried to handle Windows but I'm not sure if `.github\\workflows` is the correct path.

I think this checker should be added to the chains after `yaml-yamllint` but wanted to make this change first.