### PR TITLE
eask exec emacs -> eask emacs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ RUNEMACS =
 
 # Program availability
 ifdef EASK
-RUNEMACS = $(EASK) exec $(EMACSBATCH)
+RUNEMACS = $(EASK) $(EMACSBATCH)
 HAVE_EASK := $(shell sh -c "command -v $(EASK)")
 ifndef HAVE_EASK
 $(warning "$(EASK) is not available.  Please run make help")


### PR DESCRIPTION
When trying to get set up to run the integration tests, I found that the modes installed by Eask were simply not being picked up.  It had something to do with the environment produced by calling `eask exec emacs ...` instead of `eask emacs ...`.