### PR TITLE
Add luau-analyze syntax checker

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -761,6 +761,16 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check syntax with the `Lua compiler <https://www.lua.org/>`_.
 
+.. supported-language:: Luau
+
+   Flycheck checks Lua with `luau-analyze`.
+
+   .. syntax-checker:: luau-analyze
+
+      Check syntax and lint with luau-analyze.
+
+      .. _Luau-analyze: https://github.com/luau-lang/luau
+
 .. supported-language:: Markdown
 
    Flycheck checks Markdown with `markdownlint-cli`, `markdownlint-cli2`,

--- a/flycheck.el
+++ b/flycheck.el
@@ -171,6 +171,7 @@
     llvm-llc
     lua-luacheck
     lua
+    luau-analyze
     markdown-markdownlint-cli
     markdown-markdownlint-cli2
     markdown-mdl
@@ -10017,6 +10018,30 @@ See URL `https://www.lua.org/'."
           ;; Skip the name of the luac executable.
           (minimal-match (zero-or-more not-newline))
           ": stdin:" line ": " (message) line-end))
+  :modes (lua-mode lua-ts-mode))
+
+(flycheck-define-checker luau-analyze
+  "A Luau syntax checker using luau-analyze.
+
+See URL `https://github.com/luau-lang/luau'."
+  :command ("luau-analyze" "--formatter=plain" source-original)
+  :error-patterns
+  ((warning line-start
+            (file-name)
+            ":" line ":" column "-" end-column
+            ": (" (id "W" (one-or-more digit)) ") "
+            (message) line-end)
+   (error line-start
+          (file-name)
+          ":" line ":" column "-" end-column
+          ": (" (id "E" (one-or-more digit)) ") "
+          (message) line-end))
+  :working-directory
+  (lambda (checker)
+    (ignore checker)
+    (when buffer-file-name
+      (or (locate-dominating-file buffer-file-name ".luaurc")
+          (file-name-directory buffer-file-name))))
   :modes (lua-mode lua-ts-mode))
 
 (flycheck-define-checker opam

--- a/test/resources/language/luau/syntax-error.luau
+++ b/test/resources/language/luau/syntax-error.luau
@@ -1,0 +1,7 @@
+-- A syntax error caused by a missing quote
+--
+-- Checkers: luau-analyze
+
+print "oh no
+
+print "hello world"

--- a/test/resources/language/luau/warnings.luau
+++ b/test/resources/language/luau/warnings.luau
@@ -1,0 +1,6 @@
+global_var = 1
+
+local function test(arg)
+    local var2
+    return var2
+end

--- a/test/specs/languages/test-luau.el
+++ b/test/specs/languages/test-luau.el
@@ -1,0 +1,21 @@
+;;; test-luau.el --- Flycheck Specs: Luau -*- lexical-binding: t; -*-
+;;; Code:
+(require 'flycheck-buttercup)
+(require 'test-helpers)
+
+(describe "Language Luau"
+  (flycheck-buttercup-def-checker-test luau-analyze luau syntax-error
+    (flycheck-buttercup-should-syntax-check
+     "language/luau/syntax-error.luau" 'lua-mode
+     '(5 1 warning "SyntaxError: Incomplete statement: expected assignment or a function call" :id "W0" :checker luau-analyze)
+     (5 7 warning "SameLineStatement: A new statement is on the same line; add semi-colon on previous statement to silence" :id "W0" :checker luau-analyze)))
+
+  (flycheck-buttercup-def-checker-test luau-analyze luau warnings
+    (flycheck-buttercup-should-syntax-check
+     "language/luau/warnings.luau" 'lua-mode
+     '(3 16 warning "FunctionUnused: Function 'test' is never used; prefix with '_' to silence"
+         :id "W0" :checker luau-analyze)
+     '(5 12 warning "UninitializedLocal: Variable 'var2' defined at line 4 is never initialized or assigned; initialize with 'nil' to silence"
+         :id "W0" :checker luau-analyze))))
+
+;;; test-luau.el ends here


### PR DESCRIPTION
Hi, I add a new syntax check for luau programming language, using cli tool `luau-analyze`

https://github.com/luau-lang/luau

Luau is Roblox’s official scripting language, derived from Lua 5.1, optimized for game development with optional static typing, fast execution, and deep integration into Roblox Studio. It supports dynamic typing by default, but developers can add type annotations for better safety and maintainability.

I added unit test and updated doc. Run `make spec` in project root and looks ok. But I'm not sure how the unit test for luau script works. Not sure luau-analyze is included in any Linux distribution. Let me know what should I do next?

screenshot of working checker,
<img width="991" height="580" alt="image" src="https://github.com/user-attachments/assets/784975b5-d661-49a1-828b-08c94e299125" />


