### PR TITLE
Support nesting the error-list grouping dimensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,10 @@
 - The error list can group its errors by file (``M-2``), syntax checker
   (``M-3``) or level (``M-4``), laying them out under a header per group
   instead of a flat list (``M-1``), which helps a lot in project scope.
-  Press ``TAB`` on a group to collapse or expand it.  The groupings are
-  shown in a strip at the top of the error list.
+  The keys toggle each dimension and combine, so ``M-2`` then ``M-3``
+  nests the errors by checker within each file.  Press ``TAB`` on a group
+  to collapse or expand it.  The groupings are shown in a strip at the top
+  of the error list.
 - ``python-ruff`` and ``sh-shellcheck`` now carry the fixes their tools
   suggest, applicable with the quick-fix commands.  Both switched to their
   JSON output (ruff ``--output-format=json``, shellcheck ``--format

--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -39,9 +39,9 @@ Within the error list the following key bindings are available:
 :kbd:`g`     Check the source buffer and update the error list
 :kbd:`P`     Toggle between buffer and whole-project scope
 :kbd:`M-1`   Show a flat list, without grouping
-:kbd:`M-2`   Group the errors by file
-:kbd:`M-3`   Group the errors by checker
-:kbd:`M-4`   Group the errors by level
+:kbd:`M-2`   Toggle grouping the errors by file
+:kbd:`M-3`   Toggle grouping the errors by checker
+:kbd:`M-4`   Toggle grouping the errors by level
 :kbd:`TAB`   Collapse or expand the group at point
 :kbd:`q`     Quit the error list and hide its window
 ==========   ====
@@ -88,10 +88,12 @@ shown as ``[project]`` in the error list's mode line.
 
 Group the errors under a header per file, syntax checker or level with
 :kbd:`M-2`, :kbd:`M-3` and :kbd:`M-4`; :kbd:`M-1` switches back to a flat list.
-Grouping makes a project-wide list much easier to scan.  The available
-groupings and the active one are shown in a strip at the top of the error
-list.  Press :kbd:`TAB` (or :kbd:`RET` on a header) to collapse or expand the
-group at point.
+Grouping makes a project-wide list much easier to scan.  The keys toggle each
+dimension, so you can combine them: with both :kbd:`M-2` and :kbd:`M-3` the
+errors nest by checker within each file.  Combined dimensions always nest in
+the file, checker, level order.  The available groupings and the active ones
+are shown in a strip at the top of the error list.  Press :kbd:`TAB` (or
+:kbd:`RET` on a header) to collapse or expand the group at point.
 
 Filter the list
 ===============

--- a/flycheck.el
+++ b/flycheck.el
@@ -6020,21 +6020,23 @@ every open buffer of the source buffer's project (see
 (defvar-local flycheck-error-list-group-by nil
   "How the error list groups its errors.
 
-Either nil, to show a flat list sorted by location, or one of the
-symbols `file', `checker' or `level', to group the errors under a
-header per file, syntax checker or error level.  Grouping helps a
-lot in `project' scope, where errors span many files.  Choose it
-with \\<flycheck-error-list-mode-map>\\[flycheck-error-list-group-by-none],
-\\[flycheck-error-list-group-by-file], \\[flycheck-error-list-group-by-checker]
-and \\[flycheck-error-list-group-by-level].")
+Either nil, to show a flat list sorted by location, or a list of
+the symbols `file', `checker' and `level' to group the errors
+under a header per dimension.  With more than one dimension the
+groups nest, e.g. (file checker) groups by file and then by
+checker within each file.  Grouping helps a lot in `project'
+scope, where errors span many files.  Toggle the dimensions with
+\\<flycheck-error-list-mode-map>\\[flycheck-error-list-group-by-file],
+\\[flycheck-error-list-group-by-checker] and \\[flycheck-error-list-group-by-level];
+\\[flycheck-error-list-group-by-none] shows a flat list.")
 (put 'flycheck-error-list-group-by 'permanent-local t)
 
 (defvar-local flycheck-error-list--collapsed nil
-  "Set of collapsed group keys, or nil when nothing is collapsed.
+  "Set of collapsed group paths, or nil when nothing is collapsed.
 
-A hash table whose keys are the group keys (a file name, checker
-symbol or level symbol) of the groups whose errors are currently
-hidden.  Reset whenever the grouping changes.")
+A hash table whose keys are the group paths (a list of group keys
+from the outermost dimension inward) of the groups whose errors are
+currently hidden.  Reset whenever the grouping changes.")
 (put 'flycheck-error-list--collapsed 'permanent-local t)
 
 (defface flycheck-error-list-group-header
@@ -6087,21 +6089,49 @@ See `flycheck-error-list-scope'."
 (defconst flycheck-error-list--group-dimensions '(file checker level)
   "The error list grouping dimensions, in tab-line order.")
 
-(defun flycheck-error-list--set-group-by (dimension)
-  "Group the error list by DIMENSION and refresh it.
+(defun flycheck-error-list--grouping-dimensions ()
+  "Return the active grouping dimensions, in canonical order.
 
-DIMENSION is nil for a flat list, or one of the symbols in
-`flycheck-error-list--group-dimensions'."
+Normalize `flycheck-error-list-group-by' to a list and drop
+anything that is not a known dimension, so a flat list yields nil."
+  (let ((group-by (if (listp flycheck-error-list-group-by)
+                      flycheck-error-list-group-by
+                    (list flycheck-error-list-group-by))))
+    (seq-filter (lambda (d) (memq d group-by))
+                flycheck-error-list--group-dimensions)))
+
+(defun flycheck-error-list--set-group-by (dimensions)
+  "Group the error list by DIMENSIONS and refresh it.
+
+DIMENSIONS is nil for a flat list, or a list of the symbols in
+`flycheck-error-list--group-dimensions'; several dimensions nest."
   (flycheck-error-list-with-buffer
-    (setq flycheck-error-list-group-by dimension
+    (setq flycheck-error-list-group-by dimensions
           ;; Start each grouping fully expanded.
           flycheck-error-list--collapsed nil
           ;; Grouped entries are laid out in order already, so turn off column
           ;; sorting; restore the location sort for the flat list.
-          tabulated-list-sort-key (unless dimension (cons "Line" nil)))
+          tabulated-list-sort-key (unless dimensions (cons "Line" nil)))
     (flycheck-error-list-refresh)
     (message "Flycheck error list %s"
-             (if dimension (format "grouped by %s" dimension) "flat"))))
+             (if dimensions
+                 (concat "grouped by "
+                         (mapconcat #'symbol-name dimensions " > "))
+               "flat"))))
+
+(defun flycheck-error-list--toggle-group-by (dimension)
+  "Toggle grouping the error list by DIMENSION.
+
+Add or remove DIMENSION from the grouping, keeping the remaining
+dimensions in the canonical `flycheck-error-list--group-dimensions'
+order, so they always nest file then checker then level."
+  (let* ((active (flycheck-error-list--grouping-dimensions))
+         (next (if (memq dimension active)
+                   (remq dimension active)
+                 (cons dimension active))))
+    (flycheck-error-list--set-group-by
+     (seq-filter (lambda (d) (memq d next))
+                 flycheck-error-list--group-dimensions))))
 
 (defun flycheck-error-list-group-by-none ()
   "Show the error list as a flat list, without grouping."
@@ -6109,74 +6139,81 @@ DIMENSION is nil for a flat list, or one of the symbols in
   (flycheck-error-list--set-group-by nil))
 
 (defun flycheck-error-list-group-by-file ()
-  "Group the errors in the error list by file."
+  "Toggle grouping the errors in the error list by file."
   (interactive)
-  (flycheck-error-list--set-group-by 'file))
+  (flycheck-error-list--toggle-group-by 'file))
 
 (defun flycheck-error-list-group-by-checker ()
-  "Group the errors in the error list by syntax checker."
+  "Toggle grouping the errors in the error list by syntax checker."
   (interactive)
-  (flycheck-error-list--set-group-by 'checker))
+  (flycheck-error-list--toggle-group-by 'checker))
 
 (defun flycheck-error-list-group-by-level ()
-  "Group the errors in the error list by level."
+  "Toggle grouping the errors in the error list by level."
   (interactive)
-  (flycheck-error-list--set-group-by 'level))
+  (flycheck-error-list--toggle-group-by 'level))
 
 (defun flycheck-error-list--grouping-line ()
   "Return the tab-line string advertising the grouping controls."
-  (concat
-   " Group:"
-   (mapconcat
-    (lambda (item)
-      (let* ((dimension (car item))
-             (label (format "M-%d %s" (cdr item)
-                            (if dimension dimension "flat")))
-             (active (eq dimension flycheck-error-list-group-by)))
-        (concat "  " (if active
-                         (propertize label 'face
-                                     'flycheck-error-list-group-header)
-                       label))))
-    ;; nil (flat) is M-1, then the dimensions M-2, M-3, M-4.
-    (cons '(nil . 1)
-          (seq-map-indexed (lambda (d i) (cons d (+ i 2)))
-                           flycheck-error-list--group-dimensions))
-    "")
-   (when flycheck-error-list-group-by "   TAB collapse")))
+  (let ((active (flycheck-error-list--grouping-dimensions)))
+    (concat
+     " Group:"
+     (mapconcat
+      (lambda (item)
+        (let* ((dimension (car item))
+               (label (format "M-%d %s" (cdr item)
+                              (if dimension dimension "flat")))
+               ;; Highlight every active dimension, or `flat' when none.
+               (on (if dimension (memq dimension active) (null active))))
+          (concat "  " (if on
+                           (propertize label 'face
+                                       'flycheck-error-list-group-header)
+                         label))))
+      ;; nil (flat) is M-1, then the dimensions M-2, M-3, M-4.
+      (cons '(nil . 1)
+            (seq-map-indexed (lambda (d i) (cons d (+ i 2)))
+                             flycheck-error-list--group-dimensions))
+      "")
+     (when active "   TAB collapse"))))
+
+(defun flycheck-error-list--error-group-path (error)
+  "Return the group path of ERROR under the active grouping.
+
+The path is the list of group keys from the outermost dimension
+inward, identifying the innermost group ERROR belongs to."
+  (mapcar (lambda (dimension)
+            (funcall (flycheck-error-list--group-key-function dimension) error))
+          (flycheck-error-list--grouping-dimensions)))
 
 (defun flycheck-error-list-toggle-group-at-point (&optional pos)
   "Collapse or expand the group at POS in a grouped error list.
 
 POS defaults to `point'.  Works both on a group header and on any
-error row within a group.  With nothing to toggle (a flat list, or
-point away from any group) move to the next button instead, like
-Tabulated List mode's \\`TAB'."
+error row, whose innermost group it toggles.  With nothing to
+toggle (a flat list, or point away from any group) move to the next
+button instead, like Tabulated List mode's \\`TAB'."
   (interactive)
   (let* ((id (tabulated-list-get-id pos))
          (header (and (consp id) (eq (car id) 'flycheck-group)))
          (error (flycheck-error-p id)))
-    (if (and (memq flycheck-error-list-group-by
-                   flycheck-error-list--group-dimensions)
-             (or header error))
-        ;; A genuine group key may itself be nil (errors without a file), so
-        ;; decide from HEADER/ERROR rather than from the key's value.
-        (let ((key (if header
-                       (cadr id)
-                     (funcall (flycheck-error-list--group-key-function
-                               flycheck-error-list-group-by)
-                              id))))
+    (if (and (flycheck-error-list--grouping-dimensions) (or header error))
+        ;; A group is identified by its path; for an error row use the path of
+        ;; its innermost group.
+        (let ((path (if header
+                        (cadr id)
+                      (flycheck-error-list--error-group-path id))))
           (unless flycheck-error-list--collapsed
             (setq flycheck-error-list--collapsed (make-hash-table :test 'equal)))
-          (if (gethash key flycheck-error-list--collapsed)
-              (remhash key flycheck-error-list--collapsed)
-            (puthash key t flycheck-error-list--collapsed))
+          (if (gethash path flycheck-error-list--collapsed)
+              (remhash path flycheck-error-list--collapsed)
+            (puthash path t flycheck-error-list--collapsed))
           (flycheck-error-list-refresh)
-          (flycheck-error-list--goto-group key))
+          (flycheck-error-list--goto-group path))
       (forward-button 1 t nil t))))
 
-(defun flycheck-error-list--goto-group (key)
-  "Move point to the header of the group KEY, when it is present."
-  (let ((target (list 'flycheck-group key))
+(defun flycheck-error-list--goto-group (path)
+  "Move point to the header of the group PATH, when it is present."
+  (let ((target (list 'flycheck-group path))
         (pos (point-min))
         (found nil))
     (while (and pos (not found))
@@ -6365,58 +6402,69 @@ spans several files, as it does when grouping by checker or level."
 ERRORS is the full, unfiltered error set, so a filter that merely
 hides a group's errors keeps its collapse choice.  Pruning a group
 that is genuinely gone (its errors were all fixed) stops it from
-reappearing collapsed, and hiding a new error, when it comes back."
+reappearing collapsed, and hiding a new error, when it comes back.
+
+Every prefix of an error's group path is a live group, so nested
+headers above a still-present error keep their collapse too."
   (when flycheck-error-list--collapsed
-    (let ((key-fn (flycheck-error-list--group-key-function
-                   flycheck-error-list-group-by))
+    ;; Resolve the dimensions and their key functions once, not per error.
+    (let ((key-fns (mapcar #'flycheck-error-list--group-key-function
+                           (flycheck-error-list--grouping-dimensions)))
           (live (make-hash-table :test 'equal)))
       (dolist (err errors)
-        (puthash (funcall key-fn err) t live))
-      (maphash (lambda (key _)
-                 (unless (gethash key live)
-                   (remhash key flycheck-error-list--collapsed)))
+        (let ((prefix nil))
+          (dolist (key-fn key-fns)
+            (setq prefix (append prefix (list (funcall key-fn err))))
+            (puthash prefix t live))))
+      (maphash (lambda (path _)
+                 (unless (gethash path live)
+                   (remhash path flycheck-error-list--collapsed)))
                flycheck-error-list--collapsed))))
 
-(defun flycheck-error-list--group-header (dimension key count collapsed)
-  "Return a header entry for the group KEY under DIMENSION.
+(defun flycheck-error-list--group-header (path dimension key count collapsed depth)
+  "Return a header entry for the group at PATH.
 
-COUNT is the number of errors in the group and COLLAPSED tells
-whether the group is currently collapsed.  The entry's id is a
+DIMENSION and KEY name the group, COUNT is the number of errors it
+holds, COLLAPSED tells whether it is collapsed and DEPTH is its
+nesting level, used to indent nested headers.  The entry's id is a
 list headed by `flycheck-group', not a `flycheck-error', so
 navigation and the fix/explain commands skip it."
-  (list (list 'flycheck-group key)
+  (list (list 'flycheck-group path)
         (vector (flycheck-error-list-make-cell
-                 (format "%s %s (%d)"
+                 (format "%s%s %s (%d)"
+                         (make-string (* 2 depth) ?\s)
                          (if collapsed "▸" "▾")
                          (flycheck-error-list--group-name dimension key)
                          count)
                  'flycheck-error-list-group-header)
                 "" "" "" "" "")))
 
-(defun flycheck-error-list--grouped-entries (errors)
-  "Return grouped tabulated-list entries for ERRORS.
+(defun flycheck-error-list--grouped-entries (errors dimensions path depth omit-file)
+  "Return grouped entries for ERRORS under DIMENSIONS.
 
-The errors are grouped by `flycheck-error-list-group-by'; a
-collapsed group contributes only its header."
-  (let* ((dimension flycheck-error-list-group-by)
-         (key-fn (flycheck-error-list--group-key-function dimension))
-         (groups (flycheck-error-list--sort-groups
-                  dimension (seq-group-by key-fn errors)))
-         ;; The file name is redundant under each file header, but relevant
-         ;; when grouping by checker or level.
-         (omit-file (eq dimension 'file)))
-    (seq-mapcat
-     (lambda (group)
-       (let* ((key (car group))
-              (sorted (sort (cdr group) #'flycheck-error-list--group-error-<))
-              (collapsed (flycheck-error-list--group-collapsed-p key)))
-         (cons (flycheck-error-list--group-header
-                dimension key (length sorted) collapsed)
-               (unless collapsed
-                 (mapcar (lambda (err)
-                           (flycheck-error-list-make-entry err omit-file))
-                         sorted)))))
-     groups)))
+PATH is the group path leading to ERRORS, DEPTH its nesting level
+and OMIT-FILE whether to blank the File cell of the leaf rows.  The
+grouping recurses through DIMENSIONS; a collapsed group contributes
+only its header."
+  (if (null dimensions)
+      (mapcar (lambda (err) (flycheck-error-list-make-entry err omit-file))
+              (sort errors #'flycheck-error-list--group-error-<))
+    (let* ((dimension (car dimensions))
+           (key-fn (flycheck-error-list--group-key-function dimension))
+           (groups (flycheck-error-list--sort-groups
+                    dimension (seq-group-by key-fn errors))))
+      (seq-mapcat
+       (lambda (group)
+         (let* ((key (car group))
+                (group-path (append path (list key)))
+                (collapsed (flycheck-error-list--group-collapsed-p group-path)))
+           (cons (flycheck-error-list--group-header
+                  group-path dimension key (length (cdr group)) collapsed depth)
+                 (unless collapsed
+                   (flycheck-error-list--grouped-entries
+                    (cdr group) (cdr dimensions) group-path (1+ depth)
+                    omit-file)))))
+       groups))))
 
 (defun flycheck-error-list-entries ()
   "Create the entries for the error list.
@@ -6426,12 +6474,15 @@ out under a header per group; otherwise a flat list is returned and
 Tabulated List mode sorts it."
   (when-let* ((errors (flycheck-error-list-current-errors))
               (filtered (flycheck-error-list-apply-filter errors)))
-    (if (memq flycheck-error-list-group-by flycheck-error-list--group-dimensions)
+    (if-let* ((dimensions (flycheck-error-list--grouping-dimensions)))
         (progn
           ;; Prune against the unfiltered errors, so a filter that hides a
           ;; group does not discard the collapse state the user set.
           (flycheck-error-list--prune-collapsed errors)
-          (flycheck-error-list--grouped-entries filtered))
+          ;; The file name is redundant under a file header, but relevant when
+          ;; grouping only by checker or level.
+          (flycheck-error-list--grouped-entries
+           filtered dimensions nil 0 (memq 'file dimensions)))
       (mapcar #'flycheck-error-list-make-entry filtered))))
 
 (defun flycheck-error-list-entry-< (entry1 entry2)

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -207,15 +207,18 @@
             (let ((error-row (nth 1 (flycheck-error-list-entries))))
               (expect (car (aref (cadr error-row) 0)) :to-equal "")))))
 
-      (it "sets the grouping and the sort key together"
+      (it "toggles dimensions and manages the sort key"
         (flycheck/with-error-list-buffer
           (expect flycheck-error-list-group-by :to-be nil)
           (flycheck-error-list-group-by-file)
-          (expect flycheck-error-list-group-by :to-be 'file)
+          (expect flycheck-error-list-group-by :to-equal '(file))
           (expect tabulated-list-sort-key :to-be nil)
+          ;; Adding a dimension nests it in canonical order.
           (flycheck-error-list-group-by-checker)
-          (expect flycheck-error-list-group-by :to-be 'checker)
-          (expect tabulated-list-sort-key :to-be nil)
+          (expect flycheck-error-list-group-by :to-equal '(file checker))
+          ;; Toggling a dimension off leaves the rest.
+          (flycheck-error-list-group-by-file)
+          (expect flycheck-error-list-group-by :to-equal '(checker))
           (flycheck-error-list-group-by-none)
           (expect flycheck-error-list-group-by :to-be nil)
           (expect tabulated-list-sort-key :to-equal '("Line"))))
@@ -356,7 +359,7 @@
           (setq flycheck-error-list-source-buffer source
                 flycheck-error-list-group-by 'file
                 flycheck-error-list--collapsed (make-hash-table :test 'equal))
-          (puthash "/p/a.el" t flycheck-error-list--collapsed)
+          (puthash (list "/p/a.el") t flycheck-error-list--collapsed)
           (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
                      (lambda () errors)))
             (let ((entries (flycheck-error-list-entries)))
@@ -379,9 +382,9 @@
             (tabulated-list-print)
             (goto-char (point-min))       ; the a.el header
             (flycheck-error-list-toggle-group-at-point)
-            (expect (gethash "/p/a.el" flycheck-error-list--collapsed) :to-be-truthy)
+            (expect (gethash (list "/p/a.el") flycheck-error-list--collapsed) :to-be-truthy)
             (flycheck-error-list-toggle-group-at-point)
-            (expect (gethash "/p/a.el" flycheck-error-list--collapsed) :to-be nil))))
+            (expect (gethash (list "/p/a.el") flycheck-error-list--collapsed) :to-be nil))))
 
       (it "toggles the parent group from an error row"
         (flycheck/with-error-list-buffer
@@ -395,7 +398,7 @@
             (forward-line 1)              ; the a.el error row
             (expect (flycheck-error-p (tabulated-list-get-id)) :to-be-truthy)
             (flycheck-error-list-toggle-group-at-point)
-            (expect (gethash "/p/a.el" flycheck-error-list--collapsed)
+            (expect (gethash (list "/p/a.el") flycheck-error-list--collapsed)
                     :to-be-truthy))))
 
       (it "expands a group that clears and later reappears"
@@ -403,13 +406,13 @@
           (setq flycheck-error-list-source-buffer source
                 flycheck-error-list-group-by 'file
                 flycheck-error-list--collapsed (make-hash-table :test 'equal))
-          (puthash "/p/a.el" t flycheck-error-list--collapsed)
+          (puthash (list "/p/a.el") t flycheck-error-list--collapsed)
           ;; a.el has no errors this round, so its stale collapse key must be
           ;; pruned; otherwise a new a.el error would come back hidden.
           (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
                      (lambda () (list (cadr errors)))))
             (flycheck-error-list-entries)
-            (expect (gethash "/p/a.el" flycheck-error-list--collapsed)
+            (expect (gethash (list "/p/a.el") flycheck-error-list--collapsed)
                     :to-be nil))))
 
       (it "keeps collapse state when a filter hides the group"
@@ -423,19 +426,19 @@
                   flycheck-error-list--collapsed (make-hash-table :test 'equal)
                   ;; A message filter that matches only b.el's error.
                   flycheck-error-list--message-filter "bbb")
-            (puthash "/p/a.el" t flycheck-error-list--collapsed)
+            (puthash (list "/p/a.el") t flycheck-error-list--collapsed)
             (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
                        (lambda () errs)))
               (flycheck-error-list-entries)
               ;; a.el is filtered out of this render but still exists, so its
               ;; collapse must survive to when the filter is relaxed.
-              (expect (gethash "/p/a.el" flycheck-error-list--collapsed)
+              (expect (gethash (list "/p/a.el") flycheck-error-list--collapsed)
                       :to-be-truthy)))))
 
       (it "resets collapse state when the scope changes"
         (flycheck/with-error-list-buffer
           (setq flycheck-error-list--collapsed (make-hash-table :test 'equal))
-          (puthash "/p/a.el" t flycheck-error-list--collapsed)
+          (puthash (list "/p/a.el") t flycheck-error-list--collapsed)
           (flycheck-error-list-toggle-scope)
           (expect flycheck-error-list--collapsed :to-be nil)))
 
@@ -454,6 +457,92 @@
             (expect flycheck-error-list--collapsed :to-be nil)
             (expect (flycheck-error-p (tabulated-list-get-id))
                     :to-be-truthy))))))
+
+  (describe "Nested grouping"
+    (let ((errors (list (flycheck-error-new-at 1 1 'error "a"
+                                               :filename "/p/a.el" :checker 'rubocop)
+                        (flycheck-error-new-at 2 1 'warning "b"
+                                               :filename "/p/a.el" :checker 'ruby)
+                        (flycheck-error-new-at 3 1 'error "c"
+                                               :filename "/p/b.el" :checker 'rubocop)))
+          source)
+      (before-each
+        (setq source (generate-new-buffer " nested-source"))
+        (with-current-buffer source (setq default-directory "/p/")))
+      (after-each (kill-buffer source))
+
+      (defun flycheck/nested-repr ()
+        "Return the header labels and error lines of the grouped list."
+        (mapcar (lambda (e)
+                  (if (flycheck-error-p (car e))
+                      (flycheck-error-line (car e))
+                    (car (aref (cadr e) 0))))
+                (flycheck-error-list-entries)))
+
+      (it "nests dimensions and indents inner headers"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by '(file checker))
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            ;; file at depth 0, checker headers indented under it, then rows.
+            (expect (flycheck/nested-repr)
+                    :to-equal '("▾ a.el (2)"
+                                "  ▾ rubocop (1)" 1
+                                "  ▾ ruby (1)" 2
+                                "▾ b.el (1)"
+                                "  ▾ rubocop (1)" 3)))))
+
+      (it "collapsing an outer group hides all its subgroups"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by '(file checker)
+                flycheck-error-list--collapsed (make-hash-table :test 'equal))
+          (puthash (list "/p/a.el") t flycheck-error-list--collapsed)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (expect (flycheck/nested-repr)
+                    :to-equal '("▸ a.el (2)"
+                                "▾ b.el (1)"
+                                "  ▾ rubocop (1)" 3)))))
+
+      (it "collapsing an inner group hides only that subgroup"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by '(file checker)
+                flycheck-error-list--collapsed (make-hash-table :test 'equal))
+          (puthash (list "/p/a.el" 'rubocop) t flycheck-error-list--collapsed)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () errors)))
+            (expect (flycheck/nested-repr)
+                    :to-equal '("▾ a.el (2)"
+                                "  ▸ rubocop (1)"
+                                "  ▾ ruby (1)" 2
+                                "▾ b.el (1)"
+                                "  ▾ rubocop (1)" 3)))))
+
+      (it "derives an error's full group path"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-group-by '(file checker))
+          (expect (flycheck-error-list--error-group-path (car errors))
+                  :to-equal '("/p/a.el" rubocop))))
+
+      (it "prunes only paths with no live errors"
+        (flycheck/with-error-list-buffer
+          (setq flycheck-error-list-source-buffer source
+                flycheck-error-list-group-by '(file checker)
+                flycheck-error-list--collapsed (make-hash-table :test 'equal))
+          ;; A collapsed inner path that still has an error must survive; a
+          ;; path for a file that is gone must be pruned.
+          (puthash (list "/p/a.el" 'rubocop) t flycheck-error-list--collapsed)
+          (puthash (list "/p/gone.el") t flycheck-error-list--collapsed)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () (list (car errors)))))
+            (flycheck-error-list-entries)
+            (expect (gethash (list "/p/a.el" 'rubocop)
+                             flycheck-error-list--collapsed) :to-be-truthy)
+            (expect (gethash (list "/p/gone.el")
+                             flycheck-error-list--collapsed) :to-be nil))))))
 
   (describe "Grouping controls line"
     (it "advertises every dimension and marks the active one"


### PR DESCRIPTION
Grouping was single-level (file, checker, or level). This lets the dimensions nest, so you can lay the errors out by file and then by checker within each file, and so on.

`M-2`..`M-4` now toggle a dimension in and out of the grouping instead of replacing it (they always nest in the file, checker, level order), and `M-1` clears it. Headers indent one level per depth, and collapse is tracked per group path, so the same checker collapses independently under each file. The tab-line highlights every active dimension.