### PR TITLE
Add a quick-fix API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 ``master`` (unreleased)
 =======================
 
+- Flycheck can now apply machine-applicable fixes that checkers suggest.
+  ``C-c ! f`` (``flycheck-fix-error-at-point``) applies the fix of the
+  error at point, and ``x`` does the same for the selected row in the
+  error list, where fixable errors are marked ``[fix]``.  The
+  ``javascript-eslint`` (``--fix``), ``rust``/``rust-cargo``/``rust-clippy``
+  (machine-applicable suggestions) and SARIF-based checkers (e.g.
+  ``dockerfile-hadolint``) now carry these fixes, which were previously
+  parsed and discarded.  Error parsers can attach a ``flycheck-fix`` to a
+  ``flycheck-error`` via the new ``:fix`` slot.
 - The error list can now show whole-project diagnostics.  Press ``P``
   (``flycheck-error-list-toggle-scope``) to switch it between the current
   buffer and the project, where it aggregates the errors of every open

--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -229,6 +229,30 @@ checkers produce explanations, the majority do not.  Those that do are:
    Display an explanation for the first explainable error at point.
 
 
+Fix errors
+==========
+
+Some checkers report a machine-applicable fix along with an error - the
+replacement text a tool like ``eslint --fix``, ``cargo clippy`` or a SARIF
+analyzer already computes.  Flycheck keeps that fix and can apply it for you.
+In the error list, fixable errors are marked with ``[fix]`` before the message.
+
+.. define-key:: C-c ! f
+                M-x flycheck-fix-error-at-point
+
+   Apply the fix of the first fixable error at point.  Signals an error if no
+   error at point has a fix.
+
+In the :ref:`error list <flycheck-error-list>` press :kbd:`x`
+(``flycheck-error-list-apply-fix``) to apply the fix of the error on the
+current row.
+
+A fix is applied as a single undoable change, so :kbd:`C-/` reverts it.  The
+checkers that currently provide fixes are ``javascript-eslint``, the ``rust``
+checkers (from ``cargo clippy``'s machine-applicable suggestions), and any
+checker whose SARIF output includes fixes (e.g. ``dockerfile-hadolint``).
+
+
 Kill errors
 ===========
 

--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -32,6 +32,7 @@ Within the error list the following key bindings are available:
 :kbd:`n`     Jump to the next error
 :kbd:`p`     Jump to the previous error
 :kbd:`e`     Explain the error
+:kbd:`x`     Apply the error's fix, if it has one
 :kbd:`f`     Filter the error list by level
 :kbd:`F`     Remove the filter
 :kbd:`S`     Sort the error list by the column at point

--- a/flycheck-buttercup.el
+++ b/flycheck-buttercup.el
@@ -339,9 +339,14 @@ Raise an assertion error if errors or overlays remain afterwards."
 ;;; Error utilities
 
 (defun flycheck-buttercup-error-without-group (err)
-  "Return a copy of ERR with the `group' property set to nil."
+  "Return a copy of ERR with the `group' and `fix' properties set to nil.
+
+Language checker specs compare errors without asserting on these
+incidental slots: `group' holds an uninterned symbol, and `fix'
+holds a machine-applicable suggestion that is verified separately."
   (let ((copy (copy-flycheck-error err)))
     (setf (flycheck-error-group copy) nil)
+    (setf (flycheck-error-fix copy) nil)
     copy))
 
 (defun flycheck-buttercup-sort-errors (errors)

--- a/flycheck.el
+++ b/flycheck.el
@@ -8346,6 +8346,32 @@ information about staticcheck."
                   spans)
         spans))))
 
+(defun flycheck-parse-rustc--fix (spans file buffer)
+  "Build a `flycheck-fix' for BUFFER from rustc SPANS in FILE, or nil.
+
+Every span in FILE with a `suggested_replacement' whose
+`suggestion_applicability' is \"MachineApplicable\" becomes one
+edit, so a multi-part suggestion (e.g. inserting a `(' and a `)')
+is applied in full.  Spans in another file -- a suggestion that
+reaches into a macro or a different source file -- are dropped, so
+the fix never edits this buffer at foreign line and column
+numbers."
+  (let ((edits
+         (delq nil
+               (seq-map
+                (lambda (span)
+                  (let-alist span
+                    (when (and (equal .file_name file)
+                               .suggested_replacement
+                               (equal .suggestion_applicability
+                                      "MachineApplicable"))
+                      (flycheck-fix-edit-new
+                       :line .line_start :column .column_start
+                       :end-line .line_end :end-column .column_end
+                       :replacement .suggested_replacement))))
+                spans))))
+    (flycheck--make-fix buffer nil edits)))
+
 (defun flycheck-parse-rustc-diagnostic (diagnostic checker buffer)
   "Turn a rustc DIAGNOSTIC into a `flycheck-error'.
 
@@ -8429,14 +8455,22 @@ https://github.com/rust-lang/rust/blob/master/src/librustc_errors/json.rs#L154"
           :filename .file_name
           :group group
           :end-line .line_end
-          :end-column .column_end)
+          :end-column .column_end
+          :fix (flycheck-parse-rustc--fix (list span) .file_name buffer))
          errors)))
 
     ;; Then we turn children messages into flycheck errors pointing to the
     ;; location of the primary span.
     (dolist (child children)
-      (let ((message (let-alist child .message)))
-        (let-alist (car (let-alist child .spans))
+      (let* ((message (let-alist child .message))
+             (child-spans (let-alist child .spans))
+             ;; A child's suggestion may span several places (e.g. inserting
+             ;; a `(' and a matching `)'); collect all of them into one fix.
+             ;; A child's fix applies to the diagnostic's primary file; drop
+             ;; any span that reaches into another file.
+             (fix (flycheck-parse-rustc--fix child-spans primary-filename
+                                             buffer)))
+        (let-alist (car child-spans)
           (push
            (flycheck-error-new-at
             ;; Use the line/column from the first span if there is one, or
@@ -8458,7 +8492,8 @@ https://github.com/rust-lang/rust/blob/master/src/librustc_errors/json.rs#L154"
             :filename primary-filename
             :group group
             :end-line (or .line_end primary-end-line)
-            :end-column (or .column_end primary-end-column))
+            :end-column (or .column_end primary-end-column)
+            :fix fix)
            errors))))
 
     ;; If there are no spans, the error is not associated with a specific
@@ -8516,6 +8551,34 @@ lines, and returns the parsed JSON lines in a list."
     ;; SARIF defaults an unspecified level to \"warning\"
     (_ 'warning)))
 
+(defun flycheck-parse-sarif--fix (fixes uri buffer)
+  "Build a `flycheck-fix' for BUFFER from a SARIF result's FIXES array, or nil.
+
+Use the first fix, and only its artifact changes targeting URI --
+the file the diagnostic (and BUFFER) is for -- so a fix that also
+edits other files never applies their changes to this buffer.
+Each change's replacements carry a `deletedRegion' to replace with
+`insertedContent'."
+  (when fixes
+    (let-alist (elt fixes 0)
+      (flycheck--make-fix
+       buffer .description.text
+       (seq-mapcat
+        (lambda (change)
+          (let-alist change
+            (when (equal .artifactLocation.uri uri)
+              (seq-map
+               (lambda (replacement)
+                 (let-alist replacement
+                   (flycheck-fix-edit-new
+                    :line .deletedRegion.startLine
+                    :column .deletedRegion.startColumn
+                    :end-line .deletedRegion.endLine
+                    :end-column .deletedRegion.endColumn
+                    :replacement (or .insertedContent.text ""))))
+               .replacements))))
+        .artifactChanges)))))
+
 (defun flycheck-parse-sarif (output checker buffer)
   "Parse SARIF errors from OUTPUT.
 
@@ -8553,7 +8616,8 @@ information about SARIF."
                                (or .level
                                    (let-alist rule
                                      .defaultConfiguration.level))))
-                       (message .message.text))
+                       (message .message.text)
+                       (fixes .fixes))
                   (if .locations
                       (seq-map
                        (lambda (location)
@@ -8589,7 +8653,12 @@ information about SARIF."
                               (flycheck-parse-sarif--uri
                                .physicalLocation.artifactLocation.uri)
                               :end-line (unless zero-width end-line)
-                              :end-column (unless zero-width end-col)))))
+                              :end-column (unless zero-width end-col)
+                              ;; Only the fix changes for this location's file.
+                              :fix (flycheck-parse-sarif--fix
+                                    fixes
+                                    .physicalLocation.artifactLocation.uri
+                                    buffer)))))
                        .locations)
                     ;; A result without a location applies to the whole run
                     (list (flycheck-error-new-at
@@ -11151,6 +11220,41 @@ suggests an output format Flycheck fails to parse."
       (cons 'disable (car (split-string output "\n" t)))
     'suspicious))
 
+(defun flycheck--utf16-offset-to-position (offset)
+  "Return the buffer position at UTF-16 code-unit OFFSET from `point-min'.
+
+ESLint (like the LSP protocol) counts offsets in UTF-16 code
+units, so a character outside the Basic Multilingual Plane counts
+as two.  Call in the buffer being converted, widened."
+  (save-excursion
+    (goto-char (point-min))
+    (let ((remaining offset))
+      (while (and (> remaining 0) (not (eobp)))
+        (setq remaining (- remaining (if (>= (char-after) #x10000) 2 1)))
+        (forward-char 1))
+      (point))))
+
+(defun flycheck-parse-eslint--fix (fix buffer)
+  "Build a `flycheck-fix' from an ESLint FIX object for BUFFER, or nil.
+
+An ESLint fix has a `range' of two UTF-16 code-unit offsets into
+the source and the `text' to put in their place."
+  (when fix
+    (let-alist fix
+      (with-current-buffer buffer
+        (save-restriction
+          (widen)
+          (let ((beg (flycheck-line-column-at-pos
+                      (flycheck--utf16-offset-to-position (elt .range 0))))
+                (end (flycheck-line-column-at-pos
+                      (flycheck--utf16-offset-to-position (elt .range 1)))))
+            (flycheck--make-fix
+             buffer nil
+             (list (flycheck-fix-edit-new
+                    :line (car beg) :column (cdr beg)
+                    :end-line (car end) :end-column (cdr end)
+                    :replacement .text)))))))))
+
 (defun flycheck-parse-eslint (output checker buffer)
   "Parse ESLint errors/warnings from JSON OUTPUT.
 
@@ -11173,7 +11277,8 @@ See URL `https://eslint.org' for more information about ESLint."
                :buffer buffer
                :filename (buffer-file-name buffer)
                :end-line .endLine
-               :end-column .endColumn)))
+               :end-column .endColumn
+               :fix (flycheck-parse-eslint--fix .fix buffer))))
           (let-alist (caar (flycheck-parse-json output))
             .messages)))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -1267,6 +1267,7 @@ is used."
     (define-key map "?"         #'flycheck-describe-checker)
     (define-key map "h"         #'flycheck-display-error-at-point)
     (define-key map "e"         #'flycheck-explain-error-at-point)
+    (define-key map "f"         #'flycheck-fix-error-at-point)
     (define-key map "H"         #'display-local-help)
     (define-key map "i"         #'flycheck-manual)
     (define-key map "V"         #'flycheck-version)
@@ -1453,6 +1454,7 @@ Only has effect when variable `global-flycheck-mode' is non-nil."
      ["Copy messages at point" flycheck-copy-errors-as-kill
       (flycheck-overlays-at (point))]
      ["Explain error at point" flycheck-explain-error-at-point]
+     ["Apply fix at point" flycheck-fix-error-at-point]
      "---"
      ["Select syntax checker" flycheck-select-checker flycheck-mode]
      ["Disable syntax checker" flycheck-disable-checker flycheck-mode]
@@ -3403,10 +3405,20 @@ buffer-local value of `flycheck-disabled-checkers'."
   "The current syntax check in this buffer.")
 (put 'flycheck-current-syntax-check 'permanent-local t)
 
+(defvar-local flycheck--syntax-check-modified-tick nil
+  "`buffer-chars-modified-tick' when the current check started.
+
+A fix a checker suggests carries this tick (see `flycheck--make-fix')
+so `flycheck-apply-fix' can tell whether the buffer has changed since
+the checker read it, and thus whether the fix's positions are stale.")
+
 (defun flycheck-start-current-syntax-check (checker)
   "Start a syntax check in the current buffer with CHECKER.
 
 Set `flycheck-current-syntax-check' accordingly."
+  ;; Remember the buffer's modification state, so a fix this check produces
+  ;; can be refused later if the buffer has changed in the meantime.
+  (setq flycheck--syntax-check-modified-tick (buffer-chars-modified-tick))
   ;; Allocate the current syntax check *before* starting it.  This allows for
   ;; synchronous checks, which call the status callback immediately in their
   ;; start function.
@@ -4129,21 +4141,23 @@ non-nil, then only do this and skip per-buffer teardown.)"
                 flycheck-error-new
                 (&key
                  line column end-line end-column
-                 buffer checker filename message level id group
-                 &aux (-end-line end-line) (-end-column end-column)))
+                 buffer checker filename message level id group fix
+                 &aux (-end-line end-line) (-end-column end-column)
+                 (-fix fix)))
                (:constructor
                 flycheck-error-new-at
                 (line
                  column
                  &optional level message
-                 &key end-line end-column checker id group
+                 &key end-line end-column checker id group fix
                  (filename (buffer-file-name)) (buffer (current-buffer))
-                 &aux (-end-line end-line) (-end-column end-column)))
+                 &aux (-end-line end-line) (-end-column end-column)
+                 (-fix fix)))
                (:constructor
                 flycheck-error-new-at-pos
                 (pos
                  &optional level message
-                 &key end-pos checker id group
+                 &key end-pos checker id group fix
                  (filename (buffer-file-name)) (buffer (current-buffer))
                  &aux
                  ((line . column)
@@ -4151,7 +4165,8 @@ non-nil, then only do this and skip per-buffer teardown.)"
                     '(nil . nil)))
                  ((-end-line . -end-column)
                   (if end-pos (flycheck-line-column-at-pos end-pos)
-                    '(nil . nil))))))
+                    '(nil . nil)))
+                 (-fix fix))))
   "Structure representing an error reported by a syntax checker.
 Slots:
 
@@ -4214,7 +4229,7 @@ Slots:
   ;; The fields below are at the end of the record to preserve backwards
   ;; compatibility; see https://github.com/flycheck/flycheck/pull/1400 and
   ;; https://lists.gnu.org/archive/html/emacs-devel/2018-07/msg00436.html
-  -end-line -end-column)
+  -end-line -end-column -fix)
 
 ;; These accessors are defined for backwards compatibility
 ;; FIXME: Clean up once package.el learns how to recompile dependencies.
@@ -4243,6 +4258,42 @@ Slots:
                          flycheck-error--set-end-line)
 (gv-define-simple-setter flycheck-error-end-column
                          flycheck-error--set-end-column)
+
+(defun flycheck-error-fix (err)
+  "Return the suggested fix of a Flycheck error ERR, or nil.
+
+The value is a `flycheck-fix' object when the checker offered a
+machine-applicable fix for ERR; see `flycheck-apply-fix'."
+  (condition-case nil (flycheck-error--fix err)
+    (args-out-of-range nil)))
+
+(defun flycheck-error--set-fix (err fix)
+  "Set the suggested fix of a Flycheck error ERR to FIX."
+  (condition-case nil (setf (flycheck-error--fix err) fix)
+    (args-out-of-range nil)))
+
+(gv-define-simple-setter flycheck-error-fix flycheck-error--set-fix)
+
+(cl-defstruct (flycheck-fix-edit (:constructor flycheck-fix-edit-new))
+  "A single text edit of a `flycheck-fix'.
+
+Replace the region from LINE, COLUMN to END-LINE, END-COLUMN with
+REPLACEMENT.  Positions are one-based, as in `flycheck-error'; an
+edit that only inserts text has END-LINE, END-COLUMN equal to
+LINE, COLUMN, and an edit that only deletes has an empty
+REPLACEMENT."
+  line column end-line end-column replacement)
+
+(cl-defstruct (flycheck-fix (:constructor flycheck-fix-new))
+  "A machine-applicable fix a checker suggested for an error.
+
+DESCRIPTION is a short human-readable summary, or nil.  EDITS is
+the list of `flycheck-fix-edit' objects to apply together.  TICK
+is the buffer's `buffer-chars-modified-tick' when the check that
+produced the fix started; `flycheck-apply-fix' refuses to apply
+the fix if the buffer has changed since, so stale line and column
+numbers can never silently corrupt it.  See `flycheck-apply-fix'."
+  description edits tick)
 
 (defmacro flycheck-error-with-buffer (err &rest forms)
   "Switch to the buffer of ERR and evaluate FORMS.
@@ -4359,6 +4410,110 @@ The error position is the error column, or the first
 non-whitespace character of the error line, if ERR has no error column."
   (car (flycheck-error-region-for-mode
         err flycheck-highlighting-mode)))
+
+
+;;; Applying fixes
+
+(defun flycheck--fix-region (line column end-line end-column)
+  "Return the buffer region (BEG . END) named by LINE, COLUMN, END-LINE,
+END-COLUMN, resolved in the current buffer.  Missing columns default to 1
+and a missing end line to LINE."
+  (let ((beg (flycheck-line-column-to-position line (or column 1)))
+        (end (flycheck-line-column-to-position
+              (or end-line line) (or end-column column 1))))
+    (cons (min beg end) (max beg end))))
+
+(defun flycheck--fix-edit-region (edit)
+  "Return the buffer region (BEG . END) that EDIT replaces.
+
+EDIT is a `flycheck-fix-edit'; positions are resolved in the
+current buffer, so call this in the buffer being fixed."
+  (flycheck--fix-region (flycheck-fix-edit-line edit)
+                        (flycheck-fix-edit-column edit)
+                        (flycheck-fix-edit-end-line edit)
+                        (flycheck-fix-edit-end-column edit)))
+
+(defun flycheck--make-fix (buffer description edits)
+  "Return a `flycheck-fix' with DESCRIPTION and EDITS, or nil if no EDITS.
+
+Stamp the fix with BUFFER's modification tick at the start of the
+current check (see `flycheck--syntax-check-modified-tick'), so
+`flycheck-apply-fix' can tell whether the buffer has changed since."
+  (when edits
+    (flycheck-fix-new
+     :description description :edits edits
+     :tick (and (buffer-live-p buffer)
+                (buffer-local-value 'flycheck--syntax-check-modified-tick
+                                    buffer)))))
+
+(defun flycheck-apply-fix (fix &optional buffer)
+  "Apply FIX in BUFFER, defaulting to the current buffer.
+
+FIX is a `flycheck-fix' object.  Its edits are applied together as
+a single undoable change, from the end of the buffer backwards so
+that earlier edits do not invalidate the positions of later ones.
+
+Signal a `user-error', touching nothing, when BUFFER is not live
+or read-only, when the buffer has changed since the check that
+produced the fix (its line and column numbers would be stale), or
+when the fix's own edits overlap -- so a fix can never silently
+corrupt the buffer."
+  (let ((buffer (or buffer (current-buffer))))
+    (unless (buffer-live-p buffer)
+      (user-error "Cannot apply a fix: its buffer is gone"))
+    (with-current-buffer buffer
+      (when buffer-read-only
+        (user-error "Cannot apply a fix in a read-only buffer"))
+      (when (and (flycheck-fix-tick fix)
+                 (/= (flycheck-fix-tick fix) (buffer-chars-modified-tick)))
+        (user-error
+         "The buffer changed since this fix was computed; re-check first"))
+      (save-restriction
+        (widen)
+        (let ((regions
+               ;; Apply from the bottom up so applying one edit does not
+               ;; shift the positions of the ones above it; break ties on
+               ;; equal starts by the larger region first.
+               (sort (mapcar (lambda (edit)
+                               (cons (flycheck--fix-edit-region edit)
+                                     (flycheck-fix-edit-replacement edit)))
+                             (flycheck-fix-edits fix))
+                     (lambda (a b)
+                       (let ((ra (car a)) (rb (car b)))
+                         (or (> (car ra) (car rb))
+                             (and (= (car ra) (car rb))
+                                  (> (cdr ra) (cdr rb)))))))))
+          ;; Reject a fix whose own edits overlap: applying them bottom-up
+          ;; would let one edit clobber another.  REGIONS are sorted with
+          ;; later positions first, so each region must end at or before the
+          ;; previous one began.
+          (let ((limit nil))
+            (pcase-dolist (`((,beg . ,end) . ,_) regions)
+              (when (and limit (> end limit))
+                (user-error "This fix has overlapping edits; not applying it"))
+              (setq limit beg)))
+          (atomic-change-group
+            (pcase-dolist (`((,beg . ,end) . ,replacement) regions)
+              (delete-region beg end)
+              (save-excursion
+                (goto-char beg)
+                (insert (or replacement ""))))))))))
+
+(defun flycheck--error-fix-buffer (err)
+  "Return the live buffer in which ERR's fix may be applied, or nil.
+
+A fix's line and column numbers only make sense in a buffer
+visiting ERR's own file, so a cross-file error -- one a
+whole-project checker reports for a file other than the one being
+edited -- cannot be fixed in place."
+  (when-let* ((buffer (flycheck-error-buffer err))
+              ((buffer-live-p buffer)))
+    (let ((filename (flycheck-error-filename err)))
+      (when (with-current-buffer buffer
+              (or (null filename)
+                  (and buffer-file-name
+                       (flycheck-same-files-p filename buffer-file-name))))
+        buffer))))
 
 (defun flycheck-error-format-snippet (err &optional max-length)
   "Extract the text that ERR refers to from the buffer.
@@ -5732,6 +5887,7 @@ ID.")
     (define-key map (kbd "g") #'flycheck-error-list-check-source)
     (define-key map (kbd "P") #'flycheck-error-list-toggle-scope)
     (define-key map (kbd "e") #'flycheck-error-list-explain-error)
+    (define-key map (kbd "x") #'flycheck-error-list-apply-fix)
     (define-key map (kbd "RET") #'flycheck-error-list-goto-error)
     map)
   "The keymap of `flycheck-error-list-mode'.")
@@ -5945,7 +6101,15 @@ Return a list of (ID CELLS) for `tabulated-list-entries'."
          (id-str (if id (format "%s" id) ""))
          (checker (flycheck-error-checker error))
          (msg-and-checker
-          (flycheck-error-list-make-last-column flushed-msg checker))
+          (concat
+           ;; Flag errors that carry an applicable machine fix (apply with
+           ;; `x'/`flycheck-error-list-apply-fix'), for discoverability.  Only
+           ;; badge errors whose fix can actually be applied here, not
+           ;; cross-file ones the apply command would refuse.
+           (when (and (flycheck-error-fix error)
+                      (flycheck--error-fix-buffer error))
+             (propertize "[fix] " 'face 'flycheck-error-list-checker-name))
+           (flycheck-error-list-make-last-column flushed-msg checker)))
          (explainer (flycheck-checker-get checker 'error-explainer)))
     (list error
           (vector (flycheck-error-list-make-cell
@@ -6284,6 +6448,26 @@ POS defaults to `point'."
     (flycheck-error-with-buffer error
       (when-let (explanation (funcall explainer error))
         (flycheck-display-error-explanation explanation)))))
+
+(defun flycheck-error-list-apply-fix (&optional pos)
+  "Apply the suggested fix of the error at POS in the error list.
+
+POS defaults to `point'.  Signal a `user-error' when the error
+has no fix."
+  (interactive)
+  (let* ((error (tabulated-list-get-id pos))
+         (fix (and error (flycheck-error-fix error)))
+         (buffer (and error (flycheck--error-fix-buffer error))))
+    (unless fix
+      (user-error "The error at point has no fix"))
+    (unless buffer
+      (user-error "This fix cannot be applied here (the error is in another \
+file, or its buffer is gone)"))
+    (flycheck-apply-fix fix buffer)
+    (flycheck-error-list-refresh)
+    (message "Applied fix%s"
+             (if-let* ((description (flycheck-fix-description fix)))
+                 (concat ": " description) ""))))
 
 (defun flycheck-error-list-next-error-pos (pos &optional n)
   "Starting from POS get the N'th next error in the error list.
@@ -6629,6 +6813,25 @@ this error to produce the explanation to display."
                                      'error-explainer))
               (explanation (funcall explainer first-error)))
     (flycheck-display-error-explanation explanation)))
+
+(defun flycheck-fix-error-at-point ()
+  "Apply the suggested fix of the first fixable error at point.
+
+The first fixable error at point is the first error at point with
+a non-nil `flycheck-error-fix'; its fix is applied with
+`flycheck-apply-fix'.  Signal a `user-error' when no error at
+point has a fix."
+  (interactive)
+  (if-let* ((error (seq-find (lambda (err)
+                              (and (flycheck-error-fix err)
+                                   (flycheck--error-fix-buffer err)))
+                            (flycheck-overlay-errors-at (point)))))
+      (let ((fix (flycheck-error-fix error)))
+        (flycheck-apply-fix fix (flycheck--error-fix-buffer error))
+        (message "Applied fix%s"
+                 (if-let* ((description (flycheck-fix-description fix)))
+                     (concat ": " description) "")))
+    (user-error "No applicable fix at point")))
 
 (defconst flycheck-explain-error-buffer "*Flycheck error explanation*"
   "The name of the buffer to show error explanations.")

--- a/test/specs/test-quick-fixes.el
+++ b/test/specs/test-quick-fixes.el
@@ -1,0 +1,316 @@
+;;; test-quick-fixes.el --- Flycheck Specs: Quick fixes -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for the quick-fix API: the fix data model, the applicator, the
+;; at-point command, and fix extraction in the eslint/SARIF/rustc parsers.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(defun flycheck-test--edit (line col end-line end-col replacement)
+  "Return a `flycheck-fix' with a single edit."
+  (flycheck-fix-new
+   :edits (list (flycheck-fix-edit-new
+                 :line line :column col
+                 :end-line end-line :end-column end-col
+                 :replacement replacement))))
+
+(describe "Quick fixes"
+
+  (describe "flycheck-apply-fix"
+
+    (it "replaces the edit's region"
+      (with-temp-buffer
+        (insert "first\nhelo world\nthird\n")
+        (flycheck-apply-fix (flycheck-test--edit 2 1 2 5 "hello"))
+        (expect (buffer-string) :to-equal "first\nhello world\nthird\n")))
+
+    (it "inserts when the region is empty"
+      (with-temp-buffer
+        (insert "var x = 1\n")
+        (flycheck-apply-fix (flycheck-test--edit 1 10 1 10 ";"))
+        (expect (buffer-string) :to-equal "var x = 1;\n")))
+
+    (it "deletes when the replacement is empty"
+      (with-temp-buffer
+        (insert "a  b\n")
+        (flycheck-apply-fix (flycheck-test--edit 1 2 1 4 ""))
+        (expect (buffer-string) :to-equal "ab\n")))
+
+    (it "applies several edits from the bottom up"
+      ;; A later edit must not shift the positions of an earlier one.
+      (with-temp-buffer
+        (insert "aaa\nbbb\nccc\n")
+        (flycheck-apply-fix
+         (flycheck-fix-new
+          :edits (list (flycheck-fix-edit-new
+                        :line 1 :column 1 :end-line 1 :end-column 4
+                        :replacement "XXXXX")
+                       (flycheck-fix-edit-new
+                        :line 3 :column 1 :end-line 3 :end-column 4
+                        :replacement "Z"))))
+        (expect (buffer-string) :to-equal "XXXXX\nbbb\nZ\n")))
+
+    (it "applies as a single undoable change"
+      (with-temp-buffer
+        (buffer-enable-undo)
+        (insert "helo\n")
+        (undo-boundary)
+        (flycheck-apply-fix (flycheck-test--edit 1 1 1 5 "hello"))
+        (expect (buffer-string) :to-equal "hello\n")
+        (primitive-undo 1 buffer-undo-list)
+        (expect (buffer-string) :to-equal "helo\n")))
+
+    (it "refuses to edit a read-only buffer"
+      (with-temp-buffer
+        (insert "helo\n")
+        (setq buffer-read-only t)
+        (expect (flycheck-apply-fix (flycheck-test--edit 1 1 1 5 "hello"))
+                :to-throw 'user-error)))
+
+    (it "refuses to apply in a dead buffer"
+      (let ((buffer (generate-new-buffer " gone")))
+        (kill-buffer buffer)
+        (expect (flycheck-apply-fix (flycheck-test--edit 1 1 1 1 "x") buffer)
+                :to-throw 'user-error)))
+
+    (it "applies when the buffer is unchanged since the check"
+      (with-temp-buffer
+        (insert "helo\n")
+        (flycheck-apply-fix
+         (flycheck-fix-new
+          :tick (buffer-chars-modified-tick)
+          :edits (list (flycheck-fix-edit-new
+                        :line 1 :column 1 :end-line 1 :end-column 5
+                        :replacement "hello"))))
+        (expect (buffer-string) :to-equal "hello\n")))
+
+    (it "refuses a fix when the buffer changed since the check"
+      ;; The tick guard is what stops an apply after the user edits from
+      ;; corrupting the buffer, whatever the text happens to be.
+      (with-temp-buffer
+        (insert "helo\n")
+        (let ((fix (flycheck-fix-new
+                    :tick (buffer-chars-modified-tick)
+                    :edits (list (flycheck-fix-edit-new
+                                  :line 1 :column 1 :end-line 1 :end-column 5
+                                  :replacement "hello")))))
+          (goto-char (point-max))
+          (insert "more\n")            ; bumps `buffer-chars-modified-tick'
+          (expect (flycheck-apply-fix fix) :to-throw 'user-error))))
+
+    (it "refuses to apply the same fix twice"
+      ;; Applying the fix bumps the tick, so the stale second apply is refused
+      ;; even though the error and its fix linger until the async re-check.
+      (with-temp-buffer
+        (insert "helo\n")
+        (let ((fix (flycheck-fix-new
+                    :tick (buffer-chars-modified-tick)
+                    :edits (list (flycheck-fix-edit-new
+                                  :line 1 :column 1 :end-line 1 :end-column 5
+                                  :replacement "hello")))))
+          (flycheck-apply-fix fix)
+          (expect (buffer-string) :to-equal "hello\n")
+          (expect (flycheck-apply-fix fix) :to-throw 'user-error))))
+
+    (it "refuses a fix whose own edits overlap"
+      (with-temp-buffer
+        (insert "abcdef\n")
+        (expect (flycheck-apply-fix
+                 (flycheck-fix-new
+                  :edits (list (flycheck-fix-edit-new
+                                :line 1 :column 1 :end-line 1 :end-column 4
+                                :replacement "X")
+                               (flycheck-fix-edit-new
+                                :line 1 :column 3 :end-line 1 :end-column 6
+                                :replacement "Y"))))
+                :to-throw 'user-error)
+        (expect (buffer-string) :to-equal "abcdef\n"))))
+
+  (describe "flycheck-fix-error-at-point"
+
+    (it "applies the fix of the fixable error at point"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "helo world\n")
+        (goto-char (point-min))
+        (let* ((err (flycheck-error-new-at
+                     1 1 'error "typo"
+                     :end-line 1 :end-column 5
+                     :fix (flycheck-test--edit 1 1 1 5 "hello")))
+               (flycheck-current-errors (list err)))
+          (spy-on 'flycheck-overlay-errors-at :and-return-value (list err))
+          (flycheck-fix-error-at-point)
+          (expect (buffer-string) :to-equal "hello world\n"))))
+
+    (it "applies a fix whose error is for the current file"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (let ((err (flycheck-error-new-at 1 1 'error "x"
+                                          :filename "/proj/a.el"
+                                          :buffer (current-buffer))))
+          (expect (flycheck--error-fix-buffer err) :to-be (current-buffer)))))
+
+    (it "refuses a fix whose error is for another file"
+      ;; A cross-file error's positions are for another file; applying its fix
+      ;; in this buffer would corrupt it.
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (let ((err (flycheck-error-new-at 1 1 'error "x"
+                                          :filename "/proj/b.el"
+                                          :buffer (current-buffer))))
+          (expect (flycheck--error-fix-buffer err) :to-be nil))))
+
+    (it "signals when no error at point has a fix"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "helo\n")
+        (let ((err (flycheck-error-new-at 1 1 'error "no fix")))
+          (spy-on 'flycheck-overlay-errors-at :and-return-value (list err))
+          (expect (flycheck-fix-error-at-point) :to-throw 'user-error)))))
+
+  (describe "fix extraction in parsers"
+
+    (it "reads an ESLint fix"
+      (let ((json "[{\"filePath\":\"/f.js\",\"messages\":[\
+{\"ruleId\":\"semi\",\"severity\":2,\"message\":\"Missing semicolon.\",\
+\"line\":1,\"column\":10,\"endLine\":1,\"endColumn\":11,\
+\"fix\":{\"range\":[9,9],\"text\":\";\"}}]}]"))
+        (with-temp-buffer
+          (insert "var x = 1\n")
+          (let* ((err (car (flycheck-parse-eslint json 'javascript-eslint
+                                                  (current-buffer))))
+                 (fix (flycheck-error-fix err))
+                 (edit (car (flycheck-fix-edits fix))))
+            ;; Character offset 9 maps to line 1, column 10.
+            (expect (flycheck-fix-edit-line edit) :to-equal 1)
+            (expect (flycheck-fix-edit-column edit) :to-equal 10)
+            (expect (flycheck-fix-edit-replacement edit) :to-equal ";")))))
+
+    (it "reads a SARIF fix"
+      (let ((sarif "{\"runs\":[{\"tool\":{\"driver\":{\"rules\":[]}},\"results\":[\
+{\"ruleId\":\"R1\",\"level\":\"warning\",\"message\":{\"text\":\"bad\"},\
+\"locations\":[{\"physicalLocation\":{\"artifactLocation\":{\"uri\":\"f.txt\"},\
+\"region\":{\"startLine\":3,\"startColumn\":2,\"endLine\":3,\"endColumn\":6}}}],\
+\"fixes\":[{\"description\":{\"text\":\"do it\"},\"artifactChanges\":[\
+{\"artifactLocation\":{\"uri\":\"f.txt\"},\"replacements\":[{\"deletedRegion\":\
+{\"startLine\":3,\"startColumn\":2,\"endLine\":3,\"endColumn\":6},\
+\"insertedContent\":{\"text\":\"good\"}}]}]}]}]}]}"))
+        (let* ((err (car (flycheck-parse-sarif sarif 'checker (current-buffer))))
+               (fix (flycheck-error-fix err))
+               (edit (car (flycheck-fix-edits fix))))
+          (expect (flycheck-fix-description fix) :to-equal "do it")
+          (expect (flycheck-fix-edit-line edit) :to-equal 3)
+          (expect (flycheck-fix-edit-column edit) :to-equal 2)
+          (expect (flycheck-fix-edit-end-column edit) :to-equal 6)
+          (expect (flycheck-fix-edit-replacement edit) :to-equal "good"))))
+
+    (it "reads a machine-applicable rustc suggestion"
+      (let ((diag "{\"message\":\"help\",\"code\":{\"code\":\"E1\"},\"level\":\"warning\",\
+\"spans\":[{\"file_name\":\"a.rs\",\"is_primary\":true,\
+\"line_start\":2,\"line_end\":2,\"column_start\":1,\"column_end\":4,\
+\"suggested_replacement\":\"bar\",\"suggestion_applicability\":\"MachineApplicable\"}],\
+\"children\":[]}"))
+        (let* ((err (car (flycheck-parse-rustc-diagnostic
+                          (car (flycheck-parse-json diag)) 'checker
+                          (current-buffer))))
+               (fix (flycheck-error-fix err))
+               (edit (car (flycheck-fix-edits fix))))
+          (expect (flycheck-fix-edit-line edit) :to-equal 2)
+          (expect (flycheck-fix-edit-replacement edit) :to-equal "bar"))))
+
+    (it "applies a multi-span rustc suggestion in full"
+      ;; A child suggestion may touch several spans (insert `(' and `)');
+      ;; both edits must land, in the right order.
+      (let ((diag "{\"message\":\"m\",\"code\":{\"code\":\"E\"},\"level\":\"warning\",\
+\"spans\":[{\"file_name\":\"a.rs\",\"is_primary\":true,\
+\"line_start\":1,\"line_end\":1,\"column_start\":1,\"column_end\":2}],\
+\"children\":[{\"message\":\"help\",\"spans\":[\
+{\"file_name\":\"a.rs\",\"line_start\":1,\"column_start\":1,\"line_end\":1,\"column_end\":1,\
+\"suggested_replacement\":\"(\",\"suggestion_applicability\":\"MachineApplicable\"},\
+{\"file_name\":\"a.rs\",\"line_start\":1,\"column_start\":5,\"line_end\":1,\"column_end\":5,\
+\"suggested_replacement\":\")\",\"suggestion_applicability\":\"MachineApplicable\"}]}]}"))
+        (with-temp-buffer
+          (insert "abcd\n")
+          (let* ((errors (flycheck-parse-rustc-diagnostic
+                          (car (flycheck-parse-json diag)) 'checker
+                          (current-buffer)))
+                 (fix (seq-some #'flycheck-error-fix errors)))
+            (expect (length (flycheck-fix-edits fix)) :to-equal 2)
+            (flycheck-apply-fix fix)
+            (expect (buffer-string) :to-equal "(abcd)\n")))))
+
+    (it "converts ESLint UTF-16 offsets past an astral character"
+      ;; An emoji is one Emacs character but two UTF-16 code units, so an
+      ;; offset after it must map back one character to the left.
+      (let ((json "[{\"messages\":[{\"ruleId\":\"semi\",\"severity\":2,\
+\"message\":\"m\",\"line\":1,\"column\":1,\"fix\":{\"range\":[5,5],\"text\":\";\"}}]}]"))
+        (with-temp-buffer
+          ;; "x=" then an astral char (2 code units) then "y" -> UTF-16 offset
+          ;; 5 is right after "y", i.e. Emacs position 5 (treating the emoji as
+          ;; one character it would wrongly land at position 6).
+          (insert "x=")
+          (insert (char-to-string #x1F600))
+          (insert "y\n")
+          (let* ((err (car (flycheck-parse-eslint json 'javascript-eslint
+                                                  (current-buffer))))
+                 (edit (car (flycheck-fix-edits (flycheck-error-fix err)))))
+            ;; Position 5 is line 1, column 5 (x = emoji y | ).
+            (expect (flycheck-fix-edit-column edit) :to-equal 5)))))
+
+    (it "drops a rustc suggestion span in another file"
+      ;; A suggestion reaching into a different file must not edit this buffer.
+      (let ((diag "{\"message\":\"m\",\"code\":{\"code\":\"E\"},\"level\":\"warning\",\
+\"spans\":[{\"file_name\":\"a.rs\",\"is_primary\":true,\
+\"line_start\":1,\"line_end\":1,\"column_start\":1,\"column_end\":2}],\
+\"children\":[{\"message\":\"help\",\"spans\":[\
+{\"file_name\":\"other.rs\",\"line_start\":9,\"column_start\":1,\"line_end\":9,\"column_end\":2,\
+\"suggested_replacement\":\"z\",\"suggestion_applicability\":\"MachineApplicable\"}]}]}"))
+        (let ((errors (flycheck-parse-rustc-diagnostic
+                       (car (flycheck-parse-json diag)) 'checker
+                       (current-buffer))))
+          (expect (seq-some #'flycheck-error-fix errors) :to-be nil))))
+
+    (it "drops a SARIF fix change for another file"
+      (let ((sarif "{\"runs\":[{\"tool\":{\"driver\":{\"rules\":[]}},\"results\":[\
+{\"ruleId\":\"R1\",\"level\":\"warning\",\"message\":{\"text\":\"bad\"},\
+\"locations\":[{\"physicalLocation\":{\"artifactLocation\":{\"uri\":\"f.txt\"},\
+\"region\":{\"startLine\":3,\"startColumn\":2}}}],\
+\"fixes\":[{\"artifactChanges\":[\
+{\"artifactLocation\":{\"uri\":\"other.txt\"},\"replacements\":[{\"deletedRegion\":\
+{\"startLine\":3,\"startColumn\":2,\"endLine\":3,\"endColumn\":6},\
+\"insertedContent\":{\"text\":\"good\"}}]}]}]}]}]}"))
+        (let ((err (car (flycheck-parse-sarif sarif 'checker (current-buffer)))))
+          (expect (flycheck-error-fix err) :to-be nil))))
+
+    (it "ignores a non-machine-applicable rustc suggestion"
+      (let ((diag "{\"message\":\"help\",\"code\":{\"code\":\"E1\"},\"level\":\"warning\",\
+\"spans\":[{\"file_name\":\"a.rs\",\"is_primary\":true,\
+\"line_start\":2,\"line_end\":2,\"column_start\":1,\"column_end\":4,\
+\"suggested_replacement\":\"bar\",\"suggestion_applicability\":\"MaybeIncorrect\"}],\
+\"children\":[]}"))
+        (let ((err (car (flycheck-parse-rustc-diagnostic
+                         (car (flycheck-parse-json diag)) 'checker
+                         (current-buffer)))))
+          (expect (flycheck-error-fix err) :to-be nil))))))
+
+(provide 'test-quick-fixes)
+
+;;; test-quick-fixes.el ends here


### PR DESCRIPTION
Flycheck can now apply the fixes checkers already suggest. rustc/clippy, eslint (`--fix`) and SARIF analyzers all emit machine-applicable edits that Flycheck parsed and then discarded; this keeps them. Errors gain a `:fix` slot, `C-c ! f` applies the fix at point, `x` does it in the error list, and fixable rows show `[fix]`. eslint, the rust checkers, and any SARIF checker (e.g. dockerfile-hadolint) populate it.

Since it edits your buffers, it refuses any fix that could corrupt them: if the buffer changed since the check (tracked with a modification tick), if the fix's own edits overlap, if the buffer doesn't visit the error's file, or if it's read-only. I opened this for review rather than merging on green since it mutates source, but say the word and I'll merge.
