### PR TITLE
Ask before saving the buffer in the verify commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@
   extensions like flycheck-posframe keep working unchanged.
 - The error counts in the mode line are clickable: ``mouse-1`` pops up
   the error list.
+- ``flycheck-verify-setup`` and ``flycheck-verify-checker`` now ask
+  before saving a modified buffer instead of saving it silently.
 - [#1787]: Add the ``:handle-suspicious`` property to command checkers.
   It lets a checker translate a "suspicious state" (a non-zero exit
   status with no parsable errors, e.g. a missing dependency) into

--- a/flycheck.el
+++ b/flycheck.el
@@ -2838,9 +2838,12 @@ is applicable from Emacs Lisp code.  Use
   (unless (flycheck-valid-checker-p checker)
     (user-error "%s is not a syntax checker" checker))
 
-  ;; Save the buffer to make sure that all predicates are good
-  ;; FIXME: this may be surprising to users, with unintended side-effects.
-  (when (and (buffer-file-name) (buffer-modified-p))
+  ;; Predicates and `:enabled' functions usually check the file on disk, so
+  ;; the verification is only accurate for a saved buffer.  Ask instead of
+  ;; saving behind the user's back, which may have unintended side effects
+  ;; (e.g. save hooks and file watchers).
+  (when (and (buffer-file-name) (buffer-modified-p)
+             (y-or-n-p "Save the buffer to make the verification accurate? "))
     (save-buffer))
 
   (let ((buffer (current-buffer)))
@@ -2866,9 +2869,10 @@ Display a new buffer listing all syntax checkers that could be
 applicable in the current buffer.  For each syntax checker,
 possible problems are shown."
   (interactive)
-  ;; Save to make sure checkers that only work on saved buffers will pass the
-  ;; verification
-  (when (and (buffer-file-name) (buffer-modified-p))
+  ;; Checkers that only work on saved buffers would fail the verification
+  ;; for a modified buffer, so ask instead of saving behind the user's back
+  (when (and (buffer-file-name) (buffer-modified-p)
+             (y-or-n-p "Save the buffer to make the verification accurate? "))
     (save-buffer))
 
   (let* ((buffer (current-buffer))


### PR DESCRIPTION
`flycheck-verify-setup` and `flycheck-verify-checker` silently saved a modified buffer to make the verification accurate, which can trigger unintended side effects (save hooks, file watchers, formatters). Now they ask first. Resolves a long-standing FIXME; the other jump-related FIXME in that area turned out to be stale since `flycheck-jump-to-error` already handles other-file errors.