### PR TITLE
Drive the error-list grouping with the mouse

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@
   The keys toggle each dimension and combine, so ``M-2`` then ``M-3``
   nests the errors by checker within each file.  Press ``TAB`` on a group
   to collapse or expand it.  The groupings are shown in a strip at the top
-  of the error list.
+  of the error list; click a grouping there or a group header to drive it
+  all with the mouse.
 - ``python-ruff`` and ``sh-shellcheck`` now carry the fixes their tools
   suggest, applicable with the quick-fix commands.  Both switched to their
   JSON output (ruff ``--output-format=json``, shellcheck ``--format

--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -93,7 +93,9 @@ dimension, so you can combine them: with both :kbd:`M-2` and :kbd:`M-3` the
 errors nest by checker within each file.  Combined dimensions always nest in
 the file, checker, level order.  The available groupings and the active ones
 are shown in a strip at the top of the error list.  Press :kbd:`TAB` (or
-:kbd:`RET` on a header) to collapse or expand the group at point.
+:kbd:`RET` on a header) to collapse or expand the group at point.  You can
+also click a grouping in the strip to toggle it, or a group header to collapse
+or expand it.
 
 Filter the list
 ===============

--- a/flycheck.el
+++ b/flycheck.el
@@ -6125,13 +6125,16 @@ DIMENSIONS is nil for a flat list, or a list of the symbols in
 Add or remove DIMENSION from the grouping, keeping the remaining
 dimensions in the canonical `flycheck-error-list--group-dimensions'
 order, so they always nest file then checker then level."
-  (let* ((active (flycheck-error-list--grouping-dimensions))
-         (next (if (memq dimension active)
-                   (remq dimension active)
-                 (cons dimension active))))
-    (flycheck-error-list--set-group-by
-     (seq-filter (lambda (d) (memq d next))
-                 flycheck-error-list--group-dimensions))))
+  ;; Read the current grouping in the error list buffer, not whatever buffer a
+  ;; tab-line mouse click happens to run this from.
+  (flycheck-error-list-with-buffer
+    (let* ((active (flycheck-error-list--grouping-dimensions))
+           (next (if (memq dimension active)
+                     (remq dimension active)
+                   (cons dimension active))))
+      (flycheck-error-list--set-group-by
+       (seq-filter (lambda (d) (memq d next))
+                   flycheck-error-list--group-dimensions)))))
 
 (defun flycheck-error-list-group-by-none ()
   "Show the error list as a flat list, without grouping."
@@ -6153,6 +6156,30 @@ order, so they always nest file then checker then level."
   (interactive)
   (flycheck-error-list--toggle-group-by 'level))
 
+(defun flycheck-error-list--group-command (dimension)
+  "Return the command toggling grouping by DIMENSION (nil for flat)."
+  (pcase dimension
+    ('nil #'flycheck-error-list-group-by-none)
+    ('file #'flycheck-error-list-group-by-file)
+    ('checker #'flycheck-error-list-group-by-checker)
+    ('level #'flycheck-error-list-group-by-level)))
+
+(defun flycheck-error-list--grouping-label (dimension key active)
+  "Return the tab-line label for DIMENSION, its M-KEY, ACTIVE if on.
+
+The label toggles DIMENSION when clicked."
+  (let ((label (format "M-%d %s" key (if dimension dimension "flat")))
+        (map (make-sparse-keymap)))
+    (define-key map [tab-line mouse-1]
+      (flycheck-error-list--group-command dimension))
+    (propertize label
+                'face (and active 'flycheck-error-list-group-header)
+                'mouse-face 'highlight
+                'keymap map
+                'help-echo (if dimension
+                               (format "mouse-1: toggle grouping by %s" dimension)
+                             "mouse-1: show a flat list"))))
+
 (defun flycheck-error-list--grouping-line ()
   "Return the tab-line string advertising the grouping controls."
   (let ((active (flycheck-error-list--grouping-dimensions)))
@@ -6161,14 +6188,10 @@ order, so they always nest file then checker then level."
      (mapconcat
       (lambda (item)
         (let* ((dimension (car item))
-               (label (format "M-%d %s" (cdr item)
-                              (if dimension dimension "flat")))
                ;; Highlight every active dimension, or `flat' when none.
                (on (if dimension (memq dimension active) (null active))))
-          (concat "  " (if on
-                           (propertize label 'face
-                                       'flycheck-error-list-group-header)
-                         label))))
+          (concat "  " (flycheck-error-list--grouping-label
+                        dimension (cdr item) on))))
       ;; nil (flat) is M-1, then the dimensions M-2, M-3, M-4.
       (cons '(nil . 1)
             (seq-map-indexed (lambda (d i) (cons d (+ i 2)))
@@ -6230,6 +6253,10 @@ button instead, like Tabulated List mode's \\`TAB'."
 (define-button-type 'flycheck-error-list-explain-error
   'action #'flycheck-error-list-explain-error
   'help-echo "mouse-1, RET: explain error")
+
+(define-button-type 'flycheck-error-list-group
+  'supertype 'flycheck-error-list
+  'help-echo "mouse-1, RET, TAB: collapse or expand")
 
 (defsubst flycheck-error-list-make-cell (text &optional face help-echo type)
   "Make an error list cell with TEXT and FACE.
@@ -6436,7 +6463,8 @@ navigation and the fix/explain commands skip it."
                          (if collapsed "▸" "▾")
                          (flycheck-error-list--group-name dimension key)
                          count)
-                 'flycheck-error-list-group-header)
+                 'flycheck-error-list-group-header nil
+                 'flycheck-error-list-group)
                 "" "" "" "" "")))
 
 (defun flycheck-error-list--grouped-entries (errors dimensions path depth omit-file)

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -556,6 +556,60 @@
             (expect (get-text-property start 'face line)
                     :to-be 'flycheck-error-list-group-header))))))
 
+  (describe "Mouse support"
+    (it "makes each tab-line label toggle its dimension on click"
+      (flycheck/with-error-list-buffer
+        (setq flycheck-error-list-group-by nil)
+        (let* ((line (flycheck-error-list--grouping-line))
+               (start (string-match "M-2 file" line))
+               (map (get-text-property start 'keymap line)))
+          (expect (lookup-key map [tab-line mouse-1])
+                  :to-be 'flycheck-error-list-group-by-file)
+          (expect (get-text-property start 'mouse-face line) :to-be 'highlight)
+          (expect (get-text-property start 'help-echo line) :to-be-truthy))))
+
+    (it "toggles the error list's own grouping when clicked from elsewhere"
+      ;; A tab-line click runs the command with the clicked window's buffer
+      ;; current, which need not be the error list; it must still read and
+      ;; toggle the error list's own grouping, not the current buffer's.
+      (let ((el (get-buffer-create flycheck-error-list-buffer)))
+        (unwind-protect
+            (progn
+              (with-current-buffer el
+                (flycheck-error-list-mode)
+                (setq flycheck-error-list-group-by '(file checker)))
+              (with-temp-buffer
+                (flycheck-error-list-group-by-file))
+              (expect (buffer-local-value 'flycheck-error-list-group-by el)
+                      :to-equal '(checker)))
+          (kill-buffer el))))
+
+    (it "makes group headers clickable to collapse or expand"
+      (flycheck/with-error-list-buffer
+        (let ((errors (list (flycheck-error-new-at 1 1 'error "a"
+                                                   :filename "/p/a.el" :checker 'x)))
+              (source (generate-new-buffer " mouse-source")))
+          (unwind-protect
+              (progn
+                (with-current-buffer source (setq default-directory "/p/"))
+                (setq flycheck-error-list-source-buffer source
+                      flycheck-error-list-group-by '(file))
+                (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                           (lambda () errors)))
+                  (setq tabulated-list-entries (flycheck-error-list-entries))
+                  (tabulated-list-print))
+                (goto-char (point-min))
+                (let ((button (next-button (point))))
+                  ;; The header label is a group button; activating it (as a
+                  ;; click would) toggles the group's collapse state.
+                  (expect (button-type button)
+                          :to-be 'flycheck-error-list-group)
+                  (flycheck-error-list-goto-error (button-start button))
+                  (expect (gethash (list "/p/a.el")
+                                   flycheck-error-list--collapsed)
+                          :to-be-truthy)))
+            (kill-buffer source))))))
+
   (describe "Row position index"
     (defun flycheck/error-list-print (errors)
       "Render ERRORS as a flat list in the current error list buffer."


### PR DESCRIPTION
Round out the error-list grouping with mouse support, so it can be driven without the keyboard.

Clicking a grouping in the tab-line strip toggles that dimension (with a hover highlight and a tooltip), and clicking a group header collapses or expands it. Headers already reused the error-list button so a click worked; this gives them a fitting tooltip.