### PR TITLE
Add project-wide diagnostics to the error list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 ``master`` (unreleased)
 =======================
 
+- The error list can now show whole-project diagnostics.  Press ``P``
+  (``flycheck-error-list-toggle-scope``) to switch it between the current
+  buffer and the project, where it aggregates the errors of every open
+  Flycheck buffer together with the cross-file errors that checkers like
+  ``tsc``, ``cargo check`` and ``mypy`` report but the per-buffer view
+  drops.  A buffer's project is Emacs' ``project-current`` when found, and
+  the checker's working directory otherwise.
 - [#1816]: Flycheck now runs syntax checkers over TRAMP.  When a buffer
   visits a remote file, command checkers execute on the remote host
   (their executables must be installed there) instead of being unable to

--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -36,6 +36,7 @@ Within the error list the following key bindings are available:
 :kbd:`F`     Remove the filter
 :kbd:`S`     Sort the error list by the column at point
 :kbd:`g`     Check the source buffer and update the error list
+:kbd:`P`     Toggle between buffer and whole-project scope
 :kbd:`q`     Quit the error list and hide its window
 ==========   ====
 
@@ -51,6 +52,33 @@ post-jump actions like recentering:
    .. code-block:: elisp
 
       (add-hook 'flycheck-error-list-after-jump-hook #'recenter)
+
+See the whole project
+=====================
+
+Press :kbd:`P` to switch the error list between the *current buffer* and the
+*whole project*.  In project scope the list aggregates the diagnostics of every
+open Flycheck buffer in the source buffer's project, together with the
+cross-file errors your checkers report but the per-buffer view discards.  A
+checker like ``tsc``, ``cargo check`` or ``mypy`` that checks a whole package
+reports errors for files other than the one you are editing; Flycheck normally
+drops those from the buffer (see `flycheck-relevant-error-other-file-show`), but
+in project scope it keeps them, so you see the whole picture in one place.
+Press :kbd:`RET` on an error in another file to jump straight to it.
+
+.. note::
+
+   Flycheck does not run checkers on files you haven't opened; project scope
+   surfaces the diagnostics it already has, from open buffers and from the
+   cross-file output of the checks you run.  It does not turn Flycheck into a
+   background whole-project linter.  A cross-file error therefore reflects the
+   last check that reported it: it stays until the buffer that produced it is
+   checked again, since Flycheck cannot tell that another file changed without
+   re-running a check.
+
+The project of a buffer is Emacs' project (see `project-current`) when one is
+found, and the checker's working directory otherwise.  The current scope is
+shown as ``[project]`` in the error list's mode line.
 
 Filter the list
 ===============

--- a/flycheck.el
+++ b/flycheck.el
@@ -1353,6 +1353,7 @@ function must be updated to use this variable."
   `(,(propertized-buffer-identification "%12b")
     " for buffer "
     (:eval (flycheck-error-list-propertized-source-name))
+    (:eval (flycheck-error-list-mode-line-scope-indicator))
     (:eval (flycheck-error-list-mode-line-filter-indicator))
     (:eval (flycheck-error-list-mode-line-suppressed-indicator)))
   "Mode line construct for Flycheck error list.
@@ -5729,6 +5730,7 @@ ID.")
     (define-key map (kbd "n") #'flycheck-error-list-next-error)
     (define-key map (kbd "p") #'flycheck-error-list-previous-error)
     (define-key map (kbd "g") #'flycheck-error-list-check-source)
+    (define-key map (kbd "P") #'flycheck-error-list-toggle-scope)
     (define-key map (kbd "e") #'flycheck-error-list-explain-error)
     (define-key map (kbd "RET") #'flycheck-error-list-goto-error)
     map)
@@ -5840,6 +5842,17 @@ ignored."
 ;; reversions
 (put 'flycheck-error-list-source-buffer 'permanent-local t)
 
+(defvar-local flycheck-error-list-scope 'buffer
+  "The scope of the error list.
+
+Either `buffer', to show the errors of the source buffer alone, or
+`project', to show the project-wide diagnostics aggregated across
+every open buffer of the source buffer's project (see
+`flycheck--project-directory').  Toggle it with
+\\<flycheck-error-list-mode-map>\\[flycheck-error-list-toggle-scope].")
+;; Preserved across the reversions Tabulated List mode performs on refresh.
+(put 'flycheck-error-list-scope 'permanent-local t)
+
 (defun flycheck-error-list-set-source (buffer)
   "Set BUFFER as the source buffer of the error list."
   (flycheck-error-list-with-buffer
@@ -5864,6 +5877,19 @@ if the error list is already pointing to the current buffer."
     (when (buffer-live-p buffer)
       (with-current-buffer buffer
         (flycheck-buffer)))))
+
+(defun flycheck-error-list-toggle-scope ()
+  "Toggle the error list between buffer and project scope.
+
+See `flycheck-error-list-scope'."
+  (interactive)
+  (flycheck-error-list-with-buffer
+    (setq flycheck-error-list-scope
+          (if (eq flycheck-error-list-scope 'project) 'buffer 'project))
+    (flycheck-error-list-refresh)
+    (message "Flycheck error list now showing the %s"
+             (if (eq flycheck-error-list-scope 'project)
+                 "whole project" "current buffer"))))
 
 (define-button-type 'flycheck-error-list
   'action #'flycheck-error-list-goto-error
@@ -5953,10 +5979,21 @@ ensure that they line up properly once the message is displayed."
     (replace-regexp-in-string "\\([\r\n]+\\)\\(.\\)" rep msg)))
 
 (defun flycheck-error-list-current-errors ()
-  "Read the list of errors in `flycheck-error-list-source-buffer'."
+  "Read the errors to display in the error list.
+
+With `flycheck-error-list-scope' `buffer' (the default), read the
+errors of `flycheck-error-list-source-buffer'.  With `project',
+read the project-wide diagnostics of that buffer's project."
   (when (buffer-live-p flycheck-error-list-source-buffer)
-    (buffer-local-value 'flycheck-current-errors
-                        flycheck-error-list-source-buffer)))
+    (if (eq flycheck-error-list-scope 'project)
+        (flycheck--project-errors
+         ;; Guard the project lookup: a misbehaving project backend must
+         ;; not abort the error-list refresh that runs after every check.
+         (ignore-errors
+           (with-current-buffer flycheck-error-list-source-buffer
+             (flycheck--project-directory))))
+      (buffer-local-value 'flycheck-current-errors
+                          flycheck-error-list-source-buffer))))
 
 (defun flycheck-error-list-entries ()
   "Create the entries for the error list."
@@ -6059,6 +6096,11 @@ list."
      (format " [%s]" flycheck-error-list--checker-filter))
    (when flycheck-error-list--message-filter
      (format " [/%s/]" flycheck-error-list--message-filter))))
