### PR TITLE
Fix awk-gawk checker passing spurious quotes to gawk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bugs fixed
 -----------
 
 - [#2086]: Fix the name of the PyMarkdown config.
+- [#2036]: Fix ``awk-gawk`` checker passing spurious quotes to ``gawk --source``.
 
 35.0 (2025-04-23)
 ======================

--- a/flycheck.el
+++ b/flycheck.el
@@ -7657,7 +7657,7 @@ See URL `https://asciidoctor.org'."
   "GNU awk's built-in --lint checker."
   :command ("gawk"
             ;; Avoid code execution.  See https://github.com/w0rp/ale/pull/1411
-            "--source" "'BEGIN{exit} END{exit 1}'"
+            "--source" "BEGIN{exit} END{exit 1}"
             "-f" source
             "--lint"
             "/dev/null")


### PR DESCRIPTION
## Summary
- Remove spurious single quotes from the `--source` argument in the `awk-gawk` checker
- Flycheck uses `start-process`, which passes arguments directly to the executable without shell interpretation, so shell-style quoting like `'BEGIN{exit} END{exit 1}'` passes the literal quote characters to `gawk`, causing syntax errors

Fixes #2036
Supersedes #2130

## Test plan
- Existing `awk-gawk` syntax-error integration test in `test/specs/languages/test-awk.el` covers this
- The test verifies that gawk correctly reports errors, which requires the `--source` argument to be valid awk