### PR TITLE
Support new puppet-ts-mode

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10602,7 +10602,7 @@ See URL `https://puppet.com/'."
           ": Could not parse for environment " (one-or-more word)
           ": " (message (minimal-match (zero-or-more anything)))
           " at " (file-name "/" (zero-or-more not-newline)) ":" line line-end))
-  :modes puppet-mode
+  :modes (puppet-mode puppet-ts-mode)
   :next-checkers ((warning . puppet-lint)))
 
 (flycheck-def-config-file-var flycheck-puppet-lint-rc puppet-lint
@@ -10644,7 +10644,7 @@ See URL `https://puppet-lint.com/'."
   :error-patterns
   ((warning line-start (file-name) ":" line ":warning: " (message) line-end)
    (error line-start (file-name) ":" line ":error: " (message) line-end))
-  :modes puppet-mode
+  :modes (puppet-mode puppet-ts-mode)
   ;; Since we check the original file, we can only use this syntax checker if
   ;; the buffer is actually linked to a file, and if it is not modified.
   :predicate flycheck-buffer-saved-p)


### PR DESCRIPTION
This PR adds ``puppet-ts-mode`` to the ``:modes`` condition for the two Puppet related checkers.  The change allows the two checkers to also run with the new ``puppet-ts-mode`` that I wrote and which is available on Melpa.

I did not add any tests.  ``puppet-ts-mode`` uses a tree-sitter parser for the Puppet language and that whould have to be installed before the major mode can be used.  I don't think that is feasible in the test framework.