### PR TITLE
Resolve symbol references in flycheck-define-checker :error-patterns

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7448,7 +7448,8 @@ SYMBOL with `flycheck-def-executable-var'."
          :command ',command
          ,@(when parser
              `(:error-parser #',parser))
-         :error-patterns ',(plist-get properties :error-patterns)
+         :error-patterns ',(let ((pat (plist-get properties :error-patterns)))
+                            (if (symbolp pat) (symbol-value pat) pat))
          ,@(when filter
              `(:error-filter #',filter))
          ,@(when explainer
@@ -11183,6 +11184,14 @@ See URL `https://github.com/rpm-software-management/rpmlint'."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "33"))
 
+(eval-and-compile
+  (defconst flycheck-markdownlint-error-patterns
+    '((error line-start
+             (file-name) ":" line
+             (? ":" column) " " (id (one-or-more (not (any space))))
+             " " (message) line-end))
+    "Error patterns shared by markdownlint-cli and markdownlint-cli2."))
+
 (defun flycheck-markdownlint-error-filter (errors)
   "Error filter for markdownlint checkers."
   (flycheck-sanitize-errors
@@ -11204,11 +11213,7 @@ See URL `https://github.com/igorshubovych/markdownlint-cli'."
             (option-list "--enable" flycheck-markdown-markdownlint-cli-enable-rules)
             "--"
             source)
-  :error-patterns
-  ((error line-start
-          (file-name) ":" line
-          (? ":" column) " " (id (one-or-more (not (any space))))
-          " " (message) line-end))
+  :error-patterns flycheck-markdownlint-error-patterns
   :error-filter flycheck-markdownlint-error-filter
   :modes (markdown-mode gfm-mode)
   :error-explainer flycheck-markdownlint-error-explainer)
@@ -11226,11 +11231,7 @@ See URL `https://github.com/DavidAnson/markdownlint-cli2'."
             (config-file "--config" flycheck-markdown-markdownlint-cli2-config)
             "--"
             source)
-  :error-patterns
-  ((error line-start
-          (file-name) ":" line
-          (? ":" column) " " (id (one-or-more (not (any space))))
-          " " (message) line-end))
+  :error-patterns flycheck-markdownlint-error-patterns
   :error-filter flycheck-markdownlint-error-filter
   :modes (markdown-mode gfm-mode)
   :error-explainer flycheck-markdownlint-error-explainer)
@@ -12099,6 +12100,17 @@ See URL `https://stylelint.io/'."
 (flycheck-def-args-var flycheck-sh-bash-args (sh-bash)
   :package-version '(flycheck . "32"))
 
+(eval-and-compile
+  (defconst flycheck-bash-error-patterns
+    '((error line-start
+             ;; The name/path of the bash executable
+             (one-or-more (not (any ":"))) ":"
+             ;; A label "line", possibly localized
+             (one-or-more (not (any digit)))
+             line (zero-or-more " ") ":" (zero-or-more " ")
+             (message) line-end))
+    "Error patterns for Bash syntax checkers."))
+
 (flycheck-define-checker sh-bash
   "A Bash syntax checker using the Bash shell.
 
@@ -12107,14 +12119,7 @@ See URL `https://www.gnu.org/software/bash/'."
             (eval flycheck-sh-bash-args)
             "--")
   :standard-input t
-  :error-patterns
-  ((error line-start
-          ;; The name/path of the bash executable
-          (one-or-more (not (any ":"))) ":"
-          ;; A label "line", possibly localized
-          (one-or-more (not (any digit)))
-          line (zero-or-more " ") ":" (zero-or-more " ")
-          (message) line-end))
+  :error-patterns flycheck-bash-error-patterns
   :modes (sh-mode bash-ts-mode)
   :predicate (lambda () (eq sh-shell 'bash))
   :next-checkers ((warning . sh-shellcheck)))
@@ -12137,14 +12142,7 @@ See URL `https://gondor.apana.org.au/~herbert/dash/'."
 See URL `https://www.gnu.org/software/bash/'."
   :command ("bash" "--posix" "--norc" "-n" "--")
   :standard-input t
-  :error-patterns
-  ((error line-start
-          ;; The name/path of the bash executable
-          (one-or-more (not (any ":"))) ":"
-          ;; A label "line", possibly localized
-          (one-or-more (not (any digit)))
-          line (zero-or-more " ") ":" (zero-or-more " ")
-          (message) line-end))
+  :error-patterns flycheck-bash-error-patterns
   :modes sh-mode
   :predicate (lambda () (eq sh-shell 'sh))
   :next-checkers ((warning . sh-shellcheck)))


### PR DESCRIPTION
## Summary

- Fix the `flycheck-define-checker` macro to resolve symbol references in `:error-patterns` via `symbol-value` at expansion time
- Wrap shared `defconst` forms (`flycheck-markdownlint-error-patterns`, `flycheck-bash-error-patterns`) in `eval-and-compile` so they're available during byte-compilation

This is an alternative approach to ec989b18 which inlined the patterns. Instead of duplicating the patterns, this keeps them shared via `defconst` and teaches the macro to handle symbol references.

## Context

The `flycheck-define-checker` macro quotes `:error-patterns` at expansion time with `',(plist-get ...)`. When the value is a literal list this works fine, but when it's a symbol (variable reference), the result is a quoted symbol rather than the list it refers to — causing `(wrong-type-argument sequencep ...)` at load time.

## Test plan

- [x] `emacs --batch -L . -l flycheck.el` loads without errors
- [x] Byte-compilation produces no warnings
- [ ] CI passes