### PR TITLE
Make flycheck-explain-error-at-point copy the full error message instead of the last one

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -5699,8 +5699,10 @@ universal prefix arg, and only the id with normal prefix arg."
   (let ((messages (delq nil (seq-map (or formatter #'flycheck-error-message)
                                      (flycheck-overlay-errors-at pos)))))
     (when messages
-      (seq-do #'kill-new (reverse messages))
-      (message (string-join messages "\n")))))
+      (let ((full-message (string-join messages "\n"))
+      (kill-new full-message)
+      (message full-message)
+      )))))
 
 (defun flycheck-explain-error-at-point ()
   "Display an explanation for the first explainable error at point.


### PR DESCRIPTION
When `flycheck-explain-error-at-point` is used, only the latest error in the messages list is copied to the kill ring.

With this patch, full messages list will be copied into a the kill ring as a single string.

Is the original behavior intended? If so, why is that the case.

And an aside, Is there an alternative to `flycheck-list-errors` but for a single error? I'd like the error at point to be pasted into a new buffer. Is this possible?