### PR TITLE
ghc checkers: add default case for -x option.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -9524,8 +9524,8 @@ See URL `https://github.com/commercialhaskell/stack'."
             (eval flycheck-ghc-args)
             "-x" (eval
                   (pcase major-mode
-                    (`haskell-mode "hs")
-                    (`haskell-literate-mode "lhs")))
+                    (`haskell-literate-mode "lhs")
+                    (_ "hs")))
             source)
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ":"
@@ -9584,8 +9584,8 @@ See URL `https://www.haskell.org/ghc/'."
             (eval flycheck-ghc-args)
             "-x" (eval
                   (pcase major-mode
-                    (`haskell-mode "hs")
-                    (`haskell-literate-mode "lhs")))
+                    (`haskell-literate-mode "lhs")
+                    (_ "hs")))
             source)
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ":"


### PR DESCRIPTION
This provides support for other major modes like `haskell-ts-mode'.

Maybe we should find a wiser predicate for this option? I don't know if we can neglect it conditionally.