### PR TITLE
Preserve wrap-prefix text property on error overlays

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -4767,15 +4767,44 @@ function resolves `conditional' style specifications."
       (setf (overlay-get overlay 'wrap-prefix)
             (flycheck-error-level-make-indicator
              level flycheck-indication-mode t))
-      ;; Preserve any existing line-prefix text property (e.g. from
-      ;; org-indent-mode) so the overlay doesn't clobber indentation.
+      ;; Preserve existing text-property prefixes so the overlay doesn't
+      ;; clobber indentation set by other modes.
+      ;;
+      ;; line-prefix: copy the text property onto the overlay unchanged
+      ;; (e.g. from org-indent-mode).
+      ;;
+      ;; wrap-prefix: compose the flycheck fringe indicator with the
+      ;; existing value (e.g. from visual-wrap-prefix-mode).  The fringe
+      ;; indicator uses a `display' property for `!' that directly
+      ;; renders in the fringe without producing any character in the
+      ;; text area.  This effectively-zero-width character is composed
+      ;; by concatenation with the preexisting wrap prefix.
+      ;;
+      ;; Per the Elisp manual ("Properties with Special Meanings"),
+      ;; `wrap-prefix' may be a string, an image, or a stretch spec (`:width' or
+      ;; `:align-to').  When the preexisting value is a string (e.g. a repeated
+      ;; comment prefix like "% "), concatenate it directly; otherwise wrap it
+      ;; in a propertized character via its `display' property so it can be
+      ;; concatenated.
+      ;;
+      ;; Without this, an error overlay on the first character of a
+      ;; soft-wrapped visual continuation line replaces the indentation
+      ;; prefix with the fringe-only indicator, causing the line to
+      ;; jump to column 0.
       (when (buffer-live-p (overlay-buffer overlay))
         (save-restriction
           (widen)
-          (let ((existing-prefix (get-text-property
-                                  (overlay-start overlay) 'line-prefix)))
-            (when existing-prefix
-              (setf (overlay-get overlay 'line-prefix) existing-prefix))))))
+          (let* ((pos (overlay-start overlay))
+                 (existing-lp (get-text-property pos 'line-prefix))
+                 (existing-wp (get-text-property pos 'wrap-prefix)))
+            (when existing-lp
+              (setf (overlay-get overlay 'line-prefix) existing-lp))
+            (when existing-wp
+              (setf (overlay-get overlay 'wrap-prefix)
+                    (concat (overlay-get overlay 'wrap-prefix)
+                            (if (stringp existing-wp)
+                                existing-wp
+                              (propertize " " 'display existing-wp)))))))))
     (pcase (flycheck--highlighting-style err)
       ((or `nil (guard (null flycheck-highlighting-mode)))
        ;; Erase the highlighting


### PR DESCRIPTION
## Summary

Flycheck error overlays clobber the `wrap-prefix` text property set by `visual-wrap-prefix-mode`, causing soft-wrapped continuation lines to lose their indentation.

## Problem

When a buffer uses `visual-wrap-prefix-mode` (built into Emacs 30+), continuation lines of long logical lines are indented to match the first line — for example, a paragraph indented at column 10 has all its visual continuation lines also indented at column 10. This indentation is stored as a `wrap-prefix` text property on the logical line.

Flycheck places its own `wrap-prefix` on error overlays — a fringe continuation bitmap that marks visual continuation lines belonging to an error. The fringe indicator is a propertized string (`"!"`) with a `display` property that directly renders in the fringe without producing any character in the text area. Because overlay properties take precedence over text properties in Emacs, wherever a flycheck error overlay sits, its fringe-only `wrap-prefix` replaces the indentation prefix.

Most of the time this is invisible: if the error is in the middle of a line, the display engine reads the `wrap-prefix` at the start of the visual continuation line, which is outside the overlay, and produces the correct indentation. But when the error happens to land on the **first character of a visual continuation line**, the overlay's `wrap-prefix` wins, the indentation is lost, and the continuation line jumps to column 0 — the clobbering behavior described in the summary.

## Demonstration

Line 153 in the screenshots below is a single long logical line that soft-wraps onto three visual lines. The word "normalised" at the start of the third visual line carries a flycheck spelling diagnostic (squiggly underline).

**Before (broken):** the overlay's `wrap-prefix` overrides the indentation, and the third visual line jumps to column 0:

<img width="2384" height="688" alt="wrong-indentation-before-PR-line-153" src="https://github.com/user-attachments/assets/2ea68185-7c1c-4096-a4c2-6aa342ba3455" />

**After (fixed):** the indentation is preserved on all three visual lines:

<img width="2364" height="610" alt="correct-indentation-after-PR-line-153" src="https://github.com/user-attachments/assets/f71a1ee7-e1ab-464a-af2b-76947272c5b2" />

**Note:** In the screenshots above, the fringe error indicator (`»`) appears on the second visual line rather than the third (where "normalised" is displayed). This is a separate display engine behavior/bug unrelated to this PR: when `word-wrap` is enabled, the `before-string` of an overlay is rendered on the visual line before the word-wrap boundary, while the character itself moves to the next line. This bug is mentioned here for context but it is unrelated to the `wrap-prefix` fix in this PR, and has likely to be addressed by filing a report on https://debbugs.gnu.org/cgi/pkgreport.cgi?package=emacs.

## Fix

Flycheck already preserves the existing `line-prefix` text property on error overlays (added for `org-indent-mode` compatibility). This patch extends the same logic to `wrap-prefix`: instead of unconditionally replacing it, the flycheck fringe indicator is composed with the preexisting `wrap-prefix` by concatenating them. Since the fringe indicator's `display` property renders it directly in the fringe without producing any character in the text area, the concatenated result shows both the continuation bitmap/svg in the fringe and the correct indentation in the text area.

Per the Elisp manual ([Properties with Special Meanings](https://www.gnu.org/software/emacs/manual/html_node/elisp/Special-Properties.html)), `wrap-prefix` may be a string, an image, or a stretch spec (`:width` or `:align-to`). When the preexisting value is a string (e.g., a repeated comment prefix like `"% "`), it is concatenated directly; otherwise it is wrapped in a propertized character via its `display` property so it can be concatenated. The patch handles all forms.

## How to reproduce

1. Open a file in a mode that uses `visual-wrap-prefix-mode` (or enable it manually).
2. Have a long logical line that soft-wraps onto multiple visual lines, with indentation.
3. Trigger a flycheck diagnostic (e.g., a spelling error from an LSP grammar checker) on a word that happens to start at the beginning of a visual continuation line.
4. The continuation line jumps to column 0.
