### PR TITLE
Run syntax checkers over TRAMP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 ``master`` (unreleased)
 =======================
 
+- [#1816]: Flycheck now runs syntax checkers over TRAMP.  When a buffer
+  visits a remote file, command checkers execute on the remote host
+  (their executables must be installed there) instead of being unable to
+  run.  ``global-flycheck-mode`` enables Flycheck in remote buffers by
+  default.  Because each check spawns a remote process, remote buffers
+  are checked on fewer triggers by default (``save`` and
+  ``mode-enabled``); customize
+  ``flycheck-check-syntax-automatically-remote`` to change this.  Builds
+  on the earlier work in [#1842].
 
 37.0 (2026-07-18)
 =================

--- a/doc/user/flycheck-versus-flymake.rst
+++ b/doc/user/flycheck-versus-flymake.rst
@@ -113,8 +113,8 @@ it for all ``prog-mode`` buffers.  If no backends for the major mode are
 available, Flymake will non-intrusively tell you in the modeline.
 
 **Flycheck** provides a global mode `global-flycheck-mode` which enables syntax
-checking in every supported language, where it is safe to do so (remote and
-encrypted buffers are excluded by default).
+checking in every supported language, including remote files over TRAMP
+(encrypted buffers are excluded by default).
 
 Syntax checkers
 ---------------

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -20,13 +20,16 @@ possible.
 
    .. note::
 
-      This mode does not enable :mode:`flycheck` in remote files (via
-      TRAMP) and encrypted files.  Checking remote files may be very slow
-      depending on the network connections, and checking encrypted files would
-      leak confidential data to temporary files and subprocesses.
+      Remote files (via TRAMP) are checked like local ones: command checkers
+      run on the remote host, so the tools need to be installed there rather
+      than locally.  Because each check spawns a process over the network,
+      remote buffers are checked on fewer triggers by default; see
+      `flycheck-check-syntax-automatically-remote`.
 
-      You can manually enable :mode:`flycheck` in these buffers nonetheless, but
-      we do *not* recommend this for said reasons.
+      This mode does not enable :mode:`flycheck` in encrypted files, as
+      checking them would leak confidential data to temporary files and
+      subprocesses.  You can manually enable :mode:`flycheck` in these buffers
+      nonetheless, but we do *not* recommend it for said reason.
 
    Add the following to your :term:`init file` to enable syntax checking
    permanently:
@@ -132,6 +135,19 @@ You can customise this behaviour with `flycheck-check-syntax-automatically`:
    .. code-block:: elisp
 
       (setq flycheck-check-syntax-automatically '(mode-enabled save))
+
+.. defcustom:: flycheck-check-syntax-automatically-remote
+
+   The same as `flycheck-check-syntax-automatically`, but for buffers visiting
+   remote files (see `file-remote-p`).  Checking a remote buffer spawns a
+   process on the remote host over TRAMP, which is slow, so by default the
+   change-driven triggers (``idle-change``, ``new-line`` and
+   ``idle-buffer-switch``) are excluded and remote buffers are only checked on
+   ``save`` and ``mode-enabled``.
+
+   Set it to ``t`` to check remote buffers on the same events as local ones.
+   A manual check with :command:`flycheck-buffer` (:kbd:`C-c ! c`) always
+   works regardless of this option.
 
 When a change-driven syntax check (``idle-change`` or ``save``) is triggered
 while a recently started check is still running, the running check is

--- a/flycheck.el
+++ b/flycheck.el
@@ -7062,14 +7062,17 @@ PROCESS, and terminates standard input with EOF."
   "Start a command CHECKER with CALLBACK."
   (let (process)
     (condition-case err
-        (let* (;; `flycheck-find-checker-executable' may return a remote
+        (let* (;; `flycheck-find-checker-executable' may return nil for a
+               ;; cached-enabled checker whose executable later vanished.
+               ;; Fail the check cleanly rather than starting a process with
+               ;; a nil program, which never exits and hangs the check.
+               (executable (or (flycheck-find-checker-executable checker)
+                               (error "Cannot find the executable of checker %s"
+                                      checker)))
+               ;; `flycheck-find-checker-executable' may return a remote
                ;; (TRAMP) file name; the process program must be the plain
-               ;; local name on the remote host.  It may also return nil (a
-               ;; cached-enabled checker whose executable later vanished), in
-               ;; which case leave it nil, as before, rather than erroring in
-               ;; `file-local-name'.
-               (executable (flycheck-find-checker-executable checker))
-               (program (and executable (file-local-name executable)))
+               ;; local name on the remote host.
+               (program (file-local-name executable))
                (args (flycheck-checker-substituted-arguments checker))
                (command (flycheck--wrap-command program args))
                (sentinel-events nil)
@@ -10445,8 +10448,11 @@ pragma.  Each extension is enabled via `-X'."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.19"))
 
-(defvar flycheck-haskell-ghc-cache-directory (make-hash-table :test 'equal)
-  "The cache directory for `ghc' output, keyed by host.
+;; A hash table (not the scalar of earlier versions -- hence the new name,
+;; so an in-session reload does not leave a stale non-table value that
+;; `gethash' would choke on).
+(defvar flycheck--haskell-ghc-cache-directories (make-hash-table :test 'equal)
+  "The cache directories for `ghc' output, keyed by host.
 The key is the remote identifier of `default-directory' (see
 `file-remote-p'), or nil for the local host, since `ghc' runs on
 the host of the checked buffer and needs a cache directory there.")
@@ -10458,12 +10464,12 @@ If no cache directory exists yet for the current host, create one
 on that host and return it.  Otherwise return the previously used
 cache directory."
   (let ((host (file-remote-p default-directory)))
-    (or (gethash host flycheck-haskell-ghc-cache-directory)
+    (or (gethash host flycheck--haskell-ghc-cache-directories)
         ;; `make-nearby-temp-file' creates the directory on the host of
         ;; `default-directory', so `ghc' running there can write to it.
         (puthash host
                  (make-nearby-temp-file "flycheck-haskell-ghc-cache" 'directory)
-                 flycheck-haskell-ghc-cache-directory))))
+                 flycheck--haskell-ghc-cache-directories))))
 
 (defun flycheck--locate-dominating-file-matching (directory regexp)
   "Search for a file in directory hierarchy starting at DIRECTORY.
@@ -11384,7 +11390,10 @@ See URL `https://proselint.com/' for more information about proselint."
               (let-alist (car response)
                 .result.<stdin>.diagnostics)))))
 
-(defvar flycheck--proselint-use-old-args (make-hash-table :test 'equal)
+;; A hash table (not the scalar of earlier versions -- hence the new name,
+;; so an in-session reload does not leave a stale non-table value that
+;; `gethash' would choke on).
+(defvar flycheck--proselint-old-args-by-host (make-hash-table :test 'equal)
   "Cache for proselint version detection, keyed by host.
 The key is the remote identifier of `default-directory' (see
 `file-remote-p'), or nil for the local host, since the proselint
@@ -11397,14 +11406,14 @@ absent from the table has not been probed yet.")
 (defun flycheck--proselint-args ()
   "Return command arguments for proselint, detecting the version once per host."
   (let ((host (file-remote-p default-directory)))
-    (when (eq (gethash host flycheck--proselint-use-old-args 'unknown) 'unknown)
+    (when (eq (gethash host flycheck--proselint-old-args-by-host 'unknown) 'unknown)
       (puthash host
                ;; Probe on the host the check will run on (remote over TRAMP).
                (zerop (process-file
                        (or flycheck-proselint-executable "proselint")
                        nil nil nil "--version"))
-               flycheck--proselint-use-old-args))
-    (if (gethash host flycheck--proselint-use-old-args)
+               flycheck--proselint-old-args-by-host))
+    (if (gethash host flycheck--proselint-old-args-by-host)
         ;; Proselint versions <= 0.14.0:
         (list "--json" "-")
       ;; Proselint versions >= 0.16.0

--- a/flycheck.el
+++ b/flycheck.el
@@ -85,6 +85,7 @@
 ;; Declare a bunch of dynamic variables that we need from other modes
 (defvar sh-shell)                       ; For shell script checker predicates
 (defvar ess-language)                   ; For r-lintr predicate
+(defvar tramp-remote-process-environment) ; For remote checker env, see below
 (defvar markdown-hide-markup)                     ;
 (defvar markdown-fontify-code-block-default-mode) ; For rust-error-explainer
 (defvar markdown-fontify-code-blocks-natively)    ;
@@ -566,17 +567,20 @@ sandboxes."
 (defun flycheck-default-executable-find (executable)
   "Resolve EXECUTABLE to a full path.
 
-Like `executable-find', but supports relative paths.
+Like `executable-find', but supports relative paths, and resolves
+EXECUTABLE on the remote host when `default-directory' is remote,
+so that checkers can run over TRAMP.
 
 Attempts invoking `executable-find' first; if that returns nil,
 and EXECUTABLE contains a directory component, expands to a full
 path and tries invoking `executable-find' again."
-  ;; file-name-directory returns non-nil iff the given path has a
-  ;; directory component.
-  (or
-   (executable-find executable)
-   (when (file-name-directory executable)
-     (executable-find (expand-file-name executable)))))
+  (let ((remote (file-remote-p default-directory)))
+    ;; file-name-directory returns non-nil iff the given path has a
+    ;; directory component.
+    (or
+     (executable-find executable remote)
+     (when (file-name-directory executable)
+       (executable-find (expand-file-name executable) remote)))))
 
 (defcustom flycheck-indication-mode 'auto
   "The indication mode for Flycheck errors.
@@ -1566,6 +1570,19 @@ to a number and return it.  Otherwise return nil."
       (puthash file (file-truename (directory-file-name file))
                flycheck--file-truename-cache)))
 
+(defun flycheck--expand-file-name (filename directory)
+  "Expand FILENAME against DIRECTORY, honoring a remote DIRECTORY.
+
+Like `expand-file-name', but when DIRECTORY is remote and
+FILENAME is a host-local path -- as a checker running on the
+remote host over TRAMP reports -- the result names the file on
+that host, so it compares against the remote temporary files and
+opens the right file when jumped to."
+  (if-let* ((remote (and (not (file-remote-p filename))
+                         (file-remote-p directory))))
+      (concat remote (expand-file-name filename (file-local-name directory)))
+    (expand-file-name filename directory)))
+
 (defun flycheck-same-files-p (file-a file-b)
   "Determine whether FILE-A and FILE-B refer to the same file.
 
@@ -1584,8 +1601,12 @@ if they resolve to the same canonical paths."
 Use `flycheck-temp-prefix' as prefix, and add the directory to
 `flycheck-temporaries'.
 
-Return the path of the directory"
-  (let* ((tempdir (make-temp-file flycheck-temp-prefix 'directory)))
+Return the path of the directory.
+
+The directory is created on the remote host when
+`default-directory' is remote, so that checkers running over
+TRAMP can access it."
+  (let* ((tempdir (make-nearby-temp-file flycheck-temp-prefix 'directory)))
     (push tempdir flycheck-temporaries)
     tempdir))
 
@@ -1606,7 +1627,7 @@ Return the path of the file."
                    (if filename
                        (expand-file-name (file-name-nondirectory filename)
                                          (flycheck-temp-dir-system))
-                     (make-temp-file flycheck-temp-prefix nil suffix)))))
+                     (make-nearby-temp-file flycheck-temp-prefix nil suffix)))))
     (push tempfile flycheck-temporaries)
     tempfile))
 
@@ -4430,7 +4451,7 @@ Return ERRORS, modified in-place."
   (seq-do (lambda (err)
             (setf (flycheck-error-filename err)
                   (if-let (filename (flycheck-error-filename err))
-                      (expand-file-name filename directory)
+                      (flycheck--expand-file-name filename directory)
                     (buffer-file-name))))
           errors)
   errors)
@@ -6692,7 +6713,12 @@ from INFILE, and its output is sent to DESTINATION, as in
 `call-process'."
   (if-let (executable (flycheck-find-checker-executable checker))
       (condition-case err
-          (apply #'call-process executable infile destination nil args)
+          ;; `process-file' runs EXECUTABLE on the remote host when
+          ;; `default-directory' is remote, and behaves like
+          ;; `call-process' otherwise.  The program must be the plain
+          ;; local name on that host.
+          (apply #'process-file (file-local-name executable)
+                 infile destination nil args)
         (error (when error (signal (car err) (cdr err)))))
     (when error
       (user-error "Cannot find `%s' using `flycheck-executable-find'"
@@ -6851,30 +6877,44 @@ Note that substitution is *not* recursive.  No symbols or cells
 are substituted within the body of cells!"
   (pcase arg
     ((pred stringp) (list arg))
+    ;; File names below are reduced with `file-local-name': the checker
+    ;; process runs on the host of `default-directory' (a remote host
+    ;; over TRAMP) and must receive a plain local name, not a TRAMP file
+    ;; name.  The temporary files are created and later deleted through
+    ;; their full (possibly remote) names.
     (`source
-     (list (flycheck-save-buffer-to-temp #'flycheck-temp-file-system)))
+     (list (file-local-name
+            (flycheck-save-buffer-to-temp #'flycheck-temp-file-system))))
     (`source-inplace
-     (list (flycheck-save-buffer-to-temp #'flycheck-temp-file-inplace)))
+     (list (file-local-name
+            (flycheck-save-buffer-to-temp #'flycheck-temp-file-inplace))))
     (`(source ,suffix)
-     (list (flycheck-save-buffer-to-temp
-            (lambda (filename) (flycheck-temp-file-system filename suffix)))))
+     (list (file-local-name
+            (flycheck-save-buffer-to-temp
+             (lambda (filename) (flycheck-temp-file-system filename suffix))))))
     (`(source-inplace ,suffix)
-     (list (flycheck-save-buffer-to-temp
-            (lambda (filename) (flycheck-temp-file-inplace filename suffix)))))
-    (`source-original (list (or (buffer-file-name) "")))
-    (`temporary-directory (list (flycheck-temp-dir-system)))
+     (list (file-local-name
+            (flycheck-save-buffer-to-temp
+             (lambda (filename) (flycheck-temp-file-inplace filename suffix))))))
+    (`source-original (list (if-let* ((f (buffer-file-name)))
+                                (file-local-name f)
+                              "")))
+    (`temporary-directory (list (file-local-name (flycheck-temp-dir-system))))
     (`temporary-file-name
      (let ((directory (flycheck-temp-dir-system)))
-       (list (make-temp-name (expand-file-name "flycheck" directory)))))
+       (list (file-local-name
+              (make-temp-name (expand-file-name "flycheck" directory))))))
     (`null-device (list null-device))
     (`(config-file ,option-name ,file-name-var)
      (when-let* ((value (symbol-value file-name-var))
                  (file-name (flycheck-locate-config-file value checker)))
-       (flycheck-prepend-with-option option-name (list file-name))))
+       (flycheck-prepend-with-option
+        option-name (list (file-local-name file-name)))))
     (`(config-file ,option-name ,file-name-var ,prepend-fn)
      (when-let* ((value (symbol-value file-name-var))
                  (file-name (flycheck-locate-config-file value checker)))
-       (flycheck-prepend-with-option option-name (list file-name) prepend-fn)))
+       (flycheck-prepend-with-option
+        option-name (list (file-local-name file-name)) prepend-fn)))
     (`(option ,option-name ,variable)
      (when-let (value (symbol-value variable))
        (unless (stringp value)
@@ -6953,7 +6993,11 @@ PROCESS, and terminates standard input with EOF."
   "Start a command CHECKER with CALLBACK."
   (let (process)
     (condition-case err
-        (let* ((program (flycheck-find-checker-executable checker))
+        (let* (;; `flycheck-find-checker-executable' may return a remote
+               ;; (TRAMP) file name; the process program must be the plain
+               ;; local name on the remote host
+               (program (file-local-name
+                         (flycheck-find-checker-executable checker)))
                (args (flycheck-checker-substituted-arguments checker))
                (command (flycheck--wrap-command program args))
                (sentinel-events nil)
@@ -6967,10 +7011,15 @@ PROCESS, and terminates standard input with EOF."
                ;; rather than LC_ALL so that the character encoding
                ;; (LC_CTYPE) is left untouched; using LC_ALL=C forces an
                ;; ASCII locale that breaks checkers reading UTF-8 input,
-               ;; such as hledger (see #2170).
-               (process-environment (cons "LC_MESSAGES=C" process-environment)))
+               ;; such as hledger (see #2170).  For remote checks the
+               ;; environment reaches the process through
+               ;; `tramp-remote-process-environment'.
+               (process-environment (cons "LC_MESSAGES=C" process-environment))
+               (tramp-remote-process-environment
+                (when (boundp 'tramp-remote-process-environment)
+                  (cons "LC_MESSAGES=C" tramp-remote-process-environment))))
           ;; We do not associate the process with any buffer, by
-          ;; passing nil for the BUFFER argument of `start-process'.
+          ;; passing nil for the BUFFER argument of `start-file-process'.
           ;; Instead, we just remember the buffer being checked in a
           ;; process property (see below).  This neatly avoids all
           ;; side-effects implied by attaching a process to a buffer, which
@@ -6978,7 +7027,12 @@ PROCESS, and terminates standard input with EOF."
           ;;
           ;; See https://github.com/flycheck/flycheck/issues/298 for an
           ;; example for such a conflict.
-          (setq process (apply 'start-process (format "flycheck-%s" checker)
+          ;;
+          ;; We use `start-file-process' rather than `start-process' so
+          ;; the checker runs on the remote host when `default-directory'
+          ;; is remote; it behaves exactly like `start-process' otherwise.
+          (setq process (apply 'start-file-process
+                               (format "flycheck-%s" checker)
                                nil command))
           ;; Process sentinels can be called while sending input to the process.
           ;; We want to record errors raised by process-send before calling
@@ -7341,8 +7395,11 @@ _CHECKER is ignored."
   "Locate a configuration FILENAME in the home directory.
 
 Return the absolute path, if FILENAME exists in the user's home
-directory, or nil otherwise."
-  (let ((path (expand-file-name filename "~")))
+directory, or nil otherwise.  For a remote buffer, the remote
+user's home directory is searched."
+  (let* ((remote (file-remote-p default-directory))
+         (home (if remote (concat remote "~") "~"))
+         (path (expand-file-name filename home)))
     (when (file-exists-p path)
       path)))
 
@@ -7582,7 +7639,7 @@ ERR is in BUFFER-FILES, replace it with the value of variable
   (flycheck-error-with-buffer err
     (when-let (filename (flycheck-error-filename err))
       (when (seq-some (apply-partially #'flycheck-same-files-p
-                                       (expand-file-name filename cwd))
+                                       (flycheck--expand-file-name filename cwd))
                       buffer-files)
         (setf (flycheck-error-filename err) buffer-file-name)
         (when (and buffer-file-name (flycheck-error-message err))
@@ -11180,8 +11237,10 @@ See https://github.com/processing/processing/wiki/Command-Line"
   :command ("processing-java" "--force"
             ;; Don't change the order of these arguments, processing is pretty
             ;; picky
-            (eval (concat "--sketch=" (file-name-directory (buffer-file-name))))
-            (eval (concat "--output=" (flycheck-temp-dir-system)))
+            (eval (concat "--sketch=" (file-local-name
+                                       (file-name-directory (buffer-file-name)))))
+            (eval (concat "--output=" (file-local-name
+                                       (flycheck-temp-dir-system))))
             "--build")
   :error-patterns
   ((error line-start (file-name) ":" line ":" column
@@ -11243,7 +11302,8 @@ or `unknown' if not yet detected.")
   "Return command arguments for proselint, detecting the version once."
   (when (eq flycheck--proselint-use-old-args 'unknown)
     (setq flycheck--proselint-use-old-args
-          (zerop (call-process
+          ;; Probe on the host the check will run on (remote over TRAMP)
+          (zerop (process-file
                   (or flycheck-proselint-executable "proselint")
                   nil nil nil "--version"))))
   (if flycheck--proselint-use-old-args
@@ -11278,7 +11338,8 @@ are relative to the file being checked."
 
 See URL `https://developers.google.com/protocol-buffers/'."
   :command ("protoc" "--error_format" "gcc"
-            (eval (concat "--java_out=" (flycheck-temp-dir-system)))
+            (eval (concat "--java_out=" (file-local-name
+                                         (flycheck-temp-dir-system))))
             ;; Add the current directory to resolve imports
             (eval (concat "--proto_path="
                           (file-name-directory (buffer-file-name))))
@@ -12719,7 +12780,7 @@ This syntax checker needs Rust 1.18 or newer.  See URL
   :command ("rustc"
             (option "--crate-type" flycheck-rust-crate-type)
             "--emit=metadata"
-            "--out-dir" (eval (flycheck-temp-dir-system)) ; avoid creating binaries
+            "--out-dir" (eval (file-local-name (flycheck-temp-dir-system))) ; avoid creating binaries
             "--error-format=json"
             (option-flag "--test" flycheck-rust-check-tests)
             (option-list "-L" flycheck-rust-library-path concat)

--- a/flycheck.el
+++ b/flycheck.el
@@ -874,6 +874,32 @@ If nil, never check syntax automatically.  In this case, use
   :package-version '(flycheck . "0.12")
   :safe #'flycheck-symbol-list-p)
 
+(defcustom flycheck-check-syntax-automatically-remote '(save mode-enabled)
+  "When Flycheck should check syntax automatically in remote buffers.
+
+Like `flycheck-check-syntax-automatically', but used for buffers
+visiting remote files (see `file-remote-p').  Checking a remote
+buffer spawns a process on the remote host over TRAMP, which is
+slow, so the change-driven triggers (`idle-change', `new-line',
+`idle-buffer-switch') are excluded by default and remote buffers
+are only checked on `save' and `mode-enabled'.
+
+Set to the symbol t to check remote buffers on the same events as
+local ones, i.e. to use `flycheck-check-syntax-automatically'
+unchanged.  A manual \\[flycheck-buffer] always works regardless
+of this option."
+  :group 'flycheck
+  :type '(choice
+          (const :tag "Same as local buffers" t)
+          (set (const :tag "After the buffer was saved" save)
+               (const :tag "After the buffer was changed and idle" idle-change)
+               (const
+                :tag "After switching the current buffer" idle-buffer-switch)
+               (const :tag "After a new line was inserted" new-line)
+               (const :tag "After `flycheck-mode' was enabled" mode-enabled)))
+  :package-version '(flycheck . "38")
+  :safe (lambda (value) (or (eq value t) (flycheck-symbol-list-p value))))
+
 (defcustom flycheck-idle-change-delay 0.5
   "How many seconds to wait after a change before checking syntax.
 
@@ -3792,10 +3818,16 @@ under at least one of them, according to
   (and (not (or buffer-read-only (flycheck-ephemeral-buffer-p)))
        (file-exists-p default-directory)
        (or (not conditions)
-           (seq-some
-            (lambda (condition)
-              (memq condition flycheck-check-syntax-automatically))
-            conditions))))
+           (let ((allowed
+                  ;; Remote buffers use a narrower set of trigger events by
+                  ;; default, since each check spawns a slow remote process
+                  (if (and (file-remote-p default-directory)
+                           (not (eq flycheck-check-syntax-automatically-remote
+                                    t)))
+                      flycheck-check-syntax-automatically-remote
+                    flycheck-check-syntax-automatically)))
+             (seq-some (lambda (condition) (memq condition allowed))
+                       conditions)))))
 
 (defvar-local flycheck--idle-trigger-timer nil
   "Timer used to trigger a syntax check after an idle delay.")
@@ -4004,8 +4036,10 @@ Flycheck mode is not enabled for
 - Flycheck's own error message buffer,
 - ephemeral buffers (see `flycheck-ephemeral-buffer-p'),
 - encrypted buffers (see `flycheck-encrypted-buffer-p'),
-- remote files (see `file-remote-p'),
 - and major modes excluded by `flycheck-global-modes'.
+
+Remote files (see `file-remote-p') are checked like local ones;
+command checkers run on the remote host over TRAMP.
 
 Return non-nil if Flycheck mode may be enabled, and nil
 otherwise."
@@ -4019,9 +4053,7 @@ otherwise."
                 (eq (get major-mode 'mode-class) 'special)
                 (derived-mode-p 'flycheck-error-message-mode)
                 (flycheck-ephemeral-buffer-p)
-                (flycheck-encrypted-buffer-p)
-                (and (buffer-file-name)
-                     (file-remote-p (buffer-file-name) 'method))))))
+                (flycheck-encrypted-buffer-p)))))
 
 (defun flycheck-mode-on-safe ()
   "Enable command `flycheck-mode' if it is safe to do so.

--- a/flycheck.el
+++ b/flycheck.el
@@ -1609,6 +1609,15 @@ opens the right file when jumped to."
       (concat remote (expand-file-name filename (file-local-name directory)))
     (expand-file-name filename directory)))
 
+(defun flycheck-buffer-file-local-name (&optional fallback)
+  "Return the visited file's name as a plain local name.
+
+Strip any remote (TRAMP) prefix with `file-local-name', so a
+checker running on the host of the buffer's file receives a path
+that is valid there.  Return FALLBACK when the buffer has no
+backing file."
+  (if buffer-file-name (file-local-name buffer-file-name) fallback))
+
 (defun flycheck-same-files-p (file-a file-b)
   "Determine whether FILE-A and FILE-B refer to the same file.
 
@@ -6623,10 +6632,12 @@ of command checkers is `flycheck-sanitize-errors'.
      Some checkers that support reading from standard input have
      a separate flag to indicate the name of the file whose
      contents are being passed on standard input (typically
-     `stdin-filename').  In that case, use the `(option)' form in
-     `:command' to pass the value of variable `buffer-file-name'
-     when the current buffer has a file name (that is,
-     use `option \"--stdin-file-name\" buffer-file-name').
+     `stdin-filename').  In that case, use an `(eval)' form in
+     `:command' to pass `flycheck-buffer-file-local-name', which
+     yields the file name the checker's host understands even when
+     the buffer visits a remote file over TRAMP (that is, use
+     `eval (when buffer-file-name (list \"--stdin-file-name\"
+     (flycheck-buffer-file-local-name)))').
 
      For buffers not backed by files, checkers that support input
      on stdin typically report a file name like `-' or `<stdin>'.
@@ -6785,6 +6796,27 @@ the error checking automatically."
               (error "Process %s failed with %S (%s)"
                      checker exit-code output))))
       (kill-buffer temp))))
+
+(defun flycheck--process-file-lines (program &rest args)
+  "Execute PROGRAM with ARGS, returning its output as a list of lines.
+
+Like `process-lines', but runs PROGRAM through `process-file', so
+it executes on the host of `default-directory' (a remote host
+over TRAMP) instead of always locally.  PROGRAM must be the plain
+local name on that host.  Signal an error if PROGRAM cannot be
+found or exits with a non-zero status."
+  (with-temp-buffer
+    (let ((status (apply #'process-file program nil (current-buffer) nil args)))
+      (unless (eq status 0)
+        (error "%s exited with status %s" program status))
+      (goto-char (point-min))
+      (let (lines)
+        (while (not (eobp))
+          (push (buffer-substring-no-properties
+                 (line-beginning-position) (line-end-position))
+                lines)
+          (forward-line 1))
+        (nreverse lines)))))
 
 (defun flycheck-checker-arguments (checker)
   "Get the command arguments of CHECKER."
@@ -7032,9 +7064,12 @@ PROCESS, and terminates standard input with EOF."
     (condition-case err
         (let* (;; `flycheck-find-checker-executable' may return a remote
                ;; (TRAMP) file name; the process program must be the plain
-               ;; local name on the remote host
-               (program (file-local-name
-                         (flycheck-find-checker-executable checker)))
+               ;; local name on the remote host.  It may also return nil (a
+               ;; cached-enabled checker whose executable later vanished), in
+               ;; which case leave it nil, as before, rather than erroring in
+               ;; `file-local-name'.
+               (executable (flycheck-find-checker-executable checker))
+               (program (and executable (file-local-name executable)))
                (args (flycheck-checker-substituted-arguments checker))
                (command (flycheck--wrap-command program args))
                (sentinel-events nil)
@@ -9163,7 +9198,7 @@ about the JSON format of stylelint."
   "Whether there is a valid stylelint CHECKER config for the current buffer."
   (zerop (flycheck-call-checker-process
           checker nil nil nil
-          "--print-config" (or buffer-file-name "index.js"))))
+          "--print-config" (flycheck-buffer-file-local-name "index.js"))))
 
 (defun flycheck--stylelint-get-major-version (checker)
   "Return major version of stylelint CHECKER."
@@ -9196,7 +9231,8 @@ See URL `https://stylelint.io/'."
             (eval flycheck-stylelint-args)
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc)
-            "--stdin-filename" (eval (or (buffer-file-name) "style.css")))
+            "--stdin-filename" (eval (flycheck-buffer-file-local-name
+                                      "style.css")))
   :standard-input t
   :verify (lambda (_) (flycheck--stylelint-verify 'css-stylelint))
   :error-parser flycheck-parse-stylelint
@@ -10127,7 +10163,8 @@ See URL `https://go.dev/cmd/go/' and URL
   :verify (lambda (_)
             (let* ((go (flycheck-checker-executable 'go-vet))
                    (have-vet (member "vet" (ignore-errors
-                                             (process-lines go "tool")))))
+                                             (flycheck--process-file-lines
+                                              (file-local-name go) "tool")))))
               (list
                (flycheck-verification-result-new
                 :label "go tool vet"
@@ -10408,17 +10445,25 @@ pragma.  Each extension is enabled via `-X'."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.19"))
 
-(defvar flycheck-haskell-ghc-cache-directory nil
-  "The cache directory for `ghc' output.")
+(defvar flycheck-haskell-ghc-cache-directory (make-hash-table :test 'equal)
+  "The cache directory for `ghc' output, keyed by host.
+The key is the remote identifier of `default-directory' (see
+`file-remote-p'), or nil for the local host, since `ghc' runs on
+the host of the checked buffer and needs a cache directory there.")
 
 (defun flycheck-haskell-ghc-cache-directory ()
   "Get the cache location for `ghc' output.
 
-If no cache directory exists yet, create one and return it.
-Otherwise return the previously used cache directory."
-  (setq flycheck-haskell-ghc-cache-directory
-        (or flycheck-haskell-ghc-cache-directory
-            (make-temp-file "flycheck-haskell-ghc-cache" 'directory))))
+If no cache directory exists yet for the current host, create one
+on that host and return it.  Otherwise return the previously used
+cache directory."
+  (let ((host (file-remote-p default-directory)))
+    (or (gethash host flycheck-haskell-ghc-cache-directory)
+        ;; `make-nearby-temp-file' creates the directory on the host of
+        ;; `default-directory', so `ghc' running there can write to it.
+        (puthash host
+                 (make-nearby-temp-file "flycheck-haskell-ghc-cache" 'directory)
+                 flycheck-haskell-ghc-cache-directory))))
 
 (defun flycheck--locate-dominating-file-matching (directory regexp)
   "Search for a file in directory hierarchy starting at DIRECTORY.
@@ -10442,10 +10487,15 @@ directory returned by \"stack path --project-root\"."
       (rx "stack" (* any) "." (or "yml" "yaml") eos)))
    (when-let* ((stack (funcall flycheck-executable-find "stack"))
                (output (ignore-errors
-                         (process-lines stack
-                                        "--no-install-ghc"
-                                        "path" "--project-root")))
-               (stack-dir (car output)))
+                         (flycheck--process-file-lines
+                          (file-local-name stack)
+                          "--no-install-ghc"
+                          "path" "--project-root")))
+               (root (car output))
+               ;; `stack' reports a host-local path; name it on the host of
+               ;; `default-directory' so it is usable as the remote working
+               ;; directory (and checked on the right host below).
+               (stack-dir (flycheck--expand-file-name root default-directory)))
      (and (file-directory-p stack-dir) stack-dir))))
 
 (defun flycheck-haskell--ghc-find-default-directory (_checker)
@@ -10464,7 +10514,8 @@ See URL `https://github.com/commercialhaskell/stack'."
             (option "--stack-yaml" flycheck-ghc-stack-project-file)
             (option-flag "--nix" flycheck-ghc-stack-use-nix)
             "ghc" "--" "-Wall" "-no-link"
-            "-outputdir" (eval (flycheck-haskell-ghc-cache-directory))
+            "-outputdir" (eval (file-local-name
+                                (flycheck-haskell-ghc-cache-directory)))
             (option-list "-X" flycheck-ghc-language-extensions concat)
             (option-list "-i" flycheck-ghc-search-path concat)
             (eval (concat
@@ -10519,7 +10570,8 @@ See URL `https://github.com/commercialhaskell/stack'."
 
 See URL `https://www.haskell.org/ghc/'."
   :command ("ghc" "-Wall" "-no-link"
-            "-outputdir" (eval (flycheck-haskell-ghc-cache-directory))
+            "-outputdir" (eval (file-local-name
+                                (flycheck-haskell-ghc-cache-directory)))
             (option-flag "-no-user-package-db"
                          flycheck-ghc-no-user-package-database)
             (option-list "-package-db" flycheck-ghc-package-databases)
@@ -10679,7 +10731,7 @@ for more information about the custom directories."
   "Whether there is a valid eslint config for the current buffer."
   (zerop (flycheck-call-checker-process
           'javascript-eslint nil nil nil
-          "--print-config" (or buffer-file-name "index.js"))))
+          "--print-config" (flycheck-buffer-file-local-name "index.js"))))
 
 (defun flycheck--eslint-handle-suspicious (_checker exit-status output)
   "Disable the checker when eslint cannot lint at all.
@@ -11225,8 +11277,8 @@ See URL `https://pear.php.net/package/PHP_CodeSniffer/'."
             ;; Pass original file name to phpcs.  We need to concat explicitly
             ;; here, because phpcs really insists to get option and argument as
             ;; a single command line argument :|
-            (eval (when (buffer-file-name)
-                    (concat "--stdin-path=" (buffer-file-name))))
+            (eval (when buffer-file-name
+                    (concat "--stdin-path=" (flycheck-buffer-file-local-name))))
             ;; Read from standard input
             "-")
   :standard-input t
@@ -11259,7 +11311,7 @@ See URL `https://github.com/sirbrillig/phpcs-changed'."
             "--git-base" (eval flycheck-phpcs-changed-git-base)
             "--git-unstaged"
             (option "--standard=" flycheck-phpcs-standard concat)
-            (eval (buffer-file-name)))
+            (eval (flycheck-buffer-file-local-name)))
   :standard-input t
   :error-parser flycheck-parse-checkstyle
   :error-filter
@@ -11688,7 +11740,8 @@ Requires Flake8 3.0 or newer. See URL
             (option "--max-line-length" flycheck-flake8-maximum-line-length nil
                     flycheck-option-int)
             (eval (when buffer-file-name
-                    (concat "--stdin-display-name=" buffer-file-name)))
+                    (concat "--stdin-display-name="
+                            (flycheck-buffer-file-local-name))))
             "-")
   :standard-input t
   :working-directory flycheck-python-find-project-root
@@ -11735,7 +11788,8 @@ See URL `https://docs.astral.sh/ruff/'."
             (config-file "--config" flycheck-python-ruff-config)
             ;; older versions of ruff (before 0.2) used "text" instead of "concise"
             "--output-format=concise"
-            (option "--stdin-filename" buffer-file-name)
+            (eval (when buffer-file-name
+                    (list "--stdin-filename" (flycheck-buffer-file-local-name))))
             "-")
   :standard-input t
   :error-filter (lambda (errors)
@@ -12460,7 +12514,7 @@ See URL `https://rubocop.org/'."
              ;; from standard input, but it chokes when that name is the empty
              ;; string, so fall back to "stdin" in order to handle buffers with
              ;; no backing file (e.g. org-mode snippet buffers)
-             "--stdin" (eval (or (buffer-file-name) "stdin")))
+             "--stdin" (eval (flycheck-buffer-file-local-name "stdin")))
   :standard-input t
   :working-directory #'flycheck-ruby--find-project-root
   :error-patterns flycheck-ruby-rubocop-error-patterns
@@ -12486,7 +12540,7 @@ See URL `https://github.com/chef/cookstyle'."
              ;; from standard input, but it chokes when that name is the empty
              ;; string, so fall back to "stdin" in order to handle buffers with
              ;; no backing file (e.g. org-mode snippet buffers)
-             "--stdin" (eval (or (buffer-file-name) "stdin")))
+             "--stdin" (eval (flycheck-buffer-file-local-name "stdin")))
   :standard-input t
   :working-directory #'flycheck-ruby--find-project-root
   :error-patterns flycheck-ruby-rubocop-error-patterns
@@ -12739,7 +12793,11 @@ Execute `cargo --list' to find out whether COMMAND is present."
     (member command
             (mapcar (lambda (line)
                       (car (split-string (string-trim line))))
-                    (ignore-errors (process-lines cargo "--list"))))))
+                    ;; Probe on the host the check will run on (remote over
+                    ;; TRAMP), where cargo was resolved.
+                    (ignore-errors
+                      (flycheck--process-file-lines
+                       (file-local-name cargo) "--list"))))))
 
 (defun flycheck-rust-valid-crate-type-p (crate-type)
   "Whether CRATE-TYPE is a valid target type for Cargo.

--- a/flycheck.el
+++ b/flycheck.el
@@ -1684,7 +1684,10 @@ Return the path of the file."
 Return nil if the CHECKER does not write temporary files."
   (let ((args (flycheck-checker-arguments checker)))
     (cond
-     ((memq 'source args) temporary-file-directory)
+     ;; `flycheck-temp-file-system' creates the file with
+     ;; `make-nearby-temp-file', i.e. on the host of `default-directory',
+     ;; so probe that host's temporary directory, not the local one.
+     ((memq 'source args) (temporary-file-directory))
      ((memq 'source-inplace args)
       (if buffer-file-name (file-name-directory buffer-file-name)
         temporary-file-directory))
@@ -3816,7 +3819,6 @@ If CONDITIONS are given, determine whether syntax may be checked
 under at least one of them, according to
 `flycheck-check-syntax-automatically'."
   (and (not (or buffer-read-only (flycheck-ephemeral-buffer-p)))
-       (file-exists-p default-directory)
        (or (not conditions)
            (let ((allowed
                   ;; Remote buffers use a narrower set of trigger events by
@@ -3827,7 +3829,10 @@ under at least one of them, according to
                       flycheck-check-syntax-automatically-remote
                     flycheck-check-syntax-automatically)))
              (seq-some (lambda (condition) (memq condition allowed))
-                       conditions)))))
+                       conditions)))
+       ;; Checked last so a disallowed trigger short-circuits before this
+       ;; possibly-remote (and thus blocking) stat of `default-directory'.
+       (file-exists-p default-directory)))
 
 (defvar-local flycheck--idle-trigger-timer nil
   "Timer used to trigger a syntax check after an idle delay.")
@@ -7555,7 +7560,9 @@ use with `compilation-error-regexp-alist'."
 Like `flycheck-substitute-argument', except for source,
 source-inplace, and source-original."
   (if (memq arg '(source source-inplace source-original))
-      (list buffer-file-name)
+      ;; The command runs on the host of `default-directory', so strip any
+      ;; remote prefix from the file name.
+      (list (file-local-name buffer-file-name))
     (flycheck-substitute-argument arg checker)))
 
 (defun flycheck--checker-substituted-shell-command-arguments (checker)
@@ -7587,8 +7594,9 @@ shell execution."
          (abs-prog
           ;; The executable path returned by `flycheck-command-wrapper-function'
           ;; may not be absolute, so expand it here.  See URL
-          ;; `https://github.com/flycheck/flycheck/issues/1461'.
-          (or (executable-find (car wrapped))
+          ;; `https://github.com/flycheck/flycheck/issues/1461'.  Resolve it on
+          ;; the host the command runs on when `default-directory' is remote.
+          (or (executable-find (car wrapped) (file-remote-p default-directory))
               (user-error "Cannot find `%s' using `executable-find'"
                           (car wrapped))))
          (command (mapconcat #'shell-quote-argument
@@ -7596,7 +7604,8 @@ shell execution."
     (if (flycheck-checker-get checker 'standard-input)
         ;; If the syntax checker expects the source from standard input add an
         ;; appropriate shell redirection
-        (concat command " < " (shell-quote-argument (buffer-file-name)))
+        (concat command " < "
+                (shell-quote-argument (file-local-name (buffer-file-name))))
       command)))
 
 (defun flycheck-compile-name (_name)
@@ -11323,26 +11332,31 @@ See URL `https://proselint.com/' for more information about proselint."
               (let-alist (car response)
                 .result.<stdin>.diagnostics)))))
 
-(defvar flycheck--proselint-use-old-args 'unknown
-  "Cache for proselint version detection.
-Value is t for old (<= 0.14.0), nil for new (>= 0.16.0),
-or `unknown' if not yet detected.")
+(defvar flycheck--proselint-use-old-args (make-hash-table :test 'equal)
+  "Cache for proselint version detection, keyed by host.
+The key is the remote identifier of `default-directory' (see
+`file-remote-p'), or nil for the local host, since the proselint
+on each host may have a different version.  Each value is t for
+old (<= 0.14.0) proselint and nil for new (>= 0.16.0); a host
+absent from the table has not been probed yet.")
 
 (defvar flycheck-proselint-executable)
 
 (defun flycheck--proselint-args ()
-  "Return command arguments for proselint, detecting the version once."
-  (when (eq flycheck--proselint-use-old-args 'unknown)
-    (setq flycheck--proselint-use-old-args
-          ;; Probe on the host the check will run on (remote over TRAMP)
-          (zerop (process-file
-                  (or flycheck-proselint-executable "proselint")
-                  nil nil nil "--version"))))
-  (if flycheck--proselint-use-old-args
-      ;; Proselint versions <= 0.14.0:
-      (list "--json" "-")
-    ;; Proselint versions >= 0.16.0
-    (list "check" "--output-format=json")))
+  "Return command arguments for proselint, detecting the version once per host."
+  (let ((host (file-remote-p default-directory)))
+    (when (eq (gethash host flycheck--proselint-use-old-args 'unknown) 'unknown)
+      (puthash host
+               ;; Probe on the host the check will run on (remote over TRAMP).
+               (zerop (process-file
+                       (or flycheck-proselint-executable "proselint")
+                       nil nil nil "--version"))
+               flycheck--proselint-use-old-args))
+    (if (gethash host flycheck--proselint-use-old-args)
+        ;; Proselint versions <= 0.14.0:
+        (list "--json" "-")
+      ;; Proselint versions >= 0.16.0
+      (list "check" "--output-format=json"))))
 
 (flycheck-define-checker proselint
   "Flycheck checker using Proselint.
@@ -11374,7 +11388,8 @@ See URL `https://developers.google.com/protocol-buffers/'."
                                          (flycheck-temp-dir-system))))
             ;; Add the current directory to resolve imports
             (eval (concat "--proto_path="
-                          (file-name-directory (buffer-file-name))))
+                          (file-local-name
+                           (file-name-directory (buffer-file-name)))))
             ;; Add other import paths; this needs to be after the current
             ;; directory to produce the right output.  See URL
             ;; `https://github.com/flycheck/flycheck/pull/1655'
@@ -11395,7 +11410,8 @@ See URL `https://developers.google.com/protocol-buffers/'."
   "A Pug syntax checker using the pug compiler.
 
 See URL `https://pugjs.org/'."
-  :command ("pug" "-p" (eval (expand-file-name (buffer-file-name))))
+  :command ("pug" "-p"
+            (eval (file-local-name (expand-file-name (buffer-file-name)))))
   :standard-input t
   :error-patterns
   ;; errors with includes/extends (e.g. missing files)

--- a/test/specs/languages/test-proselint.el
+++ b/test/specs/languages/test-proselint.el
@@ -7,7 +7,7 @@
 
   (describe "flycheck--proselint-args"
     (before-each
-      (clrhash flycheck--proselint-use-old-args))
+      (clrhash flycheck--proselint-old-args-by-host))
 
     (it "probes a host once and caches the detected version"
       ;; Exit 0 -> old proselint, which takes the "--json -" arguments.

--- a/test/specs/languages/test-proselint.el
+++ b/test/specs/languages/test-proselint.el
@@ -4,6 +4,32 @@
 (require 'test-helpers)
 
 (describe "Language Proselint"
+
+  (describe "flycheck--proselint-args"
+    (before-each
+      (clrhash flycheck--proselint-use-old-args))
+
+    (it "probes a host once and caches the detected version"
+      ;; Exit 0 -> old proselint, which takes the "--json -" arguments.
+      (spy-on 'process-file :and-return-value 0)
+      (let ((default-directory "/tmp/"))
+        (expect (flycheck--proselint-args) :to-equal '("--json" "-"))
+        (expect (flycheck--proselint-args) :to-equal '("--json" "-")))
+      (expect 'process-file :to-have-been-called-times 1))
+
+    (it "detects the version independently on each host"
+      ;; `file-remote-p' parses the prefix without connecting, so the probe
+      ;; can be faked per host without a live remote.
+      (spy-on 'process-file :and-call-fake
+              (lambda (&rest _)
+                (if (file-remote-p default-directory) 1 0)))
+      (let ((default-directory "/tmp/"))
+        (expect (flycheck--proselint-args) :to-equal '("--json" "-")))
+      (let ((default-directory "/ssh:host:/tmp/"))
+        (expect (flycheck--proselint-args)
+                :to-equal '("check" "--output-format=json")))
+      (expect 'process-file :to-have-been-called-times 2)))
+
   (flycheck-buttercup-def-checker-test proselint (text markdown) nil
     (let ((flycheck-disabled-checkers '(markdown-markdownlint-cli markdown-markdownlint-cli2 markdown-mdl markdown-pymarkdown)))
       (flycheck-buttercup-with-env '(("LC_ALL" . nil))

--- a/test/specs/test-automatic-checking.el
+++ b/test/specs/test-automatic-checking.el
@@ -42,7 +42,38 @@
             (expect (seq-every-p #'flycheck-may-check-automatically
                                  flycheck-check-syntax-automatically)
                     :to-be-truthy)
-            (expect (flycheck-may-check-automatically) :to-be-truthy))))))
+            (expect (flycheck-may-check-automatically) :to-be-truthy)))))
+
+    (describe "in remote buffers"
+      ;; `file-remote-p' parses the prefix without connecting, so faking
+      ;; it is enough to exercise the remote cadence without a live host.
+
+      (it "narrows to the remote trigger set by default"
+        (flycheck-buttercup-with-resource-buffer "automatic-check-dummy.el"
+          (spy-on 'file-remote-p :and-return-value "/ssh:host:")
+          (expect (flycheck-may-check-automatically 'save) :to-be-truthy)
+          (expect (flycheck-may-check-automatically 'mode-enabled) :to-be-truthy)
+          (expect (flycheck-may-check-automatically 'idle-change)
+                  :not :to-be-truthy)
+          (expect (flycheck-may-check-automatically 'new-line)
+                  :not :to-be-truthy)))
+
+      (it "honors flycheck-check-syntax-automatically-remote"
+        (flycheck-buttercup-with-resource-buffer "automatic-check-dummy.el"
+          (spy-on 'file-remote-p :and-return-value "/ssh:host:")
+          (let ((flycheck-check-syntax-automatically-remote '(idle-change)))
+            (expect (flycheck-may-check-automatically 'idle-change)
+                    :to-be-truthy)
+            (expect (flycheck-may-check-automatically 'save)
+                    :not :to-be-truthy))))
+
+      (it "uses the local trigger set when set to t"
+        (flycheck-buttercup-with-resource-buffer "automatic-check-dummy.el"
+          (spy-on 'file-remote-p :and-return-value "/ssh:host:")
+          (let ((flycheck-check-syntax-automatically-remote t)
+                (flycheck-check-syntax-automatically '(idle-change)))
+            (expect (flycheck-may-check-automatically 'idle-change)
+                    :to-be-truthy))))))
 
   (describe "flycheck-check-syntax-automatically"
 

--- a/test/specs/test-command-checker.el
+++ b/test/specs/test-command-checker.el
@@ -123,6 +123,16 @@ afterwards."
         ;; Called once for `emacs-lisp', and a second time for checkdoc
         (expect was-called :to-equal 2)))
 
+    (it "signals when the executable cannot be found"
+      ;; A cached-enabled checker whose executable later vanished resolves to
+      ;; nil.  Fail the check cleanly rather than starting a process with no
+      ;; program, which never exits and would hang the check forever.
+      (spy-on 'flycheck-find-checker-executable :and-return-value nil)
+      (spy-on 'start-file-process)
+      (flycheck-buttercup-with-temp-buffer
+        (expect (flycheck-start-command-checker 'emacs-lisp #'ignore) :to-throw)
+        (expect 'start-file-process :not :to-have-been-called)))
+
     (it "truncated stdin with errors"
       ;; Skip on Emacs 28 where large pipe writes can cause SIGPIPE
       (assume (version<= "29" emacs-version))

--- a/test/specs/test-tramp.el
+++ b/test/specs/test-tramp.el
@@ -1,0 +1,101 @@
+;;; test-tramp.el --- Flycheck Specs: Remote checking over TRAMP -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs exercising Flycheck over a TRAMP connection.  They use TRAMP's
+;; "mock" method, which runs a local shell through the full remote
+;; file-name handler stack, so `process-file', `start-file-process',
+;; `make-nearby-temp-file' and remote `executable-find' all take their
+;; remote code paths against localhost -- no real remote host needed.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+(require 'tramp)
+(require 'python)
+
+(defconst flycheck-test-tramp-remote-prefix "/mock:localhost:"
+  "TRAMP prefix of the local mock connection used by these specs.")
+
+(defun flycheck-test-tramp-setup-method ()
+  "Register TRAMP's mock method, running a local shell as the remote."
+  (add-to-list 'tramp-methods
+               '("mock"
+                 (tramp-login-program "sh")
+                 (tramp-login-args (("-i")))
+                 (tramp-remote-shell "/bin/sh")
+                 (tramp-remote-shell-args ("-c"))
+                 (tramp-connection-timeout 10)))
+  (add-to-list 'tramp-default-host-alist '("\\`mock\\'" nil "localhost")))
+
+(defun flycheck-test-tramp-connectable-p ()
+  "Return non-nil if a mock TRAMP connection can be established."
+  (ignore-errors
+    (let ((default-directory flycheck-test-tramp-remote-prefix))
+      (file-exists-p (concat flycheck-test-tramp-remote-prefix "/")))))
+
+(describe "Remote syntax checking over TRAMP"
+  (before-all
+    (flycheck-test-tramp-setup-method))
+
+  (after-each
+    (ignore-errors (tramp-cleanup-all-connections)))
+
+  (it "checks a remote buffer end to end and maps error filenames back"
+    ;; Skip (rather than fail) when the mock connection can't be brought
+    ;; up or python3 is unavailable -- these are environment issues, not
+    ;; regressions.  Everything past the assumes is a hard assertion.
+    (assume (flycheck-test-tramp-connectable-p) "no mock TRAMP connection")
+    (let ((default-directory flycheck-test-tramp-remote-prefix))
+      (assume (executable-find "python3" t) "python3 not on remote"))
+    (let* ((local (make-temp-file "flycheck-tramp-" nil ".py"
+                                  "import os\n\ndef broken(:\n    pass\n"))
+           (remote (concat flycheck-test-tramp-remote-prefix local))
+           (buf (find-file-noselect remote)))
+      (unwind-protect
+          (with-current-buffer buf
+            (expect (file-remote-p default-directory) :to-be-truthy)
+            ;; Flycheck must be willing to run here now.
+            (expect (flycheck-may-enable-mode) :to-be-truthy)
+            (python-mode)
+            (let ((flycheck-checkers '(python-pycompile))
+                  (flycheck-check-syntax-automatically nil)
+                  (done nil)
+                  (deadline (+ 30 (float-time))))
+              (add-hook 'flycheck-after-syntax-check-hook
+                        (lambda () (setq done t)) nil t)
+              (flycheck-mode)
+              (flycheck-buffer)
+              (while (and (not done) (< (float-time) deadline))
+                (accept-process-output nil 0.2))
+              (expect done :to-be-truthy)
+              (expect flycheck-current-errors :to-be-truthy)
+              (let ((err (car flycheck-current-errors)))
+                (expect (flycheck-error-level err) :to-be 'error)
+                ;; The filename reported by the remote checker is mapped
+                ;; back to the full remote name, not a bare local path.
+                (expect (flycheck-error-filename err)
+                        :to-equal remote))))
+        (kill-buffer buf)
+        (ignore-errors (delete-file local))))))
+
+(provide 'test-tramp)
+
+;;; test-tramp.el ends here

--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -222,6 +222,12 @@
 
   (describe "flycheck--expand-file-name"
 
+    ;; These assert POSIX output, as reported by remote hosts over TRAMP.
+    ;; On Windows `expand-file-name' prepends the current drive to drive-less
+    ;; absolute paths, so the exact strings differ; skip there.
+    (before-each
+      (assume (not (memq system-type '(cygwin windows-nt ms-dos)))))
+
     (it "expands a relative name against a local directory"
       (expect (flycheck--expand-file-name "foo.py" "/home/user/")
               :to-equal "/home/user/foo.py"))

--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -132,7 +132,18 @@
                  (exec-suffixes '(".program" ".bat"))
                  (result (flycheck-default-executable-find
                           (expand-file-name "dir/flycheck-testprog" temp-dir))))
-            (expect result :to-equal program-path))))))
+            (expect result :to-equal program-path)))))
+
+    (describe "on a remote host"
+      (it "resolves the executable on the host of a remote default-directory"
+        ;; `file-remote-p' parses the prefix without connecting, so no
+        ;; live remote is needed to verify the REMOTE argument is passed.
+        (spy-on 'executable-find :and-return-value "/ssh:host:/usr/bin/prog")
+        (let ((default-directory "/ssh:host:/home/user/"))
+          (expect (flycheck-default-executable-find "prog")
+                  :to-equal "/ssh:host:/usr/bin/prog")
+          (expect 'executable-find
+                  :to-have-been-called-with "prog" "/ssh:host:")))))
 
   (describe "flycheck-string-to-number-safe"
 
@@ -208,6 +219,27 @@
 
     (it "returns true for an empty list"
       (expect (flycheck-symbol-list-p '()) :to-be-truthy)))
+
+  (describe "flycheck--expand-file-name"
+
+    (it "expands a relative name against a local directory"
+      (expect (flycheck--expand-file-name "foo.py" "/home/user/")
+              :to-equal "/home/user/foo.py"))
+
+    (it "expands a relative name against a remote directory"
+      (expect (flycheck--expand-file-name "foo.py" "/ssh:host:/home/user/")
+              :to-equal "/ssh:host:/home/user/foo.py"))
+
+    (it "grafts the remote prefix onto a host-local absolute path"
+      ;; A checker running on the remote host reports host-local paths;
+      ;; the result must name the file on that host, not locally.
+      (expect (flycheck--expand-file-name "/tmp/foo.py" "/ssh:host:/home/user/")
+              :to-equal "/ssh:host:/tmp/foo.py"))
+
+    (it "leaves an already-remote filename untouched"
+      (expect (flycheck--expand-file-name
+               "/ssh:host:/tmp/foo.py" "/ssh:host:/home/user/")
+              :to-equal "/ssh:host:/tmp/foo.py")))
 
   (describe "flycheck-same-files-p"
 

--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -241,6 +241,39 @@
                "/ssh:host:/tmp/foo.py" "/ssh:host:/home/user/")
               :to-equal "/ssh:host:/tmp/foo.py")))
 
+  (describe "flycheck-buffer-file-local-name"
+
+    (it "returns a local file name unchanged"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/home/user/foo.py")
+        (expect (flycheck-buffer-file-local-name) :to-equal "/home/user/foo.py")))
+
+    (it "strips the remote prefix from a TRAMP file name"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/ssh:host:/home/user/foo.py")
+        (expect (flycheck-buffer-file-local-name)
+                :to-equal "/home/user/foo.py")))
+
+    (it "returns the fallback when there is no backing file"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name nil)
+        (expect (flycheck-buffer-file-local-name "stdin") :to-equal "stdin")
+        (expect (flycheck-buffer-file-local-name) :to-be nil))))
+
+  (describe "flycheck--process-file-lines"
+
+    (it "returns the program output as a list of lines"
+      (spy-on 'process-file :and-call-fake
+              (lambda (_program _infile buffer &rest _)
+                (with-current-buffer buffer (insert "line1\nline2\n"))
+                0))
+      (expect (flycheck--process-file-lines "prog" "arg")
+              :to-equal '("line1" "line2")))
+
+    (it "signals an error on a non-zero exit status"
+      (spy-on 'process-file :and-return-value 1)
+      (expect (flycheck--process-file-lines "prog") :to-throw)))
+
   (describe "flycheck-same-files-p"
 
     (it "returns true for same files"

--- a/test/specs/test-util.el
+++ b/test/specs/test-util.el
@@ -221,28 +221,29 @@
       (expect (flycheck-symbol-list-p '()) :to-be-truthy)))
 
   (describe "flycheck--expand-file-name"
-
     ;; These assert POSIX output, as reported by remote hosts over TRAMP.
     ;; On Windows `expand-file-name' prepends the current drive to drive-less
     ;; absolute paths, so the exact strings differ; skip there.
-    (before-each
-      (assume (not (memq system-type '(cygwin windows-nt ms-dos)))))
 
     (it "expands a relative name against a local directory"
+      (assume (not (memq system-type '(cygwin windows-nt ms-dos))))
       (expect (flycheck--expand-file-name "foo.py" "/home/user/")
               :to-equal "/home/user/foo.py"))
 
     (it "expands a relative name against a remote directory"
+      (assume (not (memq system-type '(cygwin windows-nt ms-dos))))
       (expect (flycheck--expand-file-name "foo.py" "/ssh:host:/home/user/")
               :to-equal "/ssh:host:/home/user/foo.py"))
 
     (it "grafts the remote prefix onto a host-local absolute path"
+      (assume (not (memq system-type '(cygwin windows-nt ms-dos))))
       ;; A checker running on the remote host reports host-local paths;
       ;; the result must name the file on that host, not locally.
       (expect (flycheck--expand-file-name "/tmp/foo.py" "/ssh:host:/home/user/")
               :to-equal "/ssh:host:/tmp/foo.py"))
 
     (it "leaves an already-remote filename untouched"
+      (assume (not (memq system-type '(cygwin windows-nt ms-dos))))
       (expect (flycheck--expand-file-name
                "/ssh:host:/tmp/foo.py" "/ssh:host:/home/user/")
               :to-equal "/ssh:host:/tmp/foo.py")))


### PR DESCRIPTION
Flycheck can now check buffers visiting remote files over TRAMP, originally reported in #1816. The remote awareness lives in the shared process/executable/temp-file helpers rather than in each checker, so command checkers work over TRAMP without per-checker changes (which is where the earlier #1842 stalled). Checkers run on the remote host, so their tools have to be installed there.

`global-flycheck-mode` enables Flycheck in remote buffers by default. Since each remote check spawns a process over the network, `flycheck-check-syntax-automatically-remote` limits the automatic triggers there to `save` and `mode-enabled`; set it to `t` for the same triggers as local buffers.

Builds on #1842, thanks to @carrete for the groundwork there.
