### PR TITLE
Require a recent version of "seq", for "seq-union"

### DIFF
--- a/Eask
+++ b/Eask
@@ -17,6 +17,7 @@
 (source 'melpa)
 
 (depends-on "emacs" "27.1")
+(depends-on "seq" "2.24")
 
 (development
  (depends-on "f")                       ; For some maintenance tools

--- a/flycheck.el
+++ b/flycheck.el
@@ -11,7 +11,7 @@
 ;; URL: https://www.flycheck.org
 ;; Keywords: convenience, languages, tools
 ;; Version: 35.0
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "27.1") (seq "2.24"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Fixes byte compilation in older Emacsen, see #2121