### PR TITLE
Handle unknown identifiers for Chicken Scheme

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12003,6 +12003,13 @@ See URL `https://call-cc.org/'."
             "Warning: " (zero-or-more not-newline) ":\n"
             (one-or-more (any space)) "(" (file-name) ":" line ") " (message)
             line-end)
+   (error line-start
+          "Error: Module `" (one-or-more not-newline) "' has unresolved identifiers\n"
+          (zero-or-more space) "In file `" (file-name) "':"
+          line-end)
+   (error line-start
+          (zero-or-more space) (message) "\n" (zero-or-more space) "On line " line
+          line-end)
    (error line-start "Error: (line " line ") " (message) line-end)
    (error line-start "Syntax error: (" (file-name) ":" line ")"
           (zero-or-more not-newline) " - "


### PR DESCRIPTION
Hello,

this adds support for error patterns corresponding to unknown identifiers. Before this fix, if a file had enough unknown identifiers, Emacs could completely freeze. Something around 5-6 identifiers is the threshold between significant lag & almost completely freezing.

Sample problematic program:
```scheme
(module peak-chicken ()

(import (scheme) (chicken base))

(display "lol")
(newline)
(this is something that causes issues)

)
```

`csc -analyze-only -local $FILE` output:
```text

Error: Module `peak-chicken' has unresolved identifiers
  In file `peak-chicken.scm':

  Unknown identifier `this'
    On line 7

  Unknown identifier `is'
    On line 7

  Unknown identifier `something'
    On line 7

  Unknown identifier `that'
    On line 7

  Unknown identifier `causes'
    On line 7

  Unknown identifier `issues'
    On line 7

Error: shell command terminated with non-zero exit status 256: '/opt/homebrew/Cellar/chicken/5.4.0/bin/chicken' 'peak-chicken.scm' -output-file 'peak-chicken.c' '-analyze-only'
```

And this is how the fix looks in Emacs:
![flycheck-chicken-fix](https://github.com/user-attachments/assets/6430239d-1dc6-48f3-9e11-a05ed287c56d)

I played around with `csc` and found out that the line number that is reported corresponds to the line number of the enclosing parens of the Sexpression, not the exact line number of the symbols themselves. This means that if I remove the enclosing parens, then all of them will be reported as being on line 1, etc. Also, if the symbols are outside any Sexpression enclosing parenthesis, they don't even get reported as being unknown identifiers. This is all related to how the chicken compiler works, but I thought I'd share here just in case.

