### PR TITLE
Fix markdown for XML and YAML docs

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1682,6 +1682,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
    .. syntax-checker:: xml-xmllint
 
       Check syntax with :program:`xmllint` from Libxml2_.
+
       .. defcustom:: flycheck-xml-xmllint-xsd-path
                      flycheck-xml-xmllint-relaxng-path
 
@@ -1705,6 +1706,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
    .. syntax-checker:: yaml-yamllint
 
-      Check syntax with yamllint.
+      Check syntax with :program:`yamllint`.
 
       .. syntax-checker-config-file:: flycheck-yamllintrc


### PR DESCRIPTION
Hello!

This PR fix markdown for `xml-xmllint` docs: https://www.flycheck.org/en/latest/languages.html#syntax-checker-xml-xmllint

![fix-markdown](https://github.com/user-attachments/assets/bd0a9159-17e1-4585-8b11-37689f74e05c)
