### PR TITLE
Fix PyMarkdown configuration lookup

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10878,7 +10878,7 @@ See URL `https://docs.astral.sh/ruff/'."
             (id (one-or-more (any alpha)) (one-or-more digit) " ")
             (message (one-or-more not-newline))
             line-end))
-  :working-directory flycheck-python-find-project-root 
+  :working-directory flycheck-python-find-project-root
   :modes (python-mode python-ts-mode)
   :next-checkers ((warning . python-mypy)))
 
@@ -11319,7 +11319,8 @@ See URL `https://github.com/markdownlint/markdownlint'."
   :modes (markdown-mode gfm-mode))
 
 (flycheck-def-config-file-var flycheck-markdown-pymarkdown-config
-    markdown-pymarkdown nil
+    markdown-pymarkdown
+    '(".pymarkdown" ".pymarkdown.yml" "pyproject.toml")
   :package-version '(flycheck . "34"))
 
 (flycheck-define-checker markdown-pymarkdown
@@ -11327,7 +11328,7 @@ See URL `https://github.com/markdownlint/markdownlint'."
 
 See URL `https://pypi.org/project/pymarkdownlnt/'."
   :command ("pymarkdown"
-            (config-file "--config" flycheck-markdown-markdownlint-cli-config)
+            (config-file "--config" flycheck-markdown-markdown-config)
             "scan"
             source)
   :error-patterns


### PR DESCRIPTION
The PyMarkdown config file lookup variable was set to flycheck-markdown-markdownlinkt-cli-config, so the PyMarkdown configuration was not found. The PyMarkdown configuration defaults were not set, set according to https://github.com/jackdewinter/pymarkdown/blob/main/docs/advanced_configuration.md.