### PR TITLE
Group the error list by checker and level, and collapse groups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,11 @@
 - The error list no longer scans all of its rows on every cursor movement
   to highlight the errors at point, so keeping it open next to a large
   project-scope list is much cheaper.
-- The error list can group its errors by file: press ``t``
-  (``flycheck-error-list-toggle-grouping``) to lay them out under a header
-  per file instead of a flat list, which helps a lot in project scope.
+- The error list can group its errors by file (``M-2``), syntax checker
+  (``M-3``) or level (``M-4``), laying them out under a header per group
+  instead of a flat list (``M-1``), which helps a lot in project scope.
+  Press ``TAB`` on a group to collapse or expand it.  The groupings are
+  shown in a strip at the top of the error list.
 - ``python-ruff`` and ``sh-shellcheck`` now carry the fixes their tools
   suggest, applicable with the quick-fix commands.  Both switched to their
   JSON output (ruff ``--output-format=json``, shellcheck ``--format

--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -38,7 +38,11 @@ Within the error list the following key bindings are available:
 :kbd:`S`     Sort the error list by the column at point
 :kbd:`g`     Check the source buffer and update the error list
 :kbd:`P`     Toggle between buffer and whole-project scope
-:kbd:`t`     Toggle grouping the errors by file
+:kbd:`M-1`   Show a flat list, without grouping
+:kbd:`M-2`   Group the errors by file
+:kbd:`M-3`   Group the errors by checker
+:kbd:`M-4`   Group the errors by level
+:kbd:`TAB`   Collapse or expand the group at point
 :kbd:`q`     Quit the error list and hide its window
 ==========   ====
 
@@ -82,9 +86,12 @@ The project of a buffer is Emacs' project (see `project-current`) when one is
 found, and the checker's working directory otherwise.  The current scope is
 shown as ``[project]`` in the error list's mode line.
 
-Press :kbd:`t` to group the errors under a header per file instead of a flat
-list, which makes a project-wide list much easier to scan.  The mode line
-shows ``[by file]`` while grouping is on.
+Group the errors under a header per file, syntax checker or level with
+:kbd:`M-2`, :kbd:`M-3` and :kbd:`M-4`; :kbd:`M-1` switches back to a flat list.
+Grouping makes a project-wide list much easier to scan.  The available
+groupings and the active one are shown in a strip at the top of the error
+list.  Press :kbd:`TAB` (or :kbd:`RET` on a header) to collapse or expand the
+group at point.
 
 Filter the list
 ===============

--- a/flycheck.el
+++ b/flycheck.el
@@ -5886,7 +5886,11 @@ ID.")
     (define-key map (kbd "p") #'flycheck-error-list-previous-error)
     (define-key map (kbd "g") #'flycheck-error-list-check-source)
     (define-key map (kbd "P") #'flycheck-error-list-toggle-scope)
-    (define-key map (kbd "t") #'flycheck-error-list-toggle-grouping)
+    (define-key map (kbd "M-1") #'flycheck-error-list-group-by-none)
+    (define-key map (kbd "M-2") #'flycheck-error-list-group-by-file)
+    (define-key map (kbd "M-3") #'flycheck-error-list-group-by-checker)
+    (define-key map (kbd "M-4") #'flycheck-error-list-group-by-level)
+    (define-key map (kbd "TAB") #'flycheck-error-list-toggle-group-at-point)
     (define-key map (kbd "e") #'flycheck-error-list-explain-error)
     (define-key map (kbd "x") #'flycheck-error-list-apply-fix)
     (define-key map (kbd "RET") #'flycheck-error-list-goto-error)
@@ -5989,6 +5993,9 @@ ignored."
         ;; `revert-buffer' updates the mode line for us, so all we need to do is
         ;; set the corresponding mode line construct.
         mode-line-buffer-identification flycheck-error-list-mode-line)
+  ;; Advertise the grouping controls in the tab line, above the column names
+  ;; Tabulated List mode keeps in the header line.
+  (setq-local tab-line-format '(:eval (flycheck-error-list--grouping-line)))
   ;; See https://github.com/flycheck/flycheck/issues/1101
   (setq-local truncate-string-ellipsis "…")
   (tabulated-list-init-header))
@@ -6013,15 +6020,26 @@ every open buffer of the source buffer's project (see
 (defvar-local flycheck-error-list-group-by nil
   "How the error list groups its errors.
 
-Either nil, to show a flat list sorted by location, or `file', to
-group the errors under a collapsible-looking header per file --
-handy in `project' scope, where errors span many files.  Toggle it
-with \\<flycheck-error-list-mode-map>\\[flycheck-error-list-toggle-grouping].")
+Either nil, to show a flat list sorted by location, or one of the
+symbols `file', `checker' or `level', to group the errors under a
+header per file, syntax checker or error level.  Grouping helps a
+lot in `project' scope, where errors span many files.  Choose it
+with \\<flycheck-error-list-mode-map>\\[flycheck-error-list-group-by-none],
+\\[flycheck-error-list-group-by-file], \\[flycheck-error-list-group-by-checker]
+and \\[flycheck-error-list-group-by-level].")
 (put 'flycheck-error-list-group-by 'permanent-local t)
+
+(defvar-local flycheck-error-list--collapsed nil
+  "Set of collapsed group keys, or nil when nothing is collapsed.
+
+A hash table whose keys are the group keys (a file name, checker
+symbol or level symbol) of the groups whose errors are currently
+hidden.  Reset whenever the grouping changes.")
+(put 'flycheck-error-list--collapsed 'permanent-local t)
 
 (defface flycheck-error-list-group-header
   '((t :inherit flycheck-error-list-filename :weight bold))
-  "Face for the file headers in a grouped error list."
+  "Face for the group headers in a grouped error list."
   :package-version '(flycheck . "38")
   :group 'flycheck-faces)
 
@@ -6057,27 +6075,115 @@ See `flycheck-error-list-scope'."
   (interactive)
   (flycheck-error-list-with-buffer
     (setq flycheck-error-list-scope
-          (if (eq flycheck-error-list-scope 'project) 'buffer 'project))
+          (if (eq flycheck-error-list-scope 'project) 'buffer 'project)
+          ;; The groups change with the scope, so start fresh rather than
+          ;; carrying collapse state that could hide a whole file's errors.
+          flycheck-error-list--collapsed nil)
     (flycheck-error-list-refresh)
     (message "Flycheck error list now showing the %s"
              (if (eq flycheck-error-list-scope 'project)
                  "whole project" "current buffer"))))
 
-(defun flycheck-error-list-toggle-grouping ()
-  "Toggle grouping the error list by file.
+(defconst flycheck-error-list--group-dimensions '(file checker level)
+  "The error list grouping dimensions, in tab-line order.")
 
-See `flycheck-error-list-group-by'."
-  (interactive)
+(defun flycheck-error-list--set-group-by (dimension)
+  "Group the error list by DIMENSION and refresh it.
+
+DIMENSION is nil for a flat list, or one of the symbols in
+`flycheck-error-list--group-dimensions'."
   (flycheck-error-list-with-buffer
-    (setq flycheck-error-list-group-by
-          (if (eq flycheck-error-list-group-by 'file) nil 'file))
-    ;; Grouped entries are laid out in order already, so turn off column
-    ;; sorting; restore the location sort for the flat list.
-    (setq tabulated-list-sort-key
-          (unless flycheck-error-list-group-by (cons "Line" nil)))
+    (setq flycheck-error-list-group-by dimension
+          ;; Start each grouping fully expanded.
+          flycheck-error-list--collapsed nil
+          ;; Grouped entries are laid out in order already, so turn off column
+          ;; sorting; restore the location sort for the flat list.
+          tabulated-list-sort-key (unless dimension (cons "Line" nil)))
     (flycheck-error-list-refresh)
     (message "Flycheck error list %s"
-             (if flycheck-error-list-group-by "grouped by file" "flat"))))
+             (if dimension (format "grouped by %s" dimension) "flat"))))
+
+(defun flycheck-error-list-group-by-none ()
+  "Show the error list as a flat list, without grouping."
+  (interactive)
+  (flycheck-error-list--set-group-by nil))
+
+(defun flycheck-error-list-group-by-file ()
+  "Group the errors in the error list by file."
+  (interactive)
+  (flycheck-error-list--set-group-by 'file))
+
+(defun flycheck-error-list-group-by-checker ()
+  "Group the errors in the error list by syntax checker."
+  (interactive)
+  (flycheck-error-list--set-group-by 'checker))
+
+(defun flycheck-error-list-group-by-level ()
+  "Group the errors in the error list by level."
+  (interactive)
+  (flycheck-error-list--set-group-by 'level))
+
+(defun flycheck-error-list--grouping-line ()
+  "Return the tab-line string advertising the grouping controls."
+  (concat
+   " Group:"
+   (mapconcat
+    (lambda (item)
+      (let* ((dimension (car item))
+             (label (format "M-%d %s" (cdr item)
+                            (if dimension dimension "flat")))
+             (active (eq dimension flycheck-error-list-group-by)))
+        (concat "  " (if active
+                         (propertize label 'face
+                                     'flycheck-error-list-group-header)
+                       label))))
+    ;; nil (flat) is M-1, then the dimensions M-2, M-3, M-4.
+    (cons '(nil . 1)
+          (seq-map-indexed (lambda (d i) (cons d (+ i 2)))
+                           flycheck-error-list--group-dimensions))
+    "")
+   (when flycheck-error-list-group-by "   TAB collapse")))
+
+(defun flycheck-error-list-toggle-group-at-point (&optional pos)
+  "Collapse or expand the group at POS in a grouped error list.
+
+POS defaults to `point'.  Works both on a group header and on any
+error row within a group.  With nothing to toggle (a flat list, or
+point away from any group) move to the next button instead, like
+Tabulated List mode's \\`TAB'."
+  (interactive)
+  (let* ((id (tabulated-list-get-id pos))
+         (header (and (consp id) (eq (car id) 'flycheck-group)))
+         (error (flycheck-error-p id)))
+    (if (and (memq flycheck-error-list-group-by
+                   flycheck-error-list--group-dimensions)
+             (or header error))
+        ;; A genuine group key may itself be nil (errors without a file), so
+        ;; decide from HEADER/ERROR rather than from the key's value.
+        (let ((key (if header
+                       (cadr id)
+                     (funcall (flycheck-error-list--group-key-function
+                               flycheck-error-list-group-by)
+                              id))))
+          (unless flycheck-error-list--collapsed
+            (setq flycheck-error-list--collapsed (make-hash-table :test 'equal)))
+          (if (gethash key flycheck-error-list--collapsed)
+              (remhash key flycheck-error-list--collapsed)
+            (puthash key t flycheck-error-list--collapsed))
+          (flycheck-error-list-refresh)
+          (flycheck-error-list--goto-group key))
+      (forward-button 1 t nil t))))
+
+(defun flycheck-error-list--goto-group (key)
+  "Move point to the header of the group KEY, when it is present."
+  (let ((target (list 'flycheck-group key))
+        (pos (point-min))
+        (found nil))
+    (while (and pos (not found))
+      (if (equal (tabulated-list-get-id pos) target)
+          (setq found pos)
+        (setq pos (flycheck-error-list-next-error-pos pos))))
+    (when found (goto-char found))))
 
 (define-button-type 'flycheck-error-list
   'action #'flycheck-error-list-goto-error
@@ -6204,42 +6310,128 @@ read the project-wide diagnostics of that buffer's project."
         (abbreviate-file-name filename))
     (or filename "<no file>")))
 
-(defun flycheck-error-list--group-header (filename count)
-  "Return an error-list header entry for FILENAME with COUNT errors.
+(defun flycheck-error-list--group-key-function (dimension)
+  "Return the function extracting the DIMENSION group key of an error."
+  (pcase dimension
+    ('file #'flycheck-error-filename)
+    ('checker #'flycheck-error-checker)
+    ('level #'flycheck-error-level)))
 
-The entry's id is a list headed by `flycheck-group', not a
-`flycheck-error', so navigation and the fix/explain commands skip
-it."
-  (list (list 'flycheck-group filename)
+(defun flycheck-error-list--group-name (dimension key)
+  "Return the display name of the group KEY under DIMENSION."
+  (pcase dimension
+    ('file (flycheck-error-list--abbreviate-filename key))
+    ('checker (if key (symbol-name key) "without checker"))
+    ('level (if key (symbol-name key) "without level"))))
+
+(defun flycheck-error-list--sort-groups (dimension groups)
+  "Sort GROUPS, an alist of (KEY . ERRORS), for DIMENSION.
+
+Level groups are ordered from the most to the least severe; the
+others alphabetically by group name."
+  (if (eq dimension 'level)
+      (sort groups (lambda (a b)
+                     (> (flycheck-error-level-severity (car a))
+                        (flycheck-error-level-severity (car b)))))
+    ;; Decorate with the display name so it is computed (and, for files,
+    ;; abbreviated) once per group instead of on every comparison.
+    (mapcar #'cdr
+            (sort (mapcar (lambda (group)
+                            (cons (flycheck-error-list--group-name
+                                   dimension (car group))
+                                  group))
+                          groups)
+                  (lambda (a b) (string< (car a) (car b)))))))
+
+(defun flycheck-error-list--group-error-< (a b)
+  "Order errors A and B within a group by file, then by location.
+
+The file tiebreak keeps a file's errors contiguous when a group
+spans several files, as it does when grouping by checker or level."
+  (let ((file-a (or (flycheck-error-filename a) ""))
+        (file-b (or (flycheck-error-filename b) "")))
+    (if (string= file-a file-b)
+        (flycheck-error-< a b)
+      (string< file-a file-b))))
+
+(defun flycheck-error-list--group-collapsed-p (key)
+  "Return non-nil when the group KEY is currently collapsed."
+  (and flycheck-error-list--collapsed
+       (gethash key flycheck-error-list--collapsed)))
+
+(defun flycheck-error-list--prune-collapsed (errors)
+  "Drop collapse state for groups absent from ERRORS.
+
+ERRORS is the full, unfiltered error set, so a filter that merely
+hides a group's errors keeps its collapse choice.  Pruning a group
+that is genuinely gone (its errors were all fixed) stops it from
+reappearing collapsed, and hiding a new error, when it comes back."
+  (when flycheck-error-list--collapsed
+    (let ((key-fn (flycheck-error-list--group-key-function
+                   flycheck-error-list-group-by))
+          (live (make-hash-table :test 'equal)))
+      (dolist (err errors)
+        (puthash (funcall key-fn err) t live))
+      (maphash (lambda (key _)
+                 (unless (gethash key live)
+                   (remhash key flycheck-error-list--collapsed)))
+               flycheck-error-list--collapsed))))
+
+(defun flycheck-error-list--group-header (dimension key count collapsed)
+  "Return a header entry for the group KEY under DIMENSION.
+
+COUNT is the number of errors in the group and COLLAPSED tells
+whether the group is currently collapsed.  The entry's id is a
+list headed by `flycheck-group', not a `flycheck-error', so
+navigation and the fix/explain commands skip it."
+  (list (list 'flycheck-group key)
         (vector (flycheck-error-list-make-cell
-                 (format "%s (%d)"
-                         (flycheck-error-list--abbreviate-filename filename)
+                 (format "%s %s (%d)"
+                         (if collapsed "▸" "▾")
+                         (flycheck-error-list--group-name dimension key)
                          count)
                  'flycheck-error-list-group-header)
                 "" "" "" "" "")))
 
 (defun flycheck-error-list--grouped-entries (errors)
-  "Return grouped tabulated-list entries for ERRORS, one section per file."
-  (let ((groups (sort (seq-group-by #'flycheck-error-filename errors)
-                      (lambda (a b) (string< (or (car a) "") (or (car b) ""))))))
+  "Return grouped tabulated-list entries for ERRORS.
+
+The errors are grouped by `flycheck-error-list-group-by'; a
+collapsed group contributes only its header."
+  (let* ((dimension flycheck-error-list-group-by)
+         (key-fn (flycheck-error-list--group-key-function dimension))
+         (groups (flycheck-error-list--sort-groups
+                  dimension (seq-group-by key-fn errors)))
+         ;; The file name is redundant under each file header, but relevant
+         ;; when grouping by checker or level.
+         (omit-file (eq dimension 'file)))
     (seq-mapcat
      (lambda (group)
-       (let ((sorted (sort (cdr group) #'flycheck-error-<)))
-         (cons (flycheck-error-list--group-header (car group) (length sorted))
-               (mapcar (lambda (err) (flycheck-error-list-make-entry err 'omit-file))
-                       sorted))))
+       (let* ((key (car group))
+              (sorted (sort (cdr group) #'flycheck-error-list--group-error-<))
+              (collapsed (flycheck-error-list--group-collapsed-p key)))
+         (cons (flycheck-error-list--group-header
+                dimension key (length sorted) collapsed)
+               (unless collapsed
+                 (mapcar (lambda (err)
+                           (flycheck-error-list-make-entry err omit-file))
+                         sorted)))))
      groups)))
 
 (defun flycheck-error-list-entries ()
   "Create the entries for the error list.
 
-When `flycheck-error-list-group-by' is `file' the errors are laid
-out under a header per file; otherwise a flat list is returned and
+When `flycheck-error-list-group-by' is non-nil the errors are laid
+out under a header per group; otherwise a flat list is returned and
 Tabulated List mode sorts it."
   (when-let* ((errors (flycheck-error-list-current-errors))
               (filtered (flycheck-error-list-apply-filter errors)))
-    (if (eq flycheck-error-list-group-by 'file)
-        (flycheck-error-list--grouped-entries filtered)
+    (if (memq flycheck-error-list-group-by flycheck-error-list--group-dimensions)
+        (progn
+          ;; Prune against the unfiltered errors, so a filter that hides a
+          ;; group does not discard the collapse state the user set.
+          (flycheck-error-list--prune-collapsed errors)
+          (flycheck-error-list--grouped-entries filtered))
       (mapcar #'flycheck-error-list-make-entry filtered))))
 
 (defun flycheck-error-list-entry-< (entry1 entry2)
@@ -6354,11 +6546,9 @@ list."
 
 (defun flycheck-error-list-mode-line-scope-indicator ()
   "Create a string representing the current error list scope."
-  (concat
-   (when (eq flycheck-error-list-scope 'project)
-     " [project]")
-   (when (eq flycheck-error-list-group-by 'file)
-     " [by file]")))
+  ;; The grouping is advertised in the header line, not here.
+  (when (eq flycheck-error-list-scope 'project)
+    " [project]"))
 
 (defun flycheck-error-list-mode-line-suppressed-indicator ()
   "Create a string for the mode line about suppressed errors.
@@ -6485,13 +6675,17 @@ Useful for post-jump actions like recentering:
 (defun flycheck-error-list-goto-error (&optional pos)
   "Go to the location of the error at POS in the error list.
 
-POS defaults to `point'."
+On a group header collapse or expand the group instead.  POS
+defaults to `point'."
   (interactive)
-  (when-let* ((error (tabulated-list-get-id pos))
-              ;; Skip file headers, whose id is not a `flycheck-error'.
-              ((flycheck-error-p error)))
-    (flycheck-jump-to-error error)
-    (run-hooks 'flycheck-error-list-after-jump-hook)))
+  (let ((error (tabulated-list-get-id pos)))
+    (cond
+     ((flycheck-error-p error)
+      (flycheck-jump-to-error error)
+      (run-hooks 'flycheck-error-list-after-jump-hook))
+     ;; A group header, whose id is not a `flycheck-error'.
+     ((and (consp error) (eq (car error) 'flycheck-group))
+      (flycheck-error-list-toggle-group-at-point pos)))))
 
 (defun flycheck-jump-to-error (error)
   "Go to the location of ERROR."

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -196,7 +196,7 @@
                                     (flycheck-error-line (car e))
                                   (car (aref (cadr e) 0))))
                               entries)
-                      :to-equal '("a.el (2)" 1 8 "b.el (1)" 3))))))
+                      :to-equal '("▾ a.el (2)" 1 8 "▾ b.el (1)" 3))))))
 
       (it "blanks the file cell under a header"
         (flycheck/with-error-list-buffer
@@ -207,13 +207,16 @@
             (let ((error-row (nth 1 (flycheck-error-list-entries))))
               (expect (car (aref (cadr error-row) 0)) :to-equal "")))))
 
-      (it "toggles grouping and the sort key together"
+      (it "sets the grouping and the sort key together"
         (flycheck/with-error-list-buffer
           (expect flycheck-error-list-group-by :to-be nil)
-          (flycheck-error-list-toggle-grouping)
+          (flycheck-error-list-group-by-file)
           (expect flycheck-error-list-group-by :to-be 'file)
           (expect tabulated-list-sort-key :to-be nil)
-          (flycheck-error-list-toggle-grouping)
+          (flycheck-error-list-group-by-checker)
+          (expect flycheck-error-list-group-by :to-be 'checker)
+          (expect tabulated-list-sort-key :to-be nil)
+          (flycheck-error-list-group-by-none)
           (expect flycheck-error-list-group-by :to-be nil)
           (expect tabulated-list-sort-key :to-equal '("Line"))))
 
@@ -276,6 +279,193 @@
             (let ((start (point)))
               (flycheck-error-list-next-error -1)
               (expect (point) :to-equal start)))))))
+
+  (describe "Grouping by checker and level"
+    (defun flycheck/group-headers ()
+      "Return the header labels of the grouped list, in order."
+      (delq nil
+            (mapcar (lambda (e)
+                      (unless (flycheck-error-p (car e))
+                        (car (aref (cadr e) 0))))
+                    (flycheck-error-list-entries))))
+
+    (it "groups by checker, headers sorted by name"
+      (flycheck/with-error-list-buffer
+        (let ((errors (list (flycheck-error-new-at 1 1 'error nil :checker 'zebra)
+                            (flycheck-error-new-at 2 1 'error nil :checker 'alpha))))
+          (setq flycheck-error-list-group-by 'checker)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (expect (flycheck/group-headers)
+                    :to-equal '("▾ alpha (1)" "▾ zebra (1)"))))))
+
+    (it "groups by level, most severe group first"
+      (flycheck/with-error-list-buffer
+        (let ((errors (list (flycheck-error-new-at 1 1 'warning)
+                            (flycheck-error-new-at 2 1 'error)
+                            (flycheck-error-new-at 3 1 'error))))
+          (setq flycheck-error-list-group-by 'level)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (expect (flycheck/group-headers)
+                    :to-equal '("▾ error (2)" "▾ warning (1)"))))))
+
+    (it "keeps each file's errors contiguous within a group"
+      (flycheck/with-error-list-buffer
+        (let ((errors (list (flycheck-error-new-at
+                             5 1 'error nil :filename "/p/a.el" :checker 'x)
+                            (flycheck-error-new-at
+                             3 1 'error nil :filename "/p/b.el" :checker 'x)
+                            (flycheck-error-new-at
+                             10 1 'error nil :filename "/p/a.el" :checker 'x))))
+          (setq flycheck-error-list-group-by 'checker)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            ;; Sorted by file then line, so a.el's rows stay together instead
+            ;; of interleaving by line as a bare location sort would.
+            (let ((files (delq nil
+                               (mapcar (lambda (e)
+                                         (and (flycheck-error-p (car e))
+                                              (flycheck-error-filename (car e))))
+                                       (flycheck-error-list-entries)))))
+              (expect files :to-equal '("/p/a.el" "/p/a.el" "/p/b.el")))))))
+
+    (it "falls back to a flat list for an unknown grouping"
+      (flycheck/with-error-list-buffer
+        (setq flycheck-error-list-group-by 'bogus)
+        (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                   (lambda () (list (flycheck-error-new-at 1 1 'error)))))
+          ;; Must not call seq-group-by with a nil key function.
+          (let ((entries (flycheck-error-list-entries)))
+            (expect (length entries) :to-equal 1)
+            (expect (flycheck-error-p (car (car entries))) :to-be-truthy))))))
+
+  (describe "Collapsing groups"
+    (let ((errors (list (flycheck-error-new-at 1 1 'error nil
+                                               :filename "/p/a.el" :checker 'x)
+                        (flycheck-error-new-at 3 1 'error nil
+                                               :filename "/p/b.el" :checker 'x)))
+          source)
+      (before-each
+        (setq source (generate-new-buffer " collapse-source"))
+        (with-current-buffer source (setq default-directory "/p/")))
+      (after-each (kill-buffer source))
+
+      (it "drops the errors of a collapsed group but keeps its header"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by 'file
+                flycheck-error-list--collapsed (make-hash-table :test 'equal))
+          (puthash "/p/a.el" t flycheck-error-list--collapsed)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (let ((entries (flycheck-error-list-entries)))
+              ;; a.el is collapsed: just its header, marked with the collapsed
+              ;; triangle; b.el stays expanded with its error row.
+              (expect (mapcar (lambda (e)
+                                (if (flycheck-error-p (car e))
+                                    (flycheck-error-line (car e))
+                                  (car (aref (cadr e) 0))))
+                              entries)
+                      :to-equal '("▸ a.el (1)" "▾ b.el (1)" 3))))))
+
+      (it "toggles the group under point on a header"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by 'file)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (setq tabulated-list-entries (flycheck-error-list-entries))
+            (tabulated-list-print)
+            (goto-char (point-min))       ; the a.el header
+            (flycheck-error-list-toggle-group-at-point)
+            (expect (gethash "/p/a.el" flycheck-error-list--collapsed) :to-be-truthy)
+            (flycheck-error-list-toggle-group-at-point)
+            (expect (gethash "/p/a.el" flycheck-error-list--collapsed) :to-be nil))))
+
+      (it "toggles the parent group from an error row"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by 'file)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (setq tabulated-list-entries (flycheck-error-list-entries))
+            (tabulated-list-print)
+            (goto-char (point-min))
+            (forward-line 1)              ; the a.el error row
+            (expect (flycheck-error-p (tabulated-list-get-id)) :to-be-truthy)
+            (flycheck-error-list-toggle-group-at-point)
+            (expect (gethash "/p/a.el" flycheck-error-list--collapsed)
+                    :to-be-truthy))))
+
+      (it "expands a group that clears and later reappears"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by 'file
+                flycheck-error-list--collapsed (make-hash-table :test 'equal))
+          (puthash "/p/a.el" t flycheck-error-list--collapsed)
+          ;; a.el has no errors this round, so its stale collapse key must be
+          ;; pruned; otherwise a new a.el error would come back hidden.
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () (list (cadr errors)))))
+            (flycheck-error-list-entries)
+            (expect (gethash "/p/a.el" flycheck-error-list--collapsed)
+                    :to-be nil))))
+
+      (it "keeps collapse state when a filter hides the group"
+        (flycheck/with-error-list-buffer
+          (let ((errs (list (flycheck-error-new-at 1 1 'error "aaa"
+                                                   :filename "/p/a.el" :checker 'x)
+                            (flycheck-error-new-at 3 1 'error "bbb"
+                                                   :filename "/p/b.el" :checker 'x))))
+            (setq flycheck-error-list-source-buffer source
+                  flycheck-error-list-group-by 'file
+                  flycheck-error-list--collapsed (make-hash-table :test 'equal)
+                  ;; A message filter that matches only b.el's error.
+                  flycheck-error-list--message-filter "bbb")
+            (puthash "/p/a.el" t flycheck-error-list--collapsed)
+            (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                       (lambda () errs)))
+              (flycheck-error-list-entries)
+              ;; a.el is filtered out of this render but still exists, so its
+              ;; collapse must survive to when the filter is relaxed.
+              (expect (gethash "/p/a.el" flycheck-error-list--collapsed)
+                      :to-be-truthy)))))
+
+      (it "resets collapse state when the scope changes"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list--collapsed (make-hash-table :test 'equal))
+          (puthash "/p/a.el" t flycheck-error-list--collapsed)
+          (flycheck-error-list-toggle-scope)
+          (expect flycheck-error-list--collapsed :to-be nil)))
+
+      (it "moves to a button instead of toggling in a flat list"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by nil)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (setq tabulated-list-entries (flycheck-error-list-entries))
+            (tabulated-list-print)
+            (goto-char (point-min))
+            ;; TAB must not be dead in a flat list: it should not create
+            ;; collapse state and should leave point on an error row.
+            (flycheck-error-list-toggle-group-at-point)
+            (expect flycheck-error-list--collapsed :to-be nil)
+            (expect (flycheck-error-p (tabulated-list-get-id))
+                    :to-be-truthy))))))
+
+  (describe "Grouping controls line"
+    (it "advertises every dimension and marks the active one"
+      (flycheck/with-error-list-buffer
+        (setq flycheck-error-list-group-by 'checker)
+        (let ((line (flycheck-error-list--grouping-line)))
+          (dolist (fragment '("M-1 flat" "M-2 file" "M-3 checker" "M-4 level"))
+            (expect line :to-match (regexp-quote fragment)))
+          ;; The active dimension carries the header face.
+          (let ((start (string-match "M-3 checker" line)))
+            (expect (get-text-property start 'face line)
+                    :to-be 'flycheck-error-list-group-header))))))
 
   (describe "Row position index"
     (defun flycheck/error-list-print (errors)


### PR DESCRIPTION
The error list could only group by file. This adds grouping by checker and level too, and lets groups collapse.

`M-1`..`M-4` pick the grouping (flat, file, checker, level), shown in a strip at the top of the list so the keys are discoverable, and `TAB` (or `RET` on a header) collapses or expands the group at point. This replaces the `t` toggle from the by-file grouping, which only landed on unreleased master. Level groups sort most-severe first, and grouping by checker or level keeps the file column since it is no longer redundant.