### PR TITLE
Fix awk-gawk checker command quoting

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7656,7 +7656,7 @@ See URL `https://asciidoctor.org'."
   "GNU awk's built-in --lint checker."
   :command ("gawk"
             ;; Avoid code execution.  See https://github.com/w0rp/ale/pull/1411
-            "--source" "'BEGIN{exit} END{exit 1}'"
+            "--source" "\"BEGIN{exit} END{exit 1}\""
             "-f" source
             "--lint"
             "/dev/null")


### PR DESCRIPTION
Fixes #2036
This has probably been broken for years. At some point, flycheck started either wrapping single-quoted string in double quotes, like: 
`"'BEGIN{exit} END{exit 1}'"` gets passed to command line arguments as literal `"'BEGIN{exit} END{exit 1}'"`
or flycheck, for some reason, tries to escape the single quotes 
`"'BEGIN{exit} END{exit 1}'"` gets passed as `\'BEGIN{exit} END{exit 1}\'`
or something entirely different, but gawk still complains about invalid `'`

This is just a band-aid solution by switching single quotes to escaped double quotes.