### PR TITLE
ruff uses invalid-syntax instead of SyntaxError

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -10906,7 +10906,8 @@ See URL `https://docs.astral.sh/ruff/'."
   :error-patterns
   ((error line-start
           (or "-" (file-name)) ":" line ":" (optional column ":") " "
-          "SyntaxError: "
+          ;; first variant is produced by ruff < 0.8 and kept for backward compat
+          (or "SyntaxError: " "invalid-syntax: ")
           (message (one-or-more not-newline))
           line-end)
    (warning line-start


### PR DESCRIPTION
No idea when this happened but it was failing to parse ruff's output for me.

```
> ruff --version
ruff 0.14.0
```