### PR TITLE
Add 'flycheck-rust-clippy-args'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``master`` (unreleased)
 ======================
 
+------------
+New Features
+------------
+
+- [#2125]: Add ``flycheck-rust-clippy-args`` for configuring the ``rust-clippy`` checker.
+
 36.0 (2026-02-19)
 ======================
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1284,7 +1284,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          `rust-cargo` requires Rust 1.17 or newer.
          `rust` requires Rust 1.18 or newer.
-         `rust-clippy` requires the nightly version of Rust.
+         `rust-clippy` requires Rust 1.29 or newer.
 
       .. _Cargo: http://doc.crates.io/index.html
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1278,8 +1278,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
       compiler is invoked through ``cargo check`` to take Cargo dependencies
       into account.
 
-      `rust-clippy` has no configurable options.
-
       .. note::
 
          `rust-cargo` requires Rust 1.17 or newer.
@@ -1304,6 +1302,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
          A list of additional arguments passed to the ``cargo check``
          subcommand.
 
+      .. defcustom:: flycheck-rust-clippy-args
+
+         A list of additional arguments passed to the ``cargo clippy``
+         subcommand.
+
       .. defcustom:: flycheck-rust-check-tests
 
          Whether to check test code in Rust.
@@ -1324,6 +1327,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
          For `rust`, the type of the crate to check, as a string for the
          ``--crate-type`` option.
 
+         Ignored by `rust-clippy`.
+
       .. defcustom:: flycheck-rust-binary-name
 
          The name of the binary to pass to ``cargo check --TARGET-TYPE``, as a
@@ -1332,15 +1337,16 @@ to view the docstring of the syntax checker.  Likewise, you may use
          For `rust-cargo`, always required unless `flycheck-rust-crate-type` is
          ``lib`` or nil, in which case it is ignored.
 
-         Ignored by `rust`.
+         Ignored by `rust` and `rust-clippy`.
 
       .. defcustom:: flycheck-rust-features
 
-         List of features to activate during build or check.
+         List of features to activate during build, check, and Clippy.
 
          The value of this variable is a list of strings denoting features
          that will be activated to build the target to check. Features will
-         be passed to ``cargo check --features=FEATURES``.
+         be passed to ``cargo check --features=FEATURES`` and
+         ``cargo clippy --features=FEATURES``.
 
          Empty by default.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -11866,11 +11866,17 @@ This syntax checker needs Rust 1.18 or newer.  See URL
   :modes (rust-mode rust-ts-mode)
   :predicate flycheck-buffer-saved-p)
 
+(flycheck-def-args-var flycheck-rust-clippy-args rust-clippy
+  :package-version '(flycheck . "36.1"))
+
 (flycheck-define-checker rust-clippy
   "A Rust syntax checker using clippy.
 
 See URL `https://github.com/rust-lang-nursery/rust-clippy'."
-  :command ("cargo" "clippy" "--message-format=json")
+  :command ("cargo"
+            "clippy"
+            "--message-format=json"
+            (eval flycheck-rust-clippy-args))
   :error-parser flycheck-parse-cargo-rustc
   :error-filter flycheck-rust-error-filter
   :error-explainer flycheck-rust-error-explainer

--- a/flycheck.el
+++ b/flycheck.el
@@ -11876,6 +11876,8 @@ See URL `https://github.com/rust-lang/rust-clippy'."
   :command ("cargo"
             "clippy"
             "--message-format=json"
+            (option "--features=" flycheck-rust-features concat
+                    flycheck-option-comma-separated-list)
             (eval flycheck-rust-clippy-args))
   :error-parser flycheck-parse-cargo-rustc
   :error-filter flycheck-rust-error-filter

--- a/flycheck.el
+++ b/flycheck.el
@@ -11872,7 +11872,7 @@ This syntax checker needs Rust 1.18 or newer.  See URL
 (flycheck-define-checker rust-clippy
   "A Rust syntax checker using clippy.
 
-See URL `https://github.com/rust-lang-nursery/rust-clippy'."
+See URL `https://github.com/rust-lang/rust-clippy'."
   :command ("cargo"
             "clippy"
             "--message-format=json"


### PR DESCRIPTION
I want to pass `--features=...` to `cargo clippy`.  There are more configuration options implemented for `rust-cargo` than for `rust-clippy`, but this is enough to select features and also pass arbitrary args.