### PR TITLE
Wire ruff and shellcheck into the quick-fix API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``master`` (unreleased)
 =======================
 
+- ``python-ruff`` and ``sh-shellcheck`` now carry the fixes their tools
+  suggest, applicable with the quick-fix commands.  Both switched to their
+  JSON output (ruff ``--output-format=json``, shellcheck ``--format
+  json1``) to get the fix data; ruff findings no longer show the ``[*]``
+  auto-fixable marker in their message, since the error list marks them
+  ``[fix]`` instead.  ``sh-shellcheck`` now needs shellcheck 0.7 or newer.
 - Flycheck can now apply machine-applicable fixes that checkers suggest.
   ``C-c ! f`` (``flycheck-fix-error-at-point``) applies the fix of the
   error at point, and ``x`` does the same for the selected row in the

--- a/flycheck.el
+++ b/flycheck.el
@@ -13798,12 +13798,60 @@ See the ShellCheck man page for a list of available optional checks."
 (flycheck-def-args-var flycheck-shellcheck-args sh-shellcheck
   :package-version '(flycheck . "36"))
 
+(defun flycheck-parse-shellcheck--fix (fix buffer)
+  "Build a `flycheck-fix' for BUFFER from a shellcheck FIX object, or nil.
+
+A shellcheck fix carries `replacements', each replacing the region
+from its `line', `column' to its `endLine', `endColumn' (one-based
+character positions, as `flycheck-error' uses) with `replacement'."
+  (when fix
+    (let-alist fix
+      (flycheck--make-fix
+       buffer nil
+       (seq-map
+        (lambda (replacement)
+          (let-alist replacement
+            (flycheck-fix-edit-new
+             :line .line :column .column
+             :end-line .endLine :end-column .endColumn
+             :replacement .replacement)))
+        .replacements)))))
+
+(defun flycheck-parse-shellcheck (output checker buffer)
+  "Parse shellcheck JSON1 OUTPUT into Flycheck errors.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and
+the BUFFER that was checked respectively.
+
+See URL `https://github.com/koalaman/shellcheck/' for more
+information about shellcheck."
+  (seq-map
+   (lambda (comment)
+     (let-alist comment
+       (flycheck-error-new-at
+        .line .column
+        (pcase .level
+          ("error" 'error)
+          ("warning" 'warning)
+          ;; shellcheck's \"style\" level maps to info, as it did through the
+          ;; CheckStyle format Flycheck used before.
+          (_ 'info))
+        .message
+        :id (format "SC%s" .code)
+        :checker checker
+        :buffer buffer
+        :filename (unless (equal .file "-") .file)
+        :fix (flycheck-parse-shellcheck--fix .fix buffer))))
+   (let-alist (car (flycheck-parse-json output)) .comments)))
+
 (flycheck-define-checker sh-shellcheck
   "A shell script syntax and style checker using Shellcheck.
 
 See URL `https://github.com/koalaman/shellcheck/'."
   :command ("shellcheck"
-            "--format" "checkstyle"
+            ;; JSON1 carries shellcheck's fix replacements (see
+            ;; `flycheck-parse-shellcheck'); it needs shellcheck >= 0.7.
+            "--format" "json1"
             (eval
              (unless flycheck-shellcheck-infer-shell
                (list "--shell" (symbol-name sh-shell))))
@@ -13816,11 +13864,7 @@ See URL `https://github.com/koalaman/shellcheck/'."
             (eval flycheck-shellcheck-args)
             "-")
   :standard-input t
-  :error-parser flycheck-parse-checkstyle
-  :error-filter
-  (lambda (errors)
-    (flycheck-remove-error-file-names
-     "-" (flycheck-dequalify-error-ids errors)))
+  :error-parser flycheck-parse-shellcheck
   :modes (sh-mode bash-ts-mode)
   :predicate (lambda () (memq sh-shell flycheck-shellcheck-supported-shells))
   :verify (lambda (_)

--- a/flycheck.el
+++ b/flycheck.el
@@ -12287,6 +12287,57 @@ The checker output is fontified as Markdown."
   (when-let (error-code (flycheck-error-id err))
     (flycheck--explain-error-via-checker 'python-ruff "rule" error-code)))
 
+(defun flycheck-parse-ruff--fix (fix buffer)
+  "Build a `flycheck-fix' for BUFFER from a ruff FIX object, or nil.
+
+Only safe fixes -- the ones `ruff check --fix' applies without
+`--unsafe-fixes' -- are offered.  Each edit's `content' replaces
+the region between its `location' and `end_location', both
+one-based row/column pairs, as `flycheck-error' uses."
+  (let-alist fix
+    (when (equal .applicability "safe")
+      (flycheck--make-fix
+       buffer .message
+       (seq-map
+        (lambda (edit)
+          (let-alist edit
+            (flycheck-fix-edit-new
+             :line .location.row :column .location.column
+             :end-line .end_location.row :end-column .end_location.column
+             :replacement .content)))
+        .edits)))))
+
+(defun flycheck-parse-ruff (output checker buffer)
+  "Parse ruff JSON OUTPUT into Flycheck errors.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and
+the BUFFER that was checked respectively.
+
+See URL `https://docs.astral.sh/ruff/' for more information about
+ruff."
+  (seq-map
+   (lambda (finding)
+     (let-alist finding
+       ;; ruff reports syntax errors with the code \"invalid-syntax\" (or a
+       ;; null code before ruff 0.8); keep treating those as errors without a
+       ;; rule id, and everything else as a warning that `:error-filter' may
+       ;; promote (see `flycheck-flake8-fix-error-level').  ruff's own
+       ;; severity is not used, to keep the levels Flycheck has always shown.
+       (let ((syntax-error (or (null .code) (equal .code "invalid-syntax"))))
+         ;; Keep the column-based region Flycheck showed with the text
+         ;; output; the end position stays off so the highlighting does not
+         ;; change.  The fix carries its own coordinates.
+         (flycheck-error-new-at
+          .location.row .location.column
+          (if syntax-error 'error 'warning)
+          .message
+          :id (unless syntax-error .code)
+          :checker checker
+          :buffer buffer
+          :filename (unless (equal .filename "-") .filename)
+          :fix (flycheck-parse-ruff--fix .fix buffer)))))
+   (car (flycheck-parse-json output))))
+
 (flycheck-define-checker python-ruff
   "A Python syntax and style checker using Ruff.
 
@@ -12294,34 +12345,20 @@ See URL `https://docs.astral.sh/ruff/'."
   :command ("ruff"
             "check"
             (config-file "--config" flycheck-python-ruff-config)
-            ;; older versions of ruff (before 0.2) used "text" instead of "concise"
-            "--output-format=concise"
+            ;; JSON carries the machine-applicable fixes ruff computes (see
+            ;; `flycheck-parse-ruff'); "--output-format" needs ruff >= 0.2.
+            "--output-format=json"
             (eval (when buffer-file-name
                     (list "--stdin-filename" (flycheck-buffer-file-local-name))))
             "-")
   :standard-input t
+  :error-parser flycheck-parse-ruff
   :error-filter (lambda (errors)
                   (let ((errors (flycheck-sanitize-errors errors)))
                     (dolist (err errors)
                       (when (flycheck-error-id err)
                         (flycheck-flake8-fix-error-level err)))
                     errors))
-  :error-patterns
-  ((error line-start
-          (or "-" (file-name)) ":" line ":" (optional column ":") " "
-          ;; first variant is produced by ruff < 0.8 and kept for backward compat
-          (or "SyntaxError: " "invalid-syntax: ")
-          (message (one-or-more not-newline))
-          line-end)
-   (warning line-start
-            (or "-" (file-name)) ":" line ":" (optional column ":") " "
-            ;; ruff >= 0.15.7 in preview mode wraps the rule code in a
-            ;; severity tag, e.g. "error[F401]" instead of just "F401"
-            (optional (one-or-more (any alpha)) "[")
-            (id (one-or-more (any alpha)) (one-or-more digit))
-            (optional "]") " "
-            (message (one-or-more not-newline))
-            line-end))
   :error-explainer flycheck-python-ruff-explainer
   :working-directory flycheck-python-find-project-root
   :modes (python-mode python-ts-mode)

--- a/test/specs/languages/test-python.el
+++ b/test/specs/languages/test-python.el
@@ -62,34 +62,63 @@
           (flycheck-checkers '(python-ruff)))
       (flycheck-buttercup-should-syntax-check
        "language/python/test.py" 'python-mode
-       '(5 15 warning "[*] `.antigravit` imported but unused" :id "F401"
+       '(5 15 warning "`.antigravit` imported but unused" :id "F401"
            :checker python-ruff)
        '(22 1 error "Undefined name `antigravity`" :id "F821"
            :checker python-ruff))))
 
-  (describe "python-ruff error patterns"
-    ;; Run synthetic output through the patterns so we cover formats from
-    ;; ruff versions other than the one installed in CI.
-    (it "parses the plain rule code format (ruff < 0.15.7)"
+  (describe "python-ruff JSON parser"
+    (it "parses a finding and its machine-applicable fix"
       (flycheck-buttercup-with-temp-buffer
-        (expect
-         (flycheck-parse-output
-          "-:1:8: F401 `os` imported but unused\n"
-          'python-ruff (current-buffer))
-         :to-be-equal-flycheck-errors
-         (list (flycheck-error-new-at
-                1 8 'warning "`os` imported but unused"
-                :id "F401" :checker 'python-ruff)))))
-    (it "parses the severity-tagged format (ruff >= 0.15.7 preview)"
+        (let* ((errors (flycheck-parse-output
+                        "[{\"code\":\"F401\",\"message\":\"`os` imported but unused\",\
+\"location\":{\"row\":1,\"column\":8},\"end_location\":{\"row\":1,\"column\":10},\
+\"fix\":{\"applicability\":\"safe\",\"message\":\"Remove unused import\",\
+\"edits\":[{\"content\":\"\",\"location\":{\"row\":1,\"column\":1},\
+\"end_location\":{\"row\":2,\"column\":1}}]},\"filename\":\"-\"}]"
+                        'python-ruff (current-buffer)))
+               (err (car errors))
+               (edit (car (flycheck-fix-edits (flycheck-error-fix err)))))
+          (expect (flycheck-error-line err) :to-equal 1)
+          (expect (flycheck-error-column err) :to-equal 8)
+          (expect (flycheck-error-id err) :to-equal "F401")
+          (expect (flycheck-error-level err) :to-equal 'warning)
+          (expect (flycheck-error-message err) :to-equal "`os` imported but unused")
+          (expect (flycheck-fix-edit-line edit) :to-equal 1)
+          (expect (flycheck-fix-edit-end-line edit) :to-equal 2)
+          (expect (flycheck-fix-edit-replacement edit) :to-equal ""))))
+
+    (it "treats invalid-syntax as an error with no id or fix"
       (flycheck-buttercup-with-temp-buffer
-        (expect
-         (flycheck-parse-output
-          "-:1:8: error[F401] `os` imported but unused\n"
-          'python-ruff (current-buffer))
-         :to-be-equal-flycheck-errors
-         (list (flycheck-error-new-at
-                1 8 'warning "`os` imported but unused"
-                :id "F401" :checker 'python-ruff))))))
+        (let ((err (car (flycheck-parse-output
+                         "[{\"code\":\"invalid-syntax\",\"message\":\"boom\",\
+\"location\":{\"row\":3,\"column\":7},\"end_location\":{\"row\":3,\"column\":8},\
+\"fix\":null,\"filename\":\"-\"}]"
+                         'python-ruff (current-buffer)))))
+          (expect (flycheck-error-level err) :to-equal 'error)
+          (expect (flycheck-error-id err) :to-be nil)
+          (expect (flycheck-error-fix err) :to-be nil))))
+
+    (it "treats a null code (pre-0.8 syntax error) as an error"
+      (flycheck-buttercup-with-temp-buffer
+        (let ((err (car (flycheck-parse-output
+                         "[{\"code\":null,\"message\":\"SyntaxError: boom\",\
+\"location\":{\"row\":1,\"column\":1},\"end_location\":{\"row\":1,\"column\":2},\
+\"fix\":null,\"filename\":\"-\"}]"
+                         'python-ruff (current-buffer)))))
+          (expect (flycheck-error-level err) :to-equal 'error)
+          (expect (flycheck-error-id err) :to-be nil))))
+
+    (it "does not offer an unsafe fix"
+      (flycheck-buttercup-with-temp-buffer
+        (let ((err (car (flycheck-parse-output
+                         "[{\"code\":\"F811\",\"message\":\"m\",\
+\"location\":{\"row\":1,\"column\":1},\"end_location\":{\"row\":1,\"column\":2},\
+\"fix\":{\"applicability\":\"unsafe\",\"message\":\"x\",\"edits\":[\
+{\"content\":\"\",\"location\":{\"row\":1,\"column\":1},\
+\"end_location\":{\"row\":1,\"column\":2}}]},\"filename\":\"-\"}]"
+                         'python-ruff (current-buffer)))))
+          (expect (flycheck-error-fix err) :to-be nil)))))
 
   (flycheck-buttercup-def-checker-test python-pylint python nil
     (let ((flycheck-disabled-checkers '(python-flake8 python-mypy))

--- a/test/specs/languages/test-sh.el
+++ b/test/specs/languages/test-sh.el
@@ -79,6 +79,25 @@
       (flycheck-buttercup-should-syntax-check
        "language/sh/shellcheck-infer.sh" 'sh-mode
        '(4 15 warning "Remove quotes from right-hand side of =~ to match as a regex rather than literally."
-           :checker sh-shellcheck :id "SC2076")))))
+           :checker sh-shellcheck :id "SC2076"))))
+
+  (describe "sh-shellcheck JSON1 parser"
+    (it "parses a comment and its fix replacements"
+      (flycheck-buttercup-with-temp-buffer
+        (let* ((errors (flycheck-parse-output
+                        "{\"comments\":[{\"file\":\"-\",\"line\":2,\"endLine\":2,\
+\"column\":6,\"endColumn\":8,\"level\":\"info\",\"code\":2086,\
+\"message\":\"Double quote to prevent globbing.\",\"fix\":{\"replacements\":[\
+{\"line\":2,\"endLine\":2,\"column\":6,\"endColumn\":6,\"replacement\":\"Q\"},\
+{\"line\":2,\"endLine\":2,\"column\":8,\"endColumn\":8,\"replacement\":\"Q\"}]}}]}"
+                        'sh-shellcheck (current-buffer)))
+               (err (car errors))
+               (edits (flycheck-fix-edits (flycheck-error-fix err))))
+          (expect (flycheck-error-line err) :to-equal 2)
+          (expect (flycheck-error-column err) :to-equal 6)
+          (expect (flycheck-error-level err) :to-equal 'info)
+          (expect (flycheck-error-id err) :to-equal "SC2086")
+          (expect (length edits) :to-equal 2)
+          (expect (flycheck-fix-edit-replacement (car edits)) :to-equal "Q"))))))
 
 ;;; test-sh.el ends here


### PR DESCRIPTION
Ruff and shellcheck both emit machine-applicable fixes, so this wires them into the new quick-fix API. Getting the fix data means parsing their JSON rather than text, so `python-ruff` now runs `--output-format=json` and `sh-shellcheck` runs `--format json1`, each with a small dedicated parser.

The errors are unchanged (same levels, columns, ids), with two caveats worth flagging: ruff's own `[*]` auto-fixable marker no longer shows up in messages, since the error list marks fixable errors with `[fix]` now; and json1 needs shellcheck 0.7+ (was any version via checkstyle). Both tools happen to use 1-based character columns, so no coordinate juggling.
