### PR TITLE
Fix some warnings for Emacs 30.

### DIFF
--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -342,15 +342,15 @@ check that the buffer has all ERRORS, and no other errors."
     (should (equal (mapcar #'flycheck-error-without-group expected)
                    (mapcar #'flycheck-error-without-group current)))
     ;; Check that related errors are the same
-    (ignore (cl-mapcar
-             (lambda (err1 err2)
-               (should (equal (flycheck-ert-sort-errors
-                               (mapcar #'flycheck-error-without-group
-                                       (flycheck-related-errors err1 expected)))
-                              (flycheck-ert-sort-errors
-                               (mapcar #'flycheck-error-without-group
-                                       (flycheck-related-errors err2))))))
-             expected current))
+    (cl-mapc
+     (lambda (err1 err2)
+       (should (equal (flycheck-ert-sort-errors
+                       (mapcar #'flycheck-error-without-group
+                               (flycheck-related-errors err1 expected)))
+                      (flycheck-ert-sort-errors
+                       (mapcar #'flycheck-error-without-group
+                               (flycheck-related-errors err2))))))
+     expected current)
     (mapc #'flycheck-ert-should-overlay expected))
   (should (= (length errors)
              (length (flycheck-overlays-in (point-min) (point-max))))))

--- a/flycheck-ert.el
+++ b/flycheck-ert.el
@@ -342,15 +342,15 @@ check that the buffer has all ERRORS, and no other errors."
     (should (equal (mapcar #'flycheck-error-without-group expected)
                    (mapcar #'flycheck-error-without-group current)))
     ;; Check that related errors are the same
-    (cl-mapcar
-     (lambda (err1 err2)
-       (should (equal (flycheck-ert-sort-errors
-                       (mapcar #'flycheck-error-without-group
-                               (flycheck-related-errors err1 expected)))
-                      (flycheck-ert-sort-errors
-                       (mapcar #'flycheck-error-without-group
-                               (flycheck-related-errors err2))))))
-     expected current)
+    (ignore (cl-mapcar
+             (lambda (err1 err2)
+               (should (equal (flycheck-ert-sort-errors
+                               (mapcar #'flycheck-error-without-group
+                                       (flycheck-related-errors err1 expected)))
+                              (flycheck-ert-sort-errors
+                               (mapcar #'flycheck-error-without-group
+                                       (flycheck-related-errors err2))))))
+             expected current))
     (mapc #'flycheck-ert-should-overlay expected))
   (should (= (length errors)
              (length (flycheck-overlays-in (point-min) (point-max))))))

--- a/flycheck.el
+++ b/flycheck.el
@@ -1611,6 +1611,16 @@ Safely delete all files and directories listed in
   (seq-do #'flycheck-safe-delete flycheck-temporaries)
   (setq flycheck-temporaries nil))
 
+(rx-define flycheck-rx-file-name (&rest pat)
+  (eval (if (not '(pat))
+            '(minimal-match (one-or-more not-newline))
+          '(seq pat))))
+
+(rx-define flycheck-rx-message (&rest pat)
+  (eval (if (not '(pat))
+            '(one-or-more not-newline)
+          '(seq pat))))
+
 (defun flycheck-rx-to-string (form &optional no-group)
   "Like `rx-to-string' for FORM, but with special keywords:
 
@@ -1644,14 +1654,10 @@ NO-GROUP is passed to `rx-to-string'.
 
 See `rx' for a complete list of all built-in `rx' forms."
   (rx-let-eval
-      `((file-name (&rest pat) (group-n 1
-                                 ,(or '(minimal-match (one-or-more not-newline))
-                                      'pat)))
+      `((file-name (&rest pat) (group-n 1 (flycheck-rx-file-name pat)))
         (line (group-n 2 (one-or-more digit)))
         (column (group-n 3 (one-or-more digit)))
-        (message (&rest pat) (group-n 4
-                               ,(or '(one-or-more not-newline)
-                                    'pat)))
+        (message (&rest pat) (group-n 4 (flycheck-rx-message pat)))
         (id (&rest pat) (group-n 5 pat))
         (end-line (group-n 6 (one-or-more digit)))
         (end-column (group-n 7 (one-or-more digit))))


### PR DESCRIPTION
I noticed some warnings when compiling flycheck with Emacs 30. This patch is trying to fix them.

```
flycheck.el:1670:11: Warning: ‘rx-constituents’ is an obsolete variable (as of 30.1); use ‘rx-let’, ‘rx-let-eval’, or ‘rx-define’ instead.
flycheck.el:1661:10: Warning: ‘rx-constituents’ is an obsolete variable (as of 30.1); use ‘rx-let’, ‘rx-let-eval’, or ‘rx-define’ instead.
flycheck.el:10256:11: Warning: in defcustom for ‘flycheck-perl-module-list’: ‘repeat’ without type specs
flycheck-ert.el:345:6: Warning: value from call to ‘cl-mapcar’ is unused
```

P.S. I removed some helper function but I don't know if they are used by other projects.