### PR TITLE
feat: add options for configuring jsonnet

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10046,10 +10046,10 @@ See URL `https://stedolan.github.io/jq/'."
 For example (\"./lib\") ."
   :type '(repeat (directory :tag "Include directory"))
   :safe #'flycheck-string-list-p
-  :package-version '(flycheck . "20241230"))
+  :package-version '(flycheck . "35.0-snapshot"))
 
 (flycheck-def-args-var flycheck-jsonnet-command-args jsonnet
-  :package-version '(flycheck . "20241230"))
+  :package-version '(flycheck . "35.0-snapshot"))
 
 (flycheck-define-checker jsonnet
   "A Jsonnet syntax checker using the jsonnet binary.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10040,11 +10040,26 @@ See URL `https://stedolan.github.io/jq/'."
           (zero-or-more not-newline) line-end))
   :modes (json-mode js-json-mode json-ts-mode))
 
+(flycheck-def-option-var flycheck-jsonnet-include-paths nil jsonnet
+  "a list of include paths to specify to the jsonnet binary, via -J .
+
+For example (\"./lib\") ."
+  :type '(repeat (directory :tag "Include directory"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "20241230"))
+
+(flycheck-def-args-var flycheck-jsonnet-command-args jsonnet
+  :package-version '(flycheck . "20241230"))
+
 (flycheck-define-checker jsonnet
   "A Jsonnet syntax checker using the jsonnet binary.
 
 See URL `https://jsonnet.org'."
-  :command ("jsonnet" source-inplace)
+  :command
+  ("jsonnet"
+   (option-list "-J" flycheck-jsonnet-include-paths)
+   (eval flycheck-jsonnet-command-args)
+   source-inplace))
   :error-patterns
   ((error line-start "STATIC ERROR: " (file-name) ":"
           (or (seq line ":" column (zero-or-one (seq "-" end-column)))
@@ -10878,7 +10893,7 @@ See URL `https://docs.astral.sh/ruff/'."
             (id (one-or-more (any alpha)) (one-or-more digit) " ")
             (message (one-or-more not-newline))
             line-end))
-  :working-directory flycheck-python-find-project-root 
+  :working-directory flycheck-python-find-project-root
   :modes (python-mode python-ts-mode)
   :next-checkers ((warning . python-mypy)))
 


### PR DESCRIPTION
The Jsonnet tool can take arguments specifying the include directories, and external variables. 
This change allows specification of those options. 

There are no tests in this change. 

I tried to build and add tests for this but:
- The existing tests, executed via `make check specs unit` as directed in the Contributinig doc, do not run successfully. Even the format checks fail.
- if I skip the checks for formatting, and run `make SELECTOR='(language jsonnet)' integ`, the existing jsonnet tests (there are just two) also do not run. They get skipped. I don't know why. 
- if I alter flycheck-test.el to include `(require 'jsonnet-mode)` and modify Eask to add jsonnet-mode as a dependency, the jsonnet tests run, but do not succeed. I tried to get them to succeed, but could not

I spent too much time trying to figure this out, and ran into too many dead-ends.  I love flycheck, but the obstacles to  contributing tests are formidable. 
 
I will gladly add tests if you can provide a master in which the existing jsonnet tests run and succeed. 