+
+(defun flycheck-error-list-mode-line-scope-indicator ()
+  "Create a string representing the current error list scope."
+  (when (eq flycheck-error-list-scope 'project)
+    " [project]"))
 
 (defun flycheck-error-list-mode-line-suppressed-indicator ()
   "Create a string for the mode line about suppressed errors.

--- a/flycheck.el
+++ b/flycheck.el
@@ -3668,13 +3668,24 @@ Relative file names in ERRORS will be expanded relative to
 WORKING-DIR."
   (let* ((syntax-check flycheck-current-syntax-check)
          (checker (flycheck-syntax-check-checker syntax-check))
-         (errors (flycheck-relevant-errors
-                  (flycheck-fill-and-expand-error-file-names
-                   (flycheck-filter-errors
-                    (flycheck-assert-error-list-p errors) checker)
-                   working-dir))))
-    (flycheck-report-current-errors
-     (flycheck--handle-excessive-errors checker errors))
+         ;; The full, file-name-expanded error set, including errors for
+         ;; other files that `flycheck-relevant-errors' drops below.  Record
+         ;; it in the project store before narrowing to the buffer.
+         (all-errors (flycheck-fill-and-expand-error-file-names
+                      (flycheck-filter-errors
+                       (flycheck-assert-error-list-p errors) checker)
+                      working-dir))
+         (relevant (flycheck-relevant-errors all-errors))
+         (reported (flycheck--handle-excessive-errors checker relevant)))
+    ;; Record exactly what the buffer shows (`reported', already narrowed
+    ;; and flood-handled) plus the cross-file errors this check also found,
+    ;; so a buffer's own errors stay identical between buffer and project
+    ;; scope and its flood handling is never bypassed.
+    (flycheck--project-record-errors
+     (append reported
+             (flycheck--project-storable-errors
+              (seq-remove (lambda (err) (memq err relevant)) all-errors))))
+    (flycheck-report-current-errors reported)
     (let ((next-checker (unless no-next
                           (flycheck-get-next-checker-for-buffer checker))))
       (if next-checker
@@ -3731,6 +3742,13 @@ drops the errors furthest down in the buffer."
         (flycheck-error-< err1 err2)
       (> severity1 severity2))))
 
+(defun flycheck--take-most-severe-errors (errors n)
+  "Return the N most severe of ERRORS, most severe first.
+
+Errors of equal severity keep their buffer-position order (see
+`flycheck--excessive-errors-<')."
+  (seq-take (sort (copy-sequence errors) #'flycheck--excessive-errors-<) n))
+
 (defun flycheck--truncate-excessive-errors (checker errors total)
   "Truncate ERRORS from CHECKER to the error threshold.
 
@@ -3738,9 +3756,7 @@ TOTAL is the length of ERRORS.  Keep the most severe errors up to
 `flycheck-checker-error-threshold' and record the number of
 suppressed errors in `flycheck--suppressed-error-count'."
   (let* ((threshold flycheck-checker-error-threshold)
-         (kept (seq-take (sort (copy-sequence errors)
-                               #'flycheck--excessive-errors-<)
-                         threshold)))
+         (kept (flycheck--take-most-severe-errors errors threshold)))
     (cl-incf flycheck--suppressed-error-count (- total threshold))
     (unless (memq checker flycheck--excessive-checkers)
       (push checker flycheck--excessive-checkers)
@@ -4484,7 +4500,140 @@ with `flycheck-process-error-functions'."
 (defun flycheck-clear-errors ()
   "Remove all error information from the current buffer."
   (setq flycheck-current-errors nil)
+  (flycheck--project-forget-buffer)
   (flycheck-report-status 'not-checked))
+
+
+;;; Project-wide diagnostics
+;;
+;; Besides the per-buffer `flycheck-current-errors', Flycheck keeps a
+;; project-wide store of every error a check produces, including the
+;; cross-file errors that `flycheck-relevant-errors' drops from the
+;; buffer view (e.g. a `tsc' or `cargo check' run reporting errors across
+;; a whole package).  The store aggregates those with the errors of every
+;; open Flycheck buffer, so the error list can show a project at a glance
+;; (see `flycheck-error-list-scope').
+
+(defvar flycheck--project-error-store (make-hash-table :test 'eq)
+  "Store of project-wide diagnostics.
+
+Maps a source buffer to the list of `flycheck-error' objects its
+last check produced, across every file rather than just the source
+buffer.  A buffer's project is resolved lazily, when the errors are
+aggregated (see `flycheck--project-errors'), so recording stays off
+the check hot path.  Entries are retracted in `flycheck-clear-errors',
+so a re-check, clear, or buffer teardown replaces the buffer's
+contribution.")
+
+(declare-function project-root "project" (project))
+
+(defun flycheck--project-directory ()
+  "Return a key identifying the current buffer's project.
+
+Use Emacs' project (see `project-current') when a project is
+found, so diagnostics from any file in the project aggregate
+together; otherwise fall back to `default-directory', which
+matches how a checker's working directory groups a multi-file
+check.  The result is an expanded directory name."
+  (file-name-as-directory
+   (expand-file-name
+    (or (and (require 'project nil 'noerror)
+             (when-let* ((project (project-current nil)))
+               (project-root project)))
+        default-directory))))
+
+(defun flycheck--project-storable-errors (errors)
+  "Return the subset of ERRORS worth recording project-wide.
+
+Drop errors without a line number or message: the buffer view
+discards these too (see `flycheck-relevant-error-p') and the error
+list cannot sort them."
+  (seq-filter
+   (lambda (err)
+     (and (flycheck-error-line err)
+          (let ((message (flycheck-error-message err)))
+            (and message (not (string-empty-p message))))))
+   errors))
+
+(defun flycheck--project-record-errors (errors)
+  "Add the storable subset of ERRORS to the current buffer's project.
+
+Successive checkers of a check chain accumulate, mirroring
+`flycheck-report-current-errors'.  The errors are not capped here:
+the buffer's own errors arrive already flood-handled by
+`flycheck--handle-excessive-errors', so nothing recorded exceeds
+what the buffer itself shows for its file."
+  (let ((buffer (current-buffer)))
+    (puthash buffer
+             (append (flycheck--project-storable-errors errors)
+                     (gethash buffer flycheck--project-error-store))
+             flycheck--project-error-store)))
+
+(defun flycheck--project-forget-buffer (&optional buffer)
+  "Drop BUFFER's contribution to the project store.
+
+BUFFER defaults to the current buffer."
+  (remhash (or buffer (current-buffer)) flycheck--project-error-store))
+
+(defun flycheck--project-error-identity (err buffer)
+  "Return a value uniquely identifying ERR contributed by BUFFER.
+
+Two errors compare `equal' when they describe the same problem in
+the same file -- e.g. one `cargo check' diagnostic reported once
+per open crate file -- so duplicates collapse.  Errors without a
+file name are distinguished by BUFFER, so identical diagnostics
+from different unsaved buffers are not mistaken for duplicates."
+  (list (or (flycheck-error-filename err) buffer)
+        (flycheck-error-line err)
+        (flycheck-error-column err)
+        (flycheck-error-end-line err)
+        (flycheck-error-end-column err)
+        (flycheck-error-level err)
+        (flycheck-error-message err)
+        (flycheck-error-id err)
+        (flycheck-error-checker err)))
+
+(defun flycheck--project-errors (project-key)
+  "Return the deduplicated diagnostics recorded for PROJECT-KEY.
+
+Aggregate the errors every live buffer of the project contributed,
+dropping duplicates (see `flycheck--project-error-identity').  Dead
+buffers are pruned from the store on the way.
+
+Cross-file errors reflect the last check that reported them: an
+error a checker reported about another file stays until the buffer
+that produced it is re-checked, since Flycheck has no way to know
+the file changed without running a check."
+  ;; OWNER maps an error identity to the first buffer that contributed it.
+  ;; Duplicates within one buffer are kept (a checker may legitimately report
+  ;; the same diagnostic twice), but the same diagnostic seen from several
+  ;; buffers -- e.g. one `cargo check' error reported from each open crate
+  ;; file -- collapses to a single entry.
+  (let ((owner (make-hash-table :test 'equal))
+        (dead nil)
+        (result nil))
+    (when project-key
+      (maphash
+       (lambda (buffer errors)
+         (if (not (buffer-live-p buffer))
+             (push buffer dead)
+           ;; Resolve the project lazily, only now, to keep `project-current'
+           ;; off the check hot path; a misbehaving project backend must not
+           ;; abort the whole aggregation, so guard against it.
+           (when (equal project-key
+                        (ignore-errors
+                          (with-current-buffer buffer
+                            (flycheck--project-directory))))
+             (dolist (err errors)
+               (let* ((identity (flycheck--project-error-identity err buffer))
+                      (seen-in (gethash identity owner)))
+                 (when (or (null seen-in) (eq seen-in buffer))
+                   (unless seen-in (puthash identity buffer owner))
+                   (push err result)))))))
+       flycheck--project-error-store)
+      (dolist (buffer dead)
+        (remhash buffer flycheck--project-error-store)))
+    (nreverse result)))
 
 (defun flycheck-fill-and-expand-error-file-names (errors directory)
   "Fill and expand file names in ERRORS relative to DIRECTORY.

--- a/test/specs/test-project-diagnostics.el
+++ b/test/specs/test-project-diagnostics.el
@@ -1,0 +1,286 @@
+;;; test-project-diagnostics.el --- Flycheck Specs: Project diagnostics -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for the project-wide diagnostics store and the error list's
+;; project scope.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+;; Track buffers created by the specs so they never leak into the suite.
+(defvar flycheck-test--project-buffers nil)
+
+(defun flycheck-test--project-key (dir)
+  "Return the project key Flycheck computes for DIR.
+Expanding here matches `flycheck--project-directory' on every
+platform (Windows `expand-file-name' prepends the current drive)."
+  (file-name-as-directory (expand-file-name dir)))
+
+(defun flycheck-test--project-buffer (name dir)
+  "Return a fresh buffer named NAME whose project key is DIR's."
+  (let ((buffer (generate-new-buffer name)))
+    (push buffer flycheck-test--project-buffers)
+    (with-current-buffer buffer
+      (setq default-directory (flycheck-test--project-key dir)))
+    buffer))
+
+(defun flycheck-test--project-errors (dir)
+  "Return the diagnostics recorded for DIR's project."
+  (flycheck--project-errors (flycheck-test--project-key dir)))
+
+(describe "Project-wide diagnostics"
+
+  (progn
+
+    (before-each
+      ;; The store is global; start every spec from a clean slate.
+      (clrhash flycheck--project-error-store)
+      (setq flycheck-test--project-buffers nil))
+
+    (after-each
+      (mapc (lambda (b) (when (buffer-live-p b) (kill-buffer b)))
+            flycheck-test--project-buffers))
+
+    (describe "flycheck--project-directory"
+
+      (it "falls back to default-directory when there is no project"
+        (spy-on 'project-current :and-return-value nil)
+        (let ((default-directory "/tmp/some/dir/"))
+          (expect (flycheck--project-directory)
+                  :to-equal (flycheck-test--project-key "/tmp/some/dir/"))))
+
+      (it "uses the project root when a project is found"
+        (spy-on 'project-current :and-return-value '(transient . "/proj/"))
+        (spy-on 'project-root :and-return-value "/proj/root/")
+        ;; The project root wins over `default-directory'.
+        (let ((default-directory "/elsewhere/"))
+          (expect (flycheck--project-directory)
+                  :to-equal (flycheck-test--project-key "/proj/root/")))))
+
+    (describe "the error store"
+
+      ;; Key the store by default-directory so the specs control the project.
+      (before-each
+        (spy-on 'project-current :and-return-value nil))
+
+      (it "records the full error set a buffer contributes"
+        (with-current-buffer (flycheck-test--project-buffer " s" "/proj/")
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at 1 1 'error "a" :filename "/proj/x")
+                 (flycheck-error-new-at 2 1 'warning "b" :filename "/proj/y")))
+          (expect (length (flycheck-test--project-errors "/proj/")) :to-equal 2)))
+
+      (it "aggregates across buffers of the same project"
+        (dotimes (i 2)
+          (with-current-buffer (flycheck-test--project-buffer
+                                (format " p%d" i) "/proj/")
+            (flycheck--project-record-errors
+             (list (flycheck-error-new-at (1+ i) 1 'error (format "e%d" i)
+                                          :filename (format "/proj/f%d" i))))))
+        (expect (length (flycheck-test--project-errors "/proj/")) :to-equal 2))
+
+      (it "keeps projects separate"
+        (with-current-buffer (flycheck-test--project-buffer " a" "/proj-a/")
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at 1 1 'error "a" :filename "/proj-a/x"))))
+        (with-current-buffer (flycheck-test--project-buffer " b" "/proj-b/")
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at 1 1 'error "b" :filename "/proj-b/x"))))
+        (expect (length (flycheck-test--project-errors "/proj-a/")) :to-equal 1)
+        (expect (length (flycheck-test--project-errors "/proj-b/")) :to-equal 1))
+
+      (it "deduplicates identical errors for the same file"
+        ;; e.g. one `cargo check' diagnostic reported once per open crate file.
+        (dolist (name '(" d1" " d2"))
+          (with-current-buffer (flycheck-test--project-buffer name "/proj/")
+            (flycheck--project-record-errors
+             (list (flycheck-error-new-at 5 3 'error "dup"
+                                          :filename "/proj/shared"
+                                          :checker 'x)))))
+        (expect (length (flycheck-test--project-errors "/proj/")) :to-equal 1))
+
+      (it "does not merge identical errors from different fileless buffers"
+        ;; Two unsaved buffers reporting the same diagnostic are distinct.
+        (dolist (name '(" u1" " u2"))
+          (with-current-buffer (flycheck-test--project-buffer name "/proj/")
+            (flycheck--project-record-errors
+             (list (flycheck-error-new-at 1 1 'error "syntax" :checker 'x)))))
+        (expect (length (flycheck-test--project-errors "/proj/")) :to-equal 2))
+
+      (it "keeps duplicate errors reported within one buffer"
+        ;; Deduplication is across buffers, not within a single one.
+        (with-current-buffer (flycheck-test--project-buffer " dup" "/proj/")
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at 1 1 'error "twice"
+                                        :filename "/proj/x" :checker 'x)
+                 (flycheck-error-new-at 1 1 'error "twice"
+                                        :filename "/proj/x" :checker 'x)))
+          (expect (length (flycheck-test--project-errors "/proj/")) :to-equal 2)))
+
+      (it "drops errors without a line number"
+        (with-current-buffer (flycheck-test--project-buffer " n" "/proj/")
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at nil nil 'error "no line"
+                                        :filename "/proj/x")
+                 (flycheck-error-new-at 3 1 'error "has line"
+                                        :filename "/proj/x")))
+          (expect (length (flycheck-test--project-errors "/proj/")) :to-equal 1)))
+
+      (it "accumulates successive checkers of a chain in one buffer"
+        (with-current-buffer (flycheck-test--project-buffer " c" "/proj/")
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at 1 1 'error "a" :filename "/proj/x")))
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at 2 1 'error "b" :filename "/proj/y")))
+          (expect (length (flycheck-test--project-errors "/proj/")) :to-equal 2)))
+
+      (it "forgets a buffer's contribution"
+        (with-current-buffer (flycheck-test--project-buffer " g" "/proj/")
+          (flycheck--project-record-errors
+           (list (flycheck-error-new-at 1 1 'error "a" :filename "/proj/x")))
+          (flycheck--project-forget-buffer)
+          (expect (flycheck-test--project-errors "/proj/") :to-be nil)))
+
+      (it "prunes and ignores errors of killed buffers"
+        (let ((buffer (flycheck-test--project-buffer " gone" "/proj/")))
+          (with-current-buffer buffer
+            (flycheck--project-record-errors
+             (list (flycheck-error-new-at 1 1 'error "a" :filename "/proj/x"))))
+          (kill-buffer buffer)
+          (expect (flycheck-test--project-errors "/proj/") :to-be nil)
+          ;; The dead entry is pruned, not merely skipped.
+          (expect (gethash buffer flycheck--project-error-store) :to-be nil))))
+
+    (describe "capture during a syntax check"
+
+      (before-each
+        (spy-on 'project-current :and-return-value nil)
+        (flycheck-define-generic-checker 'test-project-checker
+          "A checker reporting an own-file and a cross-file error."
+          :start (lambda (checker callback)
+                   (funcall
+                    callback 'finished
+                    (list (flycheck-error-new-at 1 1 'error "own"
+                                                 :checker checker
+                                                 :filename (buffer-file-name))
+                          (flycheck-error-new-at 1 1 'warning "cross"
+                                                 :checker checker
+                                                 :filename
+                                                 (expand-file-name
+                                                  "other.txt")))))
+          :modes '(text-mode)))
+
+      (after-each
+        (setf (symbol-plist 'test-project-checker) nil))
+
+      (it "keeps cross-file errors the buffer view drops"
+        (let* ((file (make-temp-file "flycheck-proj-" nil ".txt" "hi\n"))
+               (buffer (find-file-noselect file)))
+          (unwind-protect
+              (with-current-buffer buffer
+                (text-mode)
+                (let ((flycheck-checkers '(test-project-checker))
+                      (flycheck-check-syntax-automatically nil))
+                  (flycheck-mode)
+                  (flycheck-buffer)
+                  ;; The buffer view keeps only the own-file error.
+                  (expect (length flycheck-current-errors) :to-equal 1)
+                  ;; The project store keeps both.
+                  (expect (length (flycheck--project-errors
+                                   (flycheck--project-directory)))
+                          :to-equal 2)))
+            (kill-buffer buffer)
+            (ignore-errors (delete-file file)))))
+
+      (it "replaces a buffer's contribution on re-check"
+        ;; The checker reports a distinct error each run, so a broken
+        ;; retraction would leave both runs' errors in the store.
+        (let* ((file (make-temp-file "flycheck-proj-" nil ".txt" "hi\n"))
+               (buffer (find-file-noselect file))
+               (run 0))
+          (unwind-protect
+              (with-current-buffer buffer
+                (text-mode)
+                (flycheck-define-generic-checker 'test-project-counter
+                  "Reports one error whose message changes each run."
+                  :start (lambda (checker callback)
+                           (setq run (1+ run))
+                           (funcall
+                            callback 'finished
+                            (list (flycheck-error-new-at
+                                   1 1 'error (format "run-%d" run)
+                                   :checker checker
+                                   :filename (buffer-file-name)))))
+                  :modes '(text-mode))
+                (let ((flycheck-checkers '(test-project-counter))
+                      (flycheck-check-syntax-automatically nil))
+                  (flycheck-mode)
+                  (flycheck-buffer)
+                  (flycheck-buffer)
+                  (let ((errors (flycheck--project-errors
+                                 (flycheck--project-directory))))
+                    ;; Only the second run's error remains.
+                    (expect (length errors) :to-equal 1)
+                    (expect (flycheck-error-message (car errors))
+                            :to-equal "run-2"))))
+            (setf (symbol-plist 'test-project-counter) nil)
+            (kill-buffer buffer)
+            (ignore-errors (delete-file file))))))
+
+    (describe "error list project scope"
+
+      (before-each
+        (spy-on 'project-current :and-return-value nil))
+
+      (it "defaults to buffer scope"
+        (with-current-buffer (get-buffer-create flycheck-error-list-buffer)
+          (delay-mode-hooks (flycheck-error-list-mode))
+          (expect flycheck-error-list-scope :to-be 'buffer)
+          (kill-buffer flycheck-error-list-buffer)))
+
+      (it "reads the project store in project scope"
+        (let ((source (flycheck-test--project-buffer " source" "/proj/")))
+          (with-current-buffer source
+            (flycheck--project-record-errors
+             (list (flycheck-error-new-at 1 1 'error "own" :filename "/proj/x")
+                   (flycheck-error-new-at 2 1 'warning "cross"
+                                          :filename "/proj/y"))))
+          (with-current-buffer (get-buffer-create flycheck-error-list-buffer)
+            (delay-mode-hooks (flycheck-error-list-mode))
+            (setq flycheck-error-list-source-buffer source)
+            (setq flycheck-error-list-scope 'project)
+            (expect (length (flycheck-error-list-current-errors)) :to-equal 2)
+            (kill-buffer flycheck-error-list-buffer))))
+
+      (it "toggles scope with flycheck-error-list-toggle-scope"
+        (with-current-buffer (get-buffer-create flycheck-error-list-buffer)
+          (delay-mode-hooks (flycheck-error-list-mode))
+          (expect flycheck-error-list-scope :to-be 'buffer)
+          (flycheck-error-list-toggle-scope)
+          (expect flycheck-error-list-scope :to-be 'project)
+          (flycheck-error-list-toggle-scope)
+          (expect flycheck-error-list-scope :to-be 'buffer)
+          (kill-buffer flycheck-error-list-buffer))))))
+
+(provide 'test-project-diagnostics)
+
+;;; test-project-diagnostics.el ends here


### PR DESCRIPTION
Flycheck has always been per-buffer. This adds a whole-project view to the error list without scanning files you haven't opened: it keeps the cross-file errors that checkers like `tsc`, `cargo check` and `mypy` already report and `flycheck-relevant-errors` currently drops, and aggregates them with every open buffer's errors. Press `P` in the error list to toggle between the current buffer and the project (keyed by `project-current`, or the checker's working directory as a fallback).

Cross-file errors reflect the last check that reported them and clear when that buffer is re-checked; without a resident server there's no way to know another file changed. A few calls I'd want your take on: the `project-current` keying, the `P` toggle instead of a separate command, and storing exactly what the buffer reports so its own errors match in both scopes.
