### PR TITLE
For checker `python-ruff` default `output-format` to `text` instead o…

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10892,7 +10892,7 @@ See URL `https://docs.astral.sh/ruff/'."
   :command ("ruff"
             "check"
             (config-file "--config" flycheck-python-ruff-config)
-            "--output-format=concise"
+            "--output-format=text"
             (option "--stdin-filename" buffer-file-name)
             "-")
   :standard-input t


### PR DESCRIPTION
…f `concise` which is no longer supported

Verified using ruff version 0.0.291.