### PR TITLE
Update ruff checker

### DIFF
--- a/Eask
+++ b/Eask
@@ -25,7 +25,6 @@
 
  ;; Various modes for use in the unit tests
  (depends-on "adoc-mode")
- (depends-on "bazel")
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")
  (depends-on "cwl-mode")
@@ -47,9 +46,7 @@
  (depends-on "julia-mode")
  (depends-on "less-css-mode")
  (depends-on "lua-mode")
- (depends-on "markdown-mode")
  (depends-on "mmm-mode")
- (depends-on "nix-mode")
  (depends-on "php-mode")
  (depends-on "processing-mode")
  (depends-on "protobuf-mode")

--- a/flycheck.el
+++ b/flycheck.el
@@ -10914,7 +10914,7 @@ See URL `https://docs.astral.sh/ruff/'."
           line-end)
    (warning line-start
             (or "-" (file-name)) ":" line ":" (optional column ":") " "
-            (id (one-or-more (any alpha)) (one-or-more digit) " ")
+            (id (one-or-more (any alpha)) (one-or-more digit)) " "
             (message (one-or-more not-newline))
             line-end))
   :working-directory flycheck-python-find-project-root

--- a/flycheck.el
+++ b/flycheck.el
@@ -10909,7 +10909,7 @@ See URL `https://docs.astral.sh/ruff/'."
   :error-patterns
   ((error line-start
           (or "-" (file-name)) ":" line ":" (optional column ":") " "
-          "SyntaxError: "
+          (or "SyntaxError: " "invalid-syntax: ")
           (message (one-or-more not-newline))
           line-end)
    (warning line-start

--- a/flycheck.el
+++ b/flycheck.el
@@ -10903,7 +10903,7 @@ See URL `https://docs.astral.sh/ruff/'."
   :error-filter (lambda (errors)
                   (let* ((errors (flycheck-sanitize-errors errors))
                          (errors-with-ids (seq-filter #'flycheck-error-id errors)))
-                    (seq-union
+                    (append
                      (seq-difference errors errors-with-ids)
                      (seq-map #'flycheck-flake8-fix-error-level errors-with-ids))))
   :error-patterns

--- a/flycheck.el
+++ b/flycheck.el
@@ -8912,7 +8912,9 @@ See Info Node `(elisp)Byte Compilation'."
     checkdoc-max-keyref-before-warn
     sentence-end-double-space
     ,@(and (>= emacs-major-version 28)
-           '(checkdoc-column-zero-backslash-before-paren)))
+           '(checkdoc-column-zero-backslash-before-paren))
+    ,@(and (>= emacs-major-version 31)
+           '(checkdoc-allow-quoting-nil-and-t checkdoc-arguments-missing-flag)))
   "Variables inherited by the checkdoc subprocess.")
 
 (defun flycheck-emacs-lisp-checkdoc-variables-form ()

--- a/flycheck.el
+++ b/flycheck.el
@@ -10893,6 +10893,7 @@ Requires Flake8 3.0 or newer. See URL
 See URL `https://docs.astral.sh/ruff/'."
   :command ("ruff"
             "check"
+            "--no-fix"
             (config-file "--config" flycheck-python-ruff-config)
             ;; older versions of ruff (before 0.2) used "text" instead of "concise"
             "--output-format=concise"

--- a/test/flycheck-test.el
+++ b/test/flycheck-test.el
@@ -4254,6 +4254,22 @@ Perhaps:
      '(22 1 error "undefined name 'antigravity'" :id "F821"
           :checker python-flake8))))
 
+(flycheck-ert-def-checker-test python-ruff python syntax-error
+  (flycheck-ert-should-syntax-check
+   "language/python/syntax-error.py" 'python-mode
+   '(3 7 error "Expected an identifier, but found a keyword 'import' that cannot be used here"
+       :checker python-ruff)
+   '(3 14 error "Simple statements must be separated by newlines or semicolons"
+       :checker python-ruff)))
+
+(flycheck-ert-def-checker-test python-ruff python nil
+  (flycheck-ert-should-syntax-check
+   "language/python/test.py" 'python-mode
+   '(5 15 warning "[*] `.antigravit` imported but unused" :id "F401"
+       :checker python-ruff)
+   '(22 1 error "Undefined name `antigravity`" :id "F821"
+        :checker python-ruff)))
+
 (flycheck-ert-def-checker-test python-pyright python nil
   (let ((flycheck-disabled-checkers '(python-mypy))
         (flycheck-checkers '(python-pyright)))


### PR DESCRIPTION
Hi, 
I've enabled the tests and made a couple of fixes to the `python-ruff` checker

<details>
<summary>make SELECTOR='(tag checker-python-ruff)' integ</summary>

```console
make SELECTOR='(tag checker-python-ruff)' integ
eask compile
Compiling ~/.config/emacs/lib/flycheck/flycheck.el... done ✓

Running tests on Emacs 31.0.50, built at 2025-08-29
Running 2 tests (2025-08-29 13:38:37-0500, selector ‘(and "flycheck-" (and (tag external-tool) (tag checker-python-ruff)))’)
   passed  1/2  flycheck-define-checker/python-ruff/default (0.126338 sec)
Can’t guess python-indent-offset, using defaults: 4
Can’t guess python-indent-offset, using defaults: 4
   passed  2/2  flycheck-define-checker/python-ruff/syntax-error (0.044927 sec)

Ran 2 tests, 2 results as expected, 0 unexpected (2025-08-29 13:38:37-0500, 0.171370 sec)
```
</details>