### PR TITLE
Migrate dockerfile-hadolint to the SARIF parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 =======================
 
 - Drop support for Emacs 27; Flycheck now requires Emacs 28.1 or newer.
+- The ``dockerfile-hadolint`` checker now parses hadolint's SARIF output
+  (``--format sarif``) via ``flycheck-parse-sarif`` instead of matching
+  its text output with error patterns, so it no longer breaks when
+  hadolint tweaks its human-readable format.
+- ``flycheck-parse-sarif`` now treats a zero-width SARIF region (where
+  the start and end positions coincide, as some tools emit for
+  line-level findings) as spanning the whole line, instead of producing
+  an empty highlight.
 - Add ``flycheck-parse-sarif``, a ready-made ``:error-parser`` for the
   SARIF output format that many analyzers can emit.  Like the existing
   ``flycheck-parse-checkstyle``, checker definitions can point

--- a/flycheck.el
+++ b/flycheck.el
@@ -8028,18 +8028,38 @@ information about SARIF."
                       (seq-map
                        (lambda (location)
                          (let-alist location
-                           (flycheck-error-new-at
-                            .physicalLocation.region.startLine
-                            .physicalLocation.region.startColumn
-                            level message
-                            :id id
-                            :checker checker
-                            :buffer buffer
-                            :filename
-                            (flycheck-parse-sarif--uri
-                             .physicalLocation.artifactLocation.uri)
-                            :end-line .physicalLocation.region.endLine
-                            :end-column .physicalLocation.region.endColumn)))
+                           (let* ((start-line
+                                   .physicalLocation.region.startLine)
+                                  (start-col
+                                   .physicalLocation.region.startColumn)
+                                  (end-line
+                                   .physicalLocation.region.endLine)
+                                  (end-col
+                                   .physicalLocation.region.endColumn)
+                                  ;; A zero-width region carries no span:
+                                  ;; endColumn equals startColumn on the same
+                                  ;; line (endLine defaults to startLine per
+                                  ;; the SARIF spec).  Some tools emit these
+                                  ;; for line-level findings, so treat them as
+                                  ;; the whole line -- drop the column and end
+                                  ;; and let the highlighting mode take over,
+                                  ;; rather than highlight an empty range.
+                                  (zero-width
+                                   (and end-col
+                                        (equal end-col start-col)
+                                        (or (null end-line)
+                                            (equal end-line start-line)))))
+                             (flycheck-error-new-at
+                              start-line (unless zero-width start-col)
+                              level message
+                              :id id
+                              :checker checker
+                              :buffer buffer
+                              :filename
+                              (flycheck-parse-sarif--uri
+                               .physicalLocation.artifactLocation.uri)
+                              :end-line (unless zero-width end-line)
+                              :end-column (unless zero-width end-col)))))
                        .locations)
                     ;; A result without a location applies to the whole run
                     (list (flycheck-error-new-at
@@ -9275,25 +9295,17 @@ Requires DMD 2.066 or newer.  See URL `https://dlang.org/'."
   "A Dockerfile syntax checker using hadolint.
 
 See URL `https://github.com/hadolint/hadolint/'."
-  :command ("hadolint" "--no-color" "-")
+  :command ("hadolint" "--format" "sarif" "-")
   :standard-input t
-  :error-patterns
-  ((error line-start
-          (file-name) ":" line " " (id (one-or-more alnum)) " error: " (message)
-          line-end)
-   (warning line-start
-            (file-name) ":" line " " (id (one-or-more alnum))
-            " warning: " (message) line-end)
-   (info line-start
-         (file-name) ":" line " " (id (one-or-more alnum)) " info: " (message)
-         line-end)
-   (error line-start
-          (file-name) ":" line ":" column " " (message)
-          line-end))
+  :error-parser flycheck-parse-sarif
   :error-filter
   (lambda (errors)
+    ;; hadolint reports stdin as "-" for lint findings but as
+    ;; "/dev/stdin" for parse errors; strip both so the errors attach to
+    ;; the current buffer
     (flycheck-sanitize-errors
-     (flycheck-remove-error-file-names "-" errors)))
+     (flycheck-remove-error-file-names
+      "/dev/stdin" (flycheck-remove-error-file-names "-" errors))))
   :modes (dockerfile-mode dockerfile-ts-mode))
 
 (defun flycheck-credo--working-directory (&rest _ignored)

--- a/test/specs/languages/test-dockerfile.el
+++ b/test/specs/languages/test-dockerfile.el
@@ -7,17 +7,16 @@
   (flycheck-buttercup-def-checker-test dockerfile-hadolint dockerfile error
     (flycheck-buttercup-should-syntax-check
      "language/dockerfile/Dockerfile.error" 'dockerfile-mode
-     '(2 1 error "unexpected 'I' expecting '#', '\\', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, at least one space, or end of input"
-         :checker dockerfile-hadolint)))
+     '(2 nil error "unexpected 'I'
+expecting '#', '\\', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, a pragma, at least one space, or end of input"
+         :id "DL1000" :checker dockerfile-hadolint)))
 
   (flycheck-buttercup-def-checker-test dockerfile-hadolint dockerfile warnings
     (flycheck-buttercup-should-syntax-check
      "language/dockerfile/Dockerfile.warning" 'dockerfile-mode
      '(1 nil warning "Always tag the version of an image explicitly"
          :id "DL3006" :checker dockerfile-hadolint)
-     '(2 nil error "Do not use apt-get upgrade or dist-upgrade"
-         :id "DL3005" :checker dockerfile-hadolint)
-     '(2 nil info "Delete the apt-get lists after installing something"
+     '(2 nil info "Delete the apt lists (/var/lib/apt/lists) after installing something"
          :id "DL3009" :checker dockerfile-hadolint)
      '(3 nil error "Use absolute WORKDIR"
          :id "DL3000" :checker dockerfile-hadolint))))

--- a/test/specs/test-error-parsers.el
+++ b/test/specs/test-error-parsers.el
@@ -111,6 +111,45 @@
                  (car (flycheck-parse-sarif sarif 'checker 'buffer)))
                 :to-equal "/abs/path.py")))
 
+    (it "treats a zero-width region as the whole line"
+      ;; A start == end region carries no span; drop the column and end so
+      ;; the whole line is highlighted rather than an empty range.  Also
+      ;; covers endLine omitted, which defaults to startLine.
+      (dolist (region '("\"startLine\":2,\"startColumn\":1,\"endLine\":2,\"endColumn\":1"
+                        "\"startLine\":2,\"startColumn\":4,\"endColumn\":4"))
+        (let* ((sarif (concat "{\"runs\":[{\"tool\":{\"driver\":{\"name\":\"d\"}},\
+\"results\":[{\"message\":{\"text\":\"m\"},\"locations\":[{\"physicalLocation\":\
+{\"artifactLocation\":{\"uri\":\"a.txt\"},\"region\":{" region "}}}]}]}]}"))
+               (err (car (flycheck-parse-sarif sarif 'checker 'buffer))))
+          (expect (flycheck-error-line err) :to-equal 2)
+          (expect (flycheck-error-column err) :to-be nil)
+          (expect (flycheck-error-end-line err) :to-be nil)
+          (expect (flycheck-error-end-column err) :to-be nil))))
+
+    (it "keeps a non-empty region's end position"
+      (let ((sarif "{\"runs\":[{\"tool\":{\"driver\":{\"name\":\"d\"}},\
+\"results\":[{\"message\":{\"text\":\"m\"},\"locations\":[{\"physicalLocation\":\
+{\"artifactLocation\":{\"uri\":\"a.txt\"},\"region\":\
+{\"startLine\":2,\"startColumn\":3,\"endLine\":2,\"endColumn\":7}}}]}]}]}"))
+        (let ((err (car (flycheck-parse-sarif sarif 'checker 'buffer))))
+          (expect (flycheck-error-column err) :to-equal 3)
+          (expect (flycheck-error-end-line err) :to-equal 2)
+          (expect (flycheck-error-end-column err) :to-equal 7))))
+
+    (it "keeps multiple results at the same location distinct"
+      (let ((sarif "{\"runs\":[{\"tool\":{\"driver\":{\"name\":\"d\"}},\
+\"results\":[\
+{\"ruleId\":\"A\",\"message\":{\"text\":\"first\"},\"locations\":[\
+{\"physicalLocation\":{\"artifactLocation\":{\"uri\":\"a.txt\"},\
+\"region\":{\"startLine\":3}}}]},\
+{\"ruleId\":\"B\",\"message\":{\"text\":\"second\"},\"locations\":[\
+{\"physicalLocation\":{\"artifactLocation\":{\"uri\":\"a.txt\"},\
+\"region\":{\"startLine\":3}}}]}]}]}"))
+        (expect (mapcar (lambda (e) (list (flycheck-error-id e)
+                                          (flycheck-error-message e)))
+                        (flycheck-parse-sarif sarif 'checker 'buffer))
+                :to-equal '(("A" "first") ("B" "second")))))
+
     (it "utf-8-decodes percent escapes in file URIs"
       (let ((sarif "{\"runs\":[{\"tool\":{\"driver\":{\"name\":\"d\"}},\
 \"results\":[{\"message\":{\"text\":\"m\"},\"locations\":[{\"physicalLocation\":\


### PR DESCRIPTION
Migrates `dockerfile-hadolint` from error patterns to `flycheck-parse-sarif` (`hadolint --format sarif`), the first consumer of the SARIF parser added earlier. hadolint's SARIF carries proper severities (error/warning/note, mapping to error/warning/info), full message text and rule ids, so the checker no longer breaks when hadolint changes its human-readable output. The error filter strips the stdin markers hadolint uses (`-` for lint findings, `/dev/stdin` for parse errors) so findings attach to the current buffer.

Also improves the shared parser: a zero-width SARIF region (endColumn equal to startColumn on the same line, which hadolint emits for line-level findings) is now treated as spanning the whole line, matching the old text-pattern behavior, rather than highlighting an empty range or a lone whitespace character on indented lines. Real multi-character spans are untouched.

Verified end-to-end against hadolint 2.14.0, including the parse-error path. The dockerfile language specs skip in CI (hadolint isn't installed there, same as before), so the expectations were derived from real hadolint output on the spec resource files.
