### PR TITLE
Group the error list by file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 ``master`` (unreleased)
 =======================
 
+- The error list can group its errors by file: press ``t``
+  (``flycheck-error-list-toggle-grouping``) to lay them out under a header
+  per file instead of a flat list, which helps a lot in project scope.
 - ``python-ruff`` and ``sh-shellcheck`` now carry the fixes their tools
   suggest, applicable with the quick-fix commands.  Both switched to their
   JSON output (ruff ``--output-format=json``, shellcheck ``--format

--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -38,6 +38,7 @@ Within the error list the following key bindings are available:
 :kbd:`S`     Sort the error list by the column at point
 :kbd:`g`     Check the source buffer and update the error list
 :kbd:`P`     Toggle between buffer and whole-project scope
+:kbd:`t`     Toggle grouping the errors by file
 :kbd:`q`     Quit the error list and hide its window
 ==========   ====
 
@@ -80,6 +81,10 @@ Press :kbd:`RET` on an error in another file to jump straight to it.
 The project of a buffer is Emacs' project (see `project-current`) when one is
 found, and the checker's working directory otherwise.  The current scope is
 shown as ``[project]`` in the error list's mode line.
+
+Press :kbd:`t` to group the errors under a header per file instead of a flat
+list, which makes a project-wide list much easier to scan.  The mode line
+shows ``[by file]`` while grouping is on.
 
 Filter the list
 ===============

--- a/flycheck.el
+++ b/flycheck.el
@@ -5886,6 +5886,7 @@ ID.")
     (define-key map (kbd "p") #'flycheck-error-list-previous-error)
     (define-key map (kbd "g") #'flycheck-error-list-check-source)
     (define-key map (kbd "P") #'flycheck-error-list-toggle-scope)
+    (define-key map (kbd "t") #'flycheck-error-list-toggle-grouping)
     (define-key map (kbd "e") #'flycheck-error-list-explain-error)
     (define-key map (kbd "x") #'flycheck-error-list-apply-fix)
     (define-key map (kbd "RET") #'flycheck-error-list-goto-error)
@@ -6009,6 +6010,21 @@ every open buffer of the source buffer's project (see
 ;; Preserved across the reversions Tabulated List mode performs on refresh.
 (put 'flycheck-error-list-scope 'permanent-local t)
 
+(defvar-local flycheck-error-list-group-by nil
+  "How the error list groups its errors.
+
+Either nil, to show a flat list sorted by location, or `file', to
+group the errors under a collapsible-looking header per file --
+handy in `project' scope, where errors span many files.  Toggle it
+with \\<flycheck-error-list-mode-map>\\[flycheck-error-list-toggle-grouping].")
+(put 'flycheck-error-list-group-by 'permanent-local t)
+
+(defface flycheck-error-list-group-header
+  '((t :inherit flycheck-error-list-filename :weight bold))
+  "Face for the file headers in a grouped error list."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
 (defun flycheck-error-list-set-source (buffer)
   "Set BUFFER as the source buffer of the error list."
   (flycheck-error-list-with-buffer
@@ -6046,6 +6062,22 @@ See `flycheck-error-list-scope'."
     (message "Flycheck error list now showing the %s"
              (if (eq flycheck-error-list-scope 'project)
                  "whole project" "current buffer"))))
+
+(defun flycheck-error-list-toggle-grouping ()
+  "Toggle grouping the error list by file.
+
+See `flycheck-error-list-group-by'."
+  (interactive)
+  (flycheck-error-list-with-buffer
+    (setq flycheck-error-list-group-by
+          (if (eq flycheck-error-list-group-by 'file) nil 'file))
+    ;; Grouped entries are laid out in order already, so turn off column
+    ;; sorting; restore the location sort for the flat list.
+    (setq tabulated-list-sort-key
+          (unless flycheck-error-list-group-by (cons "Line" nil)))
+    (flycheck-error-list-refresh)
+    (message "Flycheck error list %s"
+             (if flycheck-error-list-group-by "grouped by file" "flat"))))
 
 (define-button-type 'flycheck-error-list
   'action #'flycheck-error-list-goto-error
@@ -6085,10 +6117,12 @@ string with attached text properties."
    (if (numberp number) (number-to-string number) "")
    face))
 
-(defun flycheck-error-list-make-entry (error)
+(defun flycheck-error-list-make-entry (error &optional omit-file)
   "Make a table entry for the given ERROR.
 
-Return a list of (ID CELLS) for `tabulated-list-entries'."
+Return a list of (ID CELLS) for `tabulated-list-entries'.  With
+OMIT-FILE non-nil leave the File cell blank, as a file header
+already names it in a grouped list."
   (let* ((level (flycheck-error-level error))
          (level-face (flycheck-error-level-error-list-face level))
          (filename (flycheck-error-filename error))
@@ -6113,7 +6147,7 @@ Return a list of (ID CELLS) for `tabulated-list-entries'."
          (explainer (flycheck-checker-get checker 'error-explainer)))
     (list error
           (vector (flycheck-error-list-make-cell
-                   (if filename
+                   (if (and filename (not omit-file))
                        (file-name-nondirectory filename)
                      "")
                    'flycheck-error-list-filename)
@@ -6159,23 +6193,80 @@ read the project-wide diagnostics of that buffer's project."
       (buffer-local-value 'flycheck-current-errors
                           flycheck-error-list-source-buffer))))
 
+(defun flycheck-error-list--abbreviate-filename (filename)
+  "Abbreviate FILENAME for a group header, relative to the source project."
+  (if-let* ((filename)
+            (dir (and (buffer-live-p flycheck-error-list-source-buffer)
+                      (buffer-local-value 'default-directory
+                                          flycheck-error-list-source-buffer))))
+      (if (string-prefix-p dir filename)
+          (file-relative-name filename dir)
+        (abbreviate-file-name filename))
+    (or filename "<no file>")))
+
+(defun flycheck-error-list--group-header (filename count)
+  "Return an error-list header entry for FILENAME with COUNT errors.
+
+The entry's id is a list headed by `flycheck-group', not a
+`flycheck-error', so navigation and the fix/explain commands skip
+it."
+  (list (list 'flycheck-group filename)
+        (vector (flycheck-error-list-make-cell
+                 (format "%s (%d)"
+                         (flycheck-error-list--abbreviate-filename filename)
+                         count)
+                 'flycheck-error-list-group-header)
+                "" "" "" "" "")))
+
+(defun flycheck-error-list--grouped-entries (errors)
+  "Return grouped tabulated-list entries for ERRORS, one section per file."
+  (let ((groups (sort (seq-group-by #'flycheck-error-filename errors)
+                      (lambda (a b) (string< (or (car a) "") (or (car b) ""))))))
+    (seq-mapcat
+     (lambda (group)
+       (let ((sorted (sort (cdr group) #'flycheck-error-<)))
+         (cons (flycheck-error-list--group-header (car group) (length sorted))
+               (mapcar (lambda (err) (flycheck-error-list-make-entry err 'omit-file))
+                       sorted))))
+     groups)))
+
 (defun flycheck-error-list-entries ()
-  "Create the entries for the error list."
+  "Create the entries for the error list.
+
+When `flycheck-error-list-group-by' is `file' the errors are laid
+out under a header per file; otherwise a flat list is returned and
+Tabulated List mode sorts it."
   (when-let* ((errors (flycheck-error-list-current-errors))
               (filtered (flycheck-error-list-apply-filter errors)))
-    (mapcar #'flycheck-error-list-make-entry filtered)))
+    (if (eq flycheck-error-list-group-by 'file)
+        (flycheck-error-list--grouped-entries filtered)
+      (mapcar #'flycheck-error-list-make-entry filtered))))
 
 (defun flycheck-error-list-entry-< (entry1 entry2)
   "Determine whether ENTRY1 is before ENTRY2 by location.
 
+In a file-grouped list an entry can be a file header rather than an
+error; such entries have no location, so they sort as equal here and
+keep their place.
+
 See `flycheck-error-<'."
-  (flycheck-error-< (car entry1) (car entry2)))
+  (let ((err1 (car entry1))
+        (err2 (car entry2)))
+    (and (flycheck-error-p err1) (flycheck-error-p err2)
+         (flycheck-error-< err1 err2))))
 
 (defun flycheck-error-list-entry-level-< (entry1 entry2)
   "Determine whether ENTRY1 is before ENTRY2 by level.
 
+In a file-grouped list an entry can be a file header rather than an
+error; such entries have no level, so they sort as equal here and keep
+their place.
+
 See `flycheck-error-level-<'."
-  (not (flycheck-error-level-< (car entry1) (car entry2))))
+  (let ((err1 (car entry1))
+        (err2 (car entry2)))
+    (and (flycheck-error-p err1) (flycheck-error-p err2)
+         (not (flycheck-error-level-< err1 err2)))))
 
 (defvar flycheck-error-list-mode-line-map
   (let ((map (make-sparse-keymap)))
@@ -6263,8 +6354,11 @@ list."
 
 (defun flycheck-error-list-mode-line-scope-indicator ()
   "Create a string representing the current error list scope."
-  (when (eq flycheck-error-list-scope 'project)
-    " [project]"))
+  (concat
+   (when (eq flycheck-error-list-scope 'project)
+     " [project]")
+   (when (eq flycheck-error-list-group-by 'file)
+     " [by file]")))
 
 (defun flycheck-error-list-mode-line-suppressed-indicator ()
   "Create a string for the mode line about suppressed errors.
@@ -6393,7 +6487,9 @@ Useful for post-jump actions like recentering:
 
 POS defaults to `point'."
   (interactive)
-  (when-let* ((error (tabulated-list-get-id pos)))
+  (when-let* ((error (tabulated-list-get-id pos))
+              ;; Skip file headers, whose id is not a `flycheck-error'.
+              ((flycheck-error-p error)))
     (flycheck-jump-to-error error)
     (run-hooks 'flycheck-error-list-after-jump-hook)))
 
@@ -6443,6 +6539,7 @@ POS defaults to `point'."
 POS defaults to `point'."
   (interactive)
   (when-let* ((error (tabulated-list-get-id pos))
+              ((flycheck-error-p error))
               (explainer (flycheck-checker-get (flycheck-error-checker error)
                                                'error-explainer)))
     (flycheck-error-with-buffer error
@@ -6456,8 +6553,8 @@ POS defaults to `point'.  Signal a `user-error' when the error
 has no fix."
   (interactive)
   (let* ((error (tabulated-list-get-id pos))
-         (fix (and error (flycheck-error-fix error)))
-         (buffer (and error (flycheck--error-fix-buffer error))))
+         (fix (and (flycheck-error-p error) (flycheck-error-fix error)))
+         (buffer (and fix (flycheck--error-fix-buffer error))))
     (unless fix
       (user-error "The error at point has no fix"))
     (unless buffer
@@ -6501,9 +6598,25 @@ nil, if there is no next error."
 (defun flycheck-error-list-next-error (n)
   "Go to the N'th next error in the error list."
   (interactive "P")
-  (let ((pos (flycheck-error-list-next-error-pos (point) n)))
-    (when (and pos (/= pos (point)))
-      (goto-char pos)
+  (let* ((n (or n 1))
+         (dir (if (< n 0) -1 1))
+         (remaining (abs n))
+         (pos (point))
+         (target nil))
+    ;; Step one row at a time, counting only error rows so a prefix argument
+    ;; moves by that many errors and any file headers in a grouped list are
+    ;; skipped.  Stop as soon as we can no longer advance, so navigating past
+    ;; the top or bottom cannot loop forever.
+    (while (> remaining 0)
+      (let ((next (flycheck-error-list-next-error-pos pos dir)))
+        (if (or (null next) (= next pos))
+            (setq remaining 0)
+          (setq pos next)
+          (when (flycheck-error-p (tabulated-list-get-id pos))
+            (setq target pos
+                  remaining (1- remaining))))))
+    (when (and target (/= target (point)))
+      (goto-char target)
       (save-selected-window
         ;; Keep the error list selected, so that the user can navigate errors by
         ;; repeatedly pressing n/p, without having to re-select the error list

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -168,6 +168,115 @@
                     (list message 'type 'flycheck-error-list
                           'help-echo message)))))))
 
+  (describe "Grouping by file"
+    (let ((errors (list (flycheck-error-new-at 3 1 'error "in b"
+                                               :filename "/p/b.el" :checker 'x)
+                        (flycheck-error-new-at 8 1 'warning "second in a"
+                                               :filename "/p/a.el" :checker 'x)
+                        (flycheck-error-new-at 1 1 'error "first in a"
+                                               :filename "/p/a.el" :checker 'x)))
+          source)
+
+      (before-each
+        (setq source (generate-new-buffer " grouping-source"))
+        (with-current-buffer source (setq default-directory "/p/")))
+      (after-each (kill-buffer source))
+
+      (it "lays out a header per file with its errors sorted under it"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by 'file)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (let ((entries (flycheck-error-list-entries)))
+              ;; header a.el, its two errors (lines 1 then 8), header b.el, its
+              ;; one error -- files and errors both in order.
+              (expect (mapcar (lambda (e)
+                                (if (flycheck-error-p (car e))
+                                    (flycheck-error-line (car e))
+                                  (car (aref (cadr e) 0))))
+                              entries)
+                      :to-equal '("a.el (2)" 1 8 "b.el (1)" 3))))))
+
+      (it "blanks the file cell under a header"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by 'file)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (let ((error-row (nth 1 (flycheck-error-list-entries))))
+              (expect (car (aref (cadr error-row) 0)) :to-equal "")))))
+
+      (it "toggles grouping and the sort key together"
+        (flycheck/with-error-list-buffer
+          (expect flycheck-error-list-group-by :to-be nil)
+          (flycheck-error-list-toggle-grouping)
+          (expect flycheck-error-list-group-by :to-be 'file)
+          (expect tabulated-list-sort-key :to-be nil)
+          (flycheck-error-list-toggle-grouping)
+          (expect flycheck-error-list-group-by :to-be nil)
+          (expect tabulated-list-sort-key :to-equal '("Line"))))
+
+      (it "sorts headers as equal instead of crashing on them"
+        (let ((header (list (list 'flycheck-group "a.el") (make-vector 6 "")))
+              (err (list (car errors) (make-vector 6 ""))))
+          ;; A header entry carries a list id, not a `flycheck-error', so the
+          ;; column sorters must not pass it to `flycheck-error-<' and friends.
+          (expect (flycheck-error-list-entry-< header err) :to-be nil)
+          (expect (flycheck-error-list-entry-< err header) :to-be nil)
+          (expect (flycheck-error-list-entry-level-< header err) :to-be nil)
+          (expect (flycheck-error-list-entry-level-< err header) :to-be nil)))
+
+      (describe "next-error navigation"
+        (before-each
+          (spy-on 'flycheck-error-list-goto-error))
+
+        (defun flycheck/error-list-print-grouped (source errors)
+          "Render ERRORS grouped by file and move point to the first error."
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by 'file
+                tabulated-list-sort-key nil)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (setq tabulated-list-entries (flycheck-error-list-entries)))
+          (tabulated-list-print)
+          ;; The first row is the a.el header; step onto its first error.
+          (goto-char (point-min))
+          (forward-line 1))
+
+        (it "skips a file header when moving forward"
+          (flycheck/with-error-list-buffer
+            (flycheck/error-list-print-grouped source errors)
+            ;; From line 8 in a.el the next error is line 3 in b.el, past the
+            ;; b.el header.
+            (goto-char (point-min))
+            (forward-line 2)
+            (expect (flycheck-error-line
+                     (tabulated-list-get-id)) :to-equal 8)
+            (flycheck-error-list-next-error 1)
+            (expect (flycheck-error-line
+                     (tabulated-list-get-id)) :to-equal 3)))
+
+        (it "counts errors, not headers, for a prefix argument"
+          (flycheck/with-error-list-buffer
+            (flycheck/error-list-print-grouped source errors)
+            ;; Two errors forward from line 1 lands on line 3, skipping the
+            ;; b.el header that sits between the second and third error rows.
+            (expect (flycheck-error-line
+                     (tabulated-list-get-id)) :to-equal 1)
+            (flycheck-error-list-next-error 2)
+            (expect (flycheck-error-line
+                     (tabulated-list-get-id)) :to-equal 3)))
+
+        (it "terminates at the top instead of looping forever"
+          (flycheck/with-error-list-buffer
+            (flycheck/error-list-print-grouped source errors)
+            ;; Moving back from the first error has nowhere to go; this must
+            ;; return rather than spin on the leading header.
+            (let ((start (point)))
+              (flycheck-error-list-next-error -1)
+              (expect (point) :to-equal start)))))))
+
   (describe "Filter"
     (it "kills the filter variable when resetting the filter"
       (flycheck/with-error-list-buffer


### PR DESCRIPTION
Press `t` in the error list to group errors under a header per file instead of a flat list. This is mostly useful in project scope (`P`), where a flat list across many files is hard to scan; grouped, each file's errors sit under its own header, sorted by line.

It's a fresh take on the tree idea from your `error-list-revamp` branch, built on the current tabulated-list error list rather than a rebase. File grouping only for now, with the header layout left open for nested grouping and collapsing later. Navigation and the RET/x/e commands skip the headers, and the mode line shows `[by file]`.
