### PR TITLE
Fix org-lint line number handling

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -8849,7 +8849,10 @@ has access to all installed packages and user configuration."
                                (pcase e
                                  (`(,_n [,line ,_trust ,desc ,_checker])
                                   (flycheck-error-new-at
-                                   line nil 'info desc
+                                   (if (stringp line)
+                                       (string-to-number line)
+                                     line)
+                                   nil 'info desc
                                    :checker checker))
                                  (_
                                   (flycheck-error-new-at


### PR DESCRIPTION
Corrects this issue:

```
Error from syntax checker org-lint: Wrong type argument: number-or-marker-p, #("7" 0 1 (org-lint-marker #<marker at 178 in [D] Some File>))
```

May be Emacs 31 specific. Referenced in #2161 
