### PR TITLE
Ruby 3.4 compatibility

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11690,7 +11690,8 @@ See URL `https://www.ruby-lang.org/'."
   ((error line-start "SyntaxError in -:" line ": " (message) line-end)
    (warning line-start "-:" line ":" (optional column ":")
             " warning: " (message) line-end)
-   (error line-start "-:" line ": " (message) line-end))
+   ;; Ruby 3.4 includes the interpreter path when emitting syntax errors
+   (error line-start (optional (one-or-more (not (any ":"))) ": ") "-:" line ": " (message) line-end))
   :modes (enh-ruby-mode ruby-mode ruby-ts-mode)
   :next-checkers ((warning . ruby-chef-cookstyle)))
 


### PR DESCRIPTION
Ruby 3.4's new parser includes the ruby path in the first error:

```
Suspicious state from syntax checker ruby: Flycheck checker ruby returned 1, but its output contained no errors: /some-pathruby/3.4.1/bin/ruby: -:3: syntax error found (SyntaxError)
  1 | require_relative "../../automated_init"
  2 | 
> 3 | do
    | ^~ unexpected 'do', ignoring it
  4 | context "Request" do
  5 |   context "Unauthorized" do
```
