### PR TITLE
Add -Xcompiler option for cuda-nvcc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ New Features
 - [#1972]: New defcustom ``flycheck-clear-displayed-errors-function`` to
   customize how error messages are to be cleared.
 - [#2075]: Add the ``flycheck-chktex-extra-flags`` option to the ``tex-chktex`` checker.
+- [#2107]: Add ``-Xcompiler`` option for ``cuda-nvcc``.
 
 -----------
 Bugs fixed

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -300,6 +300,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
         Allows for ``__host__ __device__`` lambdas as described (`here <https://developer.nvidia.com/blog/new-compiler-features-cuda-8/>`_).
 
+      .. defcustom:: flycheck-cuda-compiler-options
+
+        Specify options directly to the compiler/preprocessor.
+
 .. supported-language:: CWL
 
    .. syntax-checker:: cwl

--- a/flycheck.el
+++ b/flycheck.el
@@ -8401,6 +8401,14 @@ See URL `https://stylelint.io/'."
   :package-version '(flycheck . "32"))
 (make-variable-buffer-local 'flycheck-cuda-language-standard)
 
+(flycheck-def-option-var flycheck-cuda-compiler-options '("-Wall" "-Wextra") cuda-nvcc
+  "Specify options directly to the compiler/preprocessor."
+  :type '(choice (const :tag "No additional compiler options" nil)
+                 (repeat :tag "Addition compiler options"
+                         (string :tag "Compiler option")))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "35"))
+
 (flycheck-def-option-var flycheck-cuda-gencodes nil cuda-nvcc
   "Our real and virtual GPU architectures to pass to nvcc."
   :type '(repeat (file :tag "GPU architecture"))
@@ -8458,6 +8466,7 @@ See URL `https://developer.nvidia.com/cuda-llvm-compiler'."
             (option-flag "--expt-extended-lambda" flycheck-cuda-extended-lambda)
             (option-list "-include" flycheck-cuda-includes)
             (option-list "-gencode" flycheck-cuda-gencodes)
+            (option-list "-Xcompiler" flycheck-cuda-compiler-options)
             (option-list "-D" flycheck-cuda-definitions concat)
             (option-list "-I" flycheck-cuda-include-path)
             source)


### PR DESCRIPTION
The arguments provided to `-Xcompiler` are passed to nvcc's underlyring compiler.