### PR TITLE
Index error-list rows so highlighting doesn't scan the buffer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 ``master`` (unreleased)
 =======================
 
+- The error list no longer scans all of its rows on every cursor movement
+  to highlight the errors at point, so keeping it open next to a large
+  project-scope list is much cheaper.
 - The error list can group its errors by file: press ``t``
   (``flycheck-error-list-toggle-grouping``) to lay them out under a header
   per file instead of a flat list, which helps a lot in project scope.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6627,6 +6627,41 @@ nil, if there is no next error."
   "Error highlight overlays in the error list buffer.")
 (put 'flycheck-error-list-highlight-overlays 'permanent-local t)
 
+(defvar-local flycheck-error-list--position-cache nil
+  "Cached mapping from each listed error to its row positions.
+
+A cons (TICK . TABLE), where TICK is the `buffer-modified-tick' at
+which TABLE was built and TABLE maps each row's error (compared
+with `equal') to the list of buffer positions where it appears.
+It is rebuilt lazily whenever the error list is reprinted, so that
+highlighting the errors at point does not have to scan the whole
+buffer on every command.")
+(put 'flycheck-error-list--position-cache 'permanent-local t)
+
+(defun flycheck-error-list--positions ()
+  "Return a table mapping each listed error to its row positions.
+
+The table maps an error (compared with `equal', matching the old
+`member' lookup) to the list of positions where it is shown, so a
+single error highlighted on several rows still lights up all of
+them.  The result is cached and only rebuilt when the error list
+buffer changes, keyed on `buffer-modified-tick'.  This is safe
+because every change to the rows goes through a reprint, which
+edits the buffer text and bumps the tick, and the displayed error
+objects are replaced wholesale on each check rather than mutated
+in place."
+  (let ((tick (buffer-modified-tick)))
+    (unless (eql (car flycheck-error-list--position-cache) tick)
+      (let ((table (make-hash-table :test 'equal))
+            (pos (point-min)))
+        (while pos
+          (let ((err (tabulated-list-get-id pos)))
+            (when (flycheck-error-p err)
+              (push pos (gethash err table))))
+          (setq pos (flycheck-error-list-next-error-pos pos)))
+        (setq flycheck-error-list--position-cache (cons tick table))))
+    (cdr flycheck-error-list--position-cache)))
+
 (defun flycheck-error-list-highlight-errors (&optional preserve-pos)
   "Highlight errors in the error list.
 
@@ -6650,28 +6685,36 @@ avoid slowing down editing when the error list is hidden."
           ;; Display the new overlays first, to avoid re-display flickering
           (setq flycheck-error-list-highlight-overlays nil)
           (when current-errors
-            (let ((next-error-pos (point-min)))
-              (while next-error-pos
-                (let* ((beg next-error-pos)
-                       (end (flycheck-error-list-next-error-pos beg))
-                       (err (tabulated-list-get-id beg)))
-                  (when (member err current-errors)
-                    (setq min-point (min min-point beg)
-                          max-point (max max-point beg))
-                    (let ((ov (make-overlay beg
-                                            ;; Extend overlay to the beginning
-                                            ;; of the next line, to highlight
-                                            ;; the whole line
-                                            (or end (point-max)))))
-                      (push ov flycheck-error-list-highlight-overlays)
-                      (setf (overlay-get ov 'flycheck-error-highlight-overlay)
-                            t)
-                      (setf (overlay-get ov 'face)
-                            'flycheck-error-list-highlight)))
-                  (setq next-error-pos end)))))
+            ;; Look up only the errors at point in the row-position index,
+            ;; rather than scanning every row of the list on each command.
+            ;; Collect the row positions first and drop duplicates, so several
+            ;; `equal' errors at point (e.g. from two checkers) still yield a
+            ;; single overlay per row.
+            (let* ((positions (flycheck-error-list--positions))
+                   (rows (delete-dups
+                          (mapcan (lambda (err)
+                                    (copy-sequence (gethash err positions)))
+                                  current-errors))))
+              (dolist (beg rows)
+                (let ((end (flycheck-error-list-next-error-pos beg)))
+                  (setq min-point (min min-point beg)
+                        max-point (max max-point beg))
+                  (let ((ov (make-overlay beg
+                                          ;; Extend overlay to the beginning
+                                          ;; of the next line, to highlight
+                                          ;; the whole line
+                                          (or end (point-max)))))
+                    (push ov flycheck-error-list-highlight-overlays)
+                    (setf (overlay-get ov 'flycheck-error-highlight-overlay)
+                          t)
+                    (setf (overlay-get ov 'face)
+                          'flycheck-error-list-highlight))))))
           ;; Delete the old overlays
           (seq-do #'delete-overlay old-overlays)
-          (when (and (not preserve-pos) current-errors)
+          ;; Recenter only when we actually highlighted a row.  The errors at
+          ;; point may all be filtered out of the list, leaving min/max-point
+          ;; at their sentinels, which would send point to an unrelated row.
+          (when (and (not preserve-pos) flycheck-error-list-highlight-overlays)
             ;; Move point to the middle error
             (goto-char (+ min-point (/ (- max-point min-point) 2)))
             (beginning-of-line)

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -277,6 +277,101 @@
               (flycheck-error-list-next-error -1)
               (expect (point) :to-equal start)))))))
 
+  (describe "Row position index"
+    (defun flycheck/error-list-print (errors)
+      "Render ERRORS as a flat list in the current error list buffer."
+      (setq flycheck-error-list-group-by nil)
+      (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                 (lambda () errors)))
+        (setq tabulated-list-entries (flycheck-error-list-entries)))
+      (tabulated-list-print))
+
+    (it "maps each listed error to the row where it is shown"
+      (flycheck/with-error-list-buffer
+        (let ((errors (list (flycheck-error-new-at 10 1 'error)
+                            (flycheck-error-new-at 20 1 'warning))))
+          (flycheck/error-list-print errors)
+          (let ((index (flycheck-error-list--positions)))
+            (dolist (err errors)
+              (let ((positions (gethash err index)))
+                (expect (length positions) :to-equal 1)
+                (expect (tabulated-list-get-id (car positions))
+                        :to-be err)))))))
+
+    (it "records every row an equal error appears on"
+      (flycheck/with-error-list-buffer
+        ;; Two distinct but `equal' errors (e.g. from different checkers
+        ;; reporting the same thing) share a key and must both light up.
+        (let ((errors (list (flycheck-error-new-at 10 1 'error "dup")
+                            (flycheck-error-new-at 10 1 'error "dup"))))
+          (flycheck/error-list-print errors)
+          (let ((positions (gethash (car errors)
+                                    (flycheck-error-list--positions))))
+            (expect (length positions) :to-equal 2)))))
+
+    (it "reuses the cached table until the list is reprinted"
+      (flycheck/with-error-list-buffer
+        (let ((errors (list (flycheck-error-new-at 10 1 'error))))
+          (flycheck/error-list-print errors)
+          (let ((first (flycheck-error-list--positions)))
+            ;; No reprint, so the very same table is handed back.
+            (expect (flycheck-error-list--positions) :to-be first)
+            ;; Reprinting bumps the buffer tick and rebuilds the table.
+            (tabulated-list-print)
+            (expect (flycheck-error-list--positions) :not :to-be first))))))
+
+  (describe "Highlighting errors at point"
+    ;; `flycheck-error-list-highlight-errors' only runs when the list is
+    ;; visible and reads the errors on the source line; stub both so the
+    ;; overlay-building path can be exercised in batch.
+    (defmacro flycheck/highlighting (errors at-point &rest body)
+      "Print ERRORS, pretend AT-POINT are the source-line errors, run BODY."
+      (declare (indent 2))
+      `(flycheck/with-error-list-buffer
+         (let ((source (generate-new-buffer " hl-source")))
+           (unwind-protect
+               (progn
+                 (flycheck/error-list-print ,errors)
+                 (setq flycheck-error-list-source-buffer source)
+                 (cl-letf (((symbol-function 'get-buffer-window)
+                            (lambda (&rest _) t))
+                           ((symbol-function 'flycheck-overlay-errors-in)
+                            (lambda (&rest _) ,at-point)))
+                   ,@body))
+             (kill-buffer source)))))
+
+    (it "highlights the row of each error on the source line"
+      (let ((errors (list (flycheck-error-new-at 10 1 'error)
+                          (flycheck-error-new-at 20 1 'warning))))
+        (flycheck/highlighting errors (list (car errors))
+          (flycheck-error-list-highlight-errors 'preserve-pos)
+          (let ((overlays flycheck-error-list-highlight-overlays))
+            (expect (length overlays) :to-equal 1)
+            (expect (tabulated-list-get-id (overlay-start (car overlays)))
+                    :to-be (car errors))))))
+
+    (it "creates one highlight per row for equal errors at point"
+      ;; Two distinct but `equal' errors show as two rows and both are at
+      ;; point; each row must get exactly one overlay, not one per error.
+      (let ((errors (list (flycheck-error-new-at 10 1 'error "dup")
+                          (flycheck-error-new-at 10 1 'error "dup"))))
+        (flycheck/highlighting errors errors
+          (flycheck-error-list-highlight-errors 'preserve-pos)
+          (expect (length flycheck-error-list-highlight-overlays)
+                  :to-equal 2))))
+
+    (it "leaves point put when the errors at point are filtered out"
+      ;; Regression: with no matching row the recenter must be skipped rather
+      ;; than sending point to an unrelated row.
+      (let ((errors (list (flycheck-error-new-at 10 1 'error)))
+            (absent (flycheck-error-new-at 99 1 'warning)))
+        (flycheck/highlighting errors (list absent)
+          (goto-char (point-max))
+          (let ((start (point)))
+            (flycheck-error-list-highlight-errors nil)
+            (expect flycheck-error-list-highlight-overlays :to-be nil)
+            (expect (point) :to-equal start))))))
+
   (describe "Filter"
     (it "kills the filter variable when resetting the filter"
       (flycheck/with-error-list-buffer


### PR DESCRIPTION
The error list re-highlights the errors at point after every command. It did that by walking every row of the list, which gets expensive with a large project-scope list open next to the source.

This builds an error to row-positions table once per reprint, cached on `buffer-modified-tick`, and looks up only the errors at point. So it's constant work per cursor move instead of O(rows), with the same `equal`-based matching and multi-row highlighting as before. While rewriting the function I also fixed a latent bug where point could jump to an unrelated row when the errors on the source line are all filtered out of the list.