### PR TITLE
Update flycheck-define-checker scala :command to run w/o ansi color codes

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12093,7 +12093,7 @@ See URL `https://github.com/sasstools/sass-lint'."
   "A Scala syntax checker using the Scala compiler.
 
 See URL `https://www.scala-lang.org/'."
-  :command ("scalac" "-Ystop-after:parser" source)
+  :command ("scalac" "-Ystop-after:parser" "-color" "never" source)
   :error-patterns
   ((error line-start (file-name) ":" line ": error: " (message) line-end))
   :modes scala-mode


### PR DESCRIPTION
ansi color codes for colorizing output should be opt-in; this is reflected in these issues:

* https://github.com/scalameta/metals/issues/2621
* https://github.com/flycheck/flycheck/issues/1020

It is also not necessarily trivial to detect and add ansi-color support depending on the implementation of emacs. For me, with doom emacs, this is not easy or transparent: https://github.com/doomemacs/doomemacs/issues/8216