### PR TITLE
Display error messages inline in the buffer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 ``master`` (unreleased)
 =======================
 
+- [#2202]: Flycheck can now show error messages inline in the buffer, next to
+  the code they refer to, in the spirit of VS Code's Error Lens and the inline
+  diagnostics of Neovim, Helix and Zed.  ``flycheck-annotate-mode`` enables
+  this.  Two styles ship out of the box: ``eol`` appends a compact message
+  after the line, and ``below`` lays the full messages out on their own
+  lines underneath.  By default the line at point uses ``below`` and the
+  rest use ``eol`` (see ``flycheck-annotate-current-line-style`` and
+  ``flycheck-annotate-other-lines-style``; set either to nil to leave those
+  lines alone).  ``flycheck-annotate-levels`` restricts which levels appear,
+  ``flycheck-annotate-style-functions`` lets you register new styles, and by
+  default the redundant echo-area message for the errors at point is
+  suppressed while the mode is on (``flycheck-annotate-suppress-echo``).  This
+  obsoletes the third-party ``flycheck-inline`` package.
 - The error list no longer scans all of its rows on every cursor movement
   to highlight the errors at point, so keeping it open next to a large
   project-scope list is much cheaper.

--- a/doc/community/extensions.rst
+++ b/doc/community/extensions.rst
@@ -37,7 +37,8 @@ These extensions change Flycheck’s user interface:
   Flycheck’s mode line status.
 * :gh:`Wilfred/flycheck-title` shows Flycheck error messages in the frame title.
 * :flyc:`flycheck-inline` shows Flycheck error messages in the buffer, directly
-  below their origin.
+  below their origin.  It is obsoleted by the built-in ``flycheck-annotate-mode``
+  (see :doc:`/user/error-reports`).
 
 Eglot
 =====

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -233,6 +233,108 @@ fringes or vertical dots in the margins to indicate the extent of the error.
 To change the fringe bitmap or the symbol used in the margins, use the function
 ``flycheck-redefine-standard-error-levels``.
 
+Inline error messages
+=====================
+
+Beyond the fringe or margin indicators, Flycheck can render the error messages
+themselves right next to the code they refer to, in the spirit of VS Code's
+Error Lens and the inline diagnostics of Neovim, Helix and Zed.  Enable
+``flycheck-annotate-mode`` to turn this on:
+
+.. code-block:: elisp
+
+   (add-hook 'flycheck-mode-hook #'flycheck-annotate-mode)
+
+.. minor-mode:: flycheck-annotate-mode
+
+   Toggle the inline display of Flycheck error messages in the current buffer.
+   The annotations appear only while ``flycheck-mode`` is on.
+
+Flycheck picks the display style per line: the line at point uses
+``flycheck-annotate-current-line-style`` and every other line uses
+``flycheck-annotate-other-lines-style``.  By default the line at point gets the
+roomy ``below`` treatment while the rest get a terse ``eol`` summary, so the
+error you're working on is spelled out in full without every other line
+competing for attention.
+
+.. defcustom:: flycheck-annotate-current-line-style
+               flycheck-annotate-other-lines-style
+
+   The display style for the line at point and for every other line,
+   respectively.  Each is one of:
+
+   ``eol``
+      Append a compact message after the code.  When a line has several
+      errors, show the most severe one and a count of the rest.
+
+   ``below``
+      Lay the full messages out on their own lines underneath the code, one
+      per error, each pointing at its column.
+
+   ``nil``
+      Do not annotate those lines.  Setting ``flycheck-annotate-other-lines-style``
+      to ``nil`` annotates only the line at point, the way Neovim and Helix
+      show diagnostics for the cursor line only.
+
+   Additional styles can be registered through
+   ``flycheck-annotate-style-functions``.
+
+.. defcustom:: flycheck-annotate-levels
+
+   The error levels to display inline, either ``t`` for all levels or a list of
+   level symbols such as ``'(error warning)``.  Errors of other levels are
+   still highlighted and listed; they just get no inline annotation.
+
+.. defcustom:: flycheck-annotate-suppress-echo
+
+   When non-nil (the default) and the line at point is annotated inline, the
+   errors at point are not additionally shown through
+   ``flycheck-display-errors-function`` (Eldoc or the echo area), to avoid
+   displaying the same message twice.  Set to ``nil`` to keep both.
+
+.. defcustom:: flycheck-annotate-format-function
+
+   The function used to format an error for inline display.  It receives a
+   single ``flycheck-error`` and returns the string to show.  The default
+   renders the message and the error ID.
+
+.. defcustom:: flycheck-annotate-style-functions
+
+   An alist mapping style symbols to their renderer functions, used to resolve
+   ``flycheck-annotate-current-line-style`` and
+   ``flycheck-annotate-other-lines-style``.  Add to it to register your own
+   styles.
+
+.. defface:: flycheck-annotate-error
+             flycheck-annotate-warning
+             flycheck-annotate-info
+
+   The faces for inline ``error``, ``warning`` and ``info`` messages
+   respectively.
+
+.. defface:: flycheck-annotate-connector
+
+   The face for the connectors that precede ``below``-style messages.
+
+.. note::
+
+   ``flycheck-annotate-mode`` obsoletes the third-party `flycheck-inline
+   <https://github.com/flycheck/flycheck-inline>`_ package, which pioneered
+   inline error messages for Flycheck.  If you used it, drop it from your
+   configuration and enable ``flycheck-annotate-mode`` instead.  The built-in
+   mode differs in a few ways:
+
+   * It ships with Flycheck, so there is nothing extra to install.
+   * It annotates every error in the visible window, not only the error at
+     point.
+   * It offers two layouts, ``eol`` (after the line) and ``below`` (on their
+     own lines underneath), and picks between them per line, instead of a
+     single placement below the error.
+   * It adds level filtering (``flycheck-annotate-levels``), a custom
+     formatter (``flycheck-annotate-format-function``), echo-area suppression
+     (``flycheck-annotate-suppress-echo``), and user-registrable styles
+     (``flycheck-annotate-style-functions``).
+
 Mode line
 =========
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -3806,6 +3806,11 @@ current syntax check."
   (when shall-interrupt
     (flycheck-stop))
   (flycheck-delete-all-overlays)
+  ;; Inline annotations are separate overlays that the error-overlay
+  ;; teardown above doesn't touch; drop them so a manual clear doesn't
+  ;; leave stale messages behind (a re-check rebuilds them).  Harmless
+  ;; no-op when inline display was never active.
+  (flycheck-annotate--clear)
   (flycheck-clear-errors)
   ;; Note: `flycheck--excessive-checkers' deliberately survives a clear,
   ;; so that the truncation notification doesn't re-fire after every
@@ -7041,7 +7046,8 @@ Intended for `eldoc-documentation-functions', where command
 `flycheck-display-errors-function' has its default value
 `flycheck-display-errors-via-eldoc', so that user customizations
 and third-party display packages keep working unchanged."
-  (when (and flycheck-mode (flycheck--display-errors-via-eldoc-p))
+  (when (and flycheck-mode (flycheck--display-errors-via-eldoc-p)
+             (not (flycheck-annotate--suppresses-echo-p)))
     (when-let* ((errors (flycheck-overlay-errors-at (point))))
       (funcall callback
                (mapconcat
@@ -7094,9 +7100,12 @@ If there are no errors, clears the error messages at point."
   (flycheck-cancel-error-display-error-at-point-timer)
   ;; When errors are displayed through Eldoc and `eldoc-mode' is active,
   ;; its own post-command refresh covers this path; without `eldoc-mode'
-  ;; fall back to Flycheck's timer, which triggers the refresh itself
-  (unless (and (flycheck--display-errors-via-eldoc-p)
-               (bound-and-true-p eldoc-mode))
+  ;; fall back to Flycheck's timer, which triggers the refresh itself.
+  ;; When inline display already covers the line at point, skip the
+  ;; echo-area message entirely (see `flycheck-annotate-suppress-echo').
+  (unless (or (flycheck-annotate--suppresses-echo-p)
+              (and (flycheck--display-errors-via-eldoc-p)
+                   (bound-and-true-p eldoc-mode)))
     (setq flycheck-display-error-at-point-timer
           (run-at-time flycheck-display-errors-delay nil
                        'flycheck-display-error-at-point))))
@@ -7199,6 +7208,355 @@ Hide the error buffer if there is no error under point."
              (equal (current-message) flycheck--last-displayed-message))
         (message nil)
       (flycheck-hide-error-buffer))))
+
+
+;;; Inline error annotations in the buffer
+;;
+;; Besides the fringe/margin indicators and the highlighting overlays,
+;; Flycheck can render the error messages themselves right next to the
+;; offending code, in the spirit of VS Code's Error Lens, Neovim's
+;; virtual text/lines and Helix's inline diagnostics.  `flycheck-annotate-mode'
+;; enables this.
+;;
+;; Two visualization styles ship out of the box (see
+;; `flycheck-annotate-style-functions'): `eol' appends a compact message after
+;; the code, and `below' lays the full messages out on their own lines
+;; underneath.  The style is chosen per line: the line at point uses
+;; `flycheck-annotate-current-line-style' and every other line uses
+;; `flycheck-annotate-other-lines-style', so by default the focused line gets
+;; the roomy `below' treatment while the rest get a terse `eol' summary.
+;;
+;; The annotations are drawn with dedicated overlays (tagged
+;; `flycheck-annotate'), kept separate from the error overlays so they don't
+;; clobber the `before-string'/`after-string' those use for indicators and
+;; the `delimiters' highlighting style.  They cover only the visible portion
+;; of the window and are rebuilt when the check reports, point changes line,
+;; or the window scrolls.
+
+(defface flycheck-annotate-error
+  '((t :inherit flycheck-error-list-error))
+  "Flycheck face for inline error messages."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
+(defface flycheck-annotate-warning
+  '((t :inherit flycheck-error-list-warning))
+  "Flycheck face for inline warning messages."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
+(defface flycheck-annotate-info
+  '((t :inherit flycheck-error-list-info))
+  "Flycheck face for inline informational messages."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
+(defface flycheck-annotate-connector
+  '((t :inherit shadow))
+  "Flycheck face for the connectors of `below'-style inline messages."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
+(defcustom flycheck-annotate-style-functions
+  '((eol . flycheck-annotate-eol-style)
+    (below . flycheck-annotate-below-style))
+  "Alist mapping inline display styles to their renderers.
+
+Each entry is a cons cell (STYLE . FUNCTION) where STYLE is a symbol
+naming a style (as used by `flycheck-annotate-current-line-style' and
+`flycheck-annotate-other-lines-style') and FUNCTION renders it.
+
+FUNCTION is called with three arguments: ERRORS, the list of errors
+anchored to one line, sorted most-severe first; ANCHOR, the buffer
+position at the end of that line to attach the overlay to; and FOCUSED,
+non-nil when the line is the one at point.  It must create its overlays
+with `flycheck-annotate--make-overlay', which tags and tracks them for
+teardown.
+
+Add to this alist to register additional styles."
+  :group 'flycheck
+  :type '(alist :key-type symbol :value-type function)
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-annotate-current-line-style 'below
+  "Inline display style for the line at point.
+
+A style symbol resolved through `flycheck-annotate-style-functions'
+\(`below' or `eol' out of the box), or nil to leave the current line
+unannotated.  See `flycheck-annotate-other-lines-style' for every other
+line."
+  :group 'flycheck
+  :type '(choice (const :tag "Full messages below the line" below)
+                 (const :tag "Compact message at end of line" eol)
+                 (const :tag "Do not annotate the current line" nil)
+                 (symbol :tag "Other style"))
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-annotate-other-lines-style 'eol
+  "Inline display style for lines other than the one at point.
+
+A style symbol resolved through `flycheck-annotate-style-functions'
+\(`below' or `eol' out of the box), or nil to annotate only the line at
+point (the way Neovim and Helix show diagnostics for the cursor line
+only).  See `flycheck-annotate-current-line-style' for the line at point."
+  :group 'flycheck
+  :type '(choice (const :tag "Compact message at end of line" eol)
+                 (const :tag "Full messages below the line" below)
+                 (const :tag "Annotate only the line at point" nil)
+                 (symbol :tag "Other style"))
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-annotate-levels t
+  "Error levels to display inline.
+
+Either t to display errors of every level, or a list of level symbols
+\(e.g. \\='(error warning)) to restrict the inline display to those
+levels.  Errors of other levels are still highlighted and listed as
+usual; they just get no inline annotation."
+  :group 'flycheck
+  :type '(choice (const :tag "All levels" t)
+                 (repeat :tag "Only these levels" symbol))
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-annotate-format-function #'flycheck-error-format-message-and-id
+  "Function to format an error for inline display.
+
+Called with a single `flycheck-error' and must return the string to
+show for it.  The default renders the message and the error ID."
+  :group 'flycheck
+  :type 'function
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-annotate-suppress-echo t
+  "Whether inline display suppresses the echo-area message at point.
+
+When non-nil and the line at point is annotated inline (that is,
+`flycheck-annotate-current-line-style' is non-nil), the errors at point
+are not additionally shown through `flycheck-display-errors-function'
+\(Eldoc or the echo area by default), to avoid displaying the same
+message twice.  Set to nil to keep both."
+  :group 'flycheck
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38"))
+
+(defvar-local flycheck-annotate--overlays nil
+  "Inline display overlays in the current buffer.")
+
+(defvar-local flycheck-annotate--last-line-start nil
+  "Beginning-of-line position the inline overlays were last built for.
+
+Tracked instead of the line number, which would cost a scan from the
+start of the buffer on every command.")
+
+(defvar-local flycheck-annotate--last-window-start nil
+  "Window start the inline overlays were last built for.")
+
+(defun flycheck-annotate--level-face (level)
+  "Return the inline face for error LEVEL."
+  (pcase level
+    ('error 'flycheck-annotate-error)
+    ('warning 'flycheck-annotate-warning)
+    ('info 'flycheck-annotate-info)
+    (_ (flycheck-error-level-error-list-face level))))
+
+(defun flycheck-annotate--make-overlay (anchor &rest props)
+  "Create a tracked inline overlay at ANCHOR with PROPS.
+
+ANCHOR is a buffer position; the overlay is empty and carries the
+`flycheck-annotate' property so it can be found and deleted.  PROPS is a
+plist of additional overlay properties, e.g. `after-string'.  Return the
+overlay."
+  (let ((ov (make-overlay anchor anchor nil t)))
+    (overlay-put ov 'flycheck-annotate t)
+    (overlay-put ov 'priority 100)
+    (while props
+      (overlay-put ov (pop props) (pop props)))
+    (push ov flycheck-annotate--overlays)
+    ov))
+
+(defun flycheck-annotate--connectors ()
+  "Return the connector strings for `below'-style messages, as (MID . LAST).
+
+MID prefixes every message but the last, LAST the final one.  Falls back
+to ASCII when the box-drawing glyphs aren't displayable.  Computed once
+per render so the font probe stays out of the per-error loop."
+  (if (char-displayable-p ?\N{BOX DRAWINGS LIGHT UP AND RIGHT})
+      (cons "\N{BOX DRAWINGS LIGHT VERTICAL AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL} "
+            "\N{BOX DRAWINGS LIGHT UP AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL} ")
+    (cons "`- " "`- ")))
+
+(defun flycheck-annotate-eol-style (errors anchor _focused)
+  "Render ERRORS as a compact message after the line ending at ANCHOR.
+
+Only the most severe error's message is shown, with a count of the rest.
+FOCUSED is ignored."
+  (let* ((err (car errors))
+         (face (flycheck-annotate--level-face (flycheck-error-level err)))
+         (msg (funcall flycheck-annotate-format-function err))
+         (more (when (cdr errors) (format " (+%d)" (length (cdr errors)))))
+         (text (propertize (concat "  " msg more) 'face face)))
+    (flycheck-annotate--make-overlay anchor 'after-string text)))
+
+(defun flycheck-annotate-below-style (errors anchor _focused)
+  "Render ERRORS on their own lines below the line ending at ANCHOR.
+
+Each error gets its own message, prefixed with a connector padded to its
+column.  FOCUSED is ignored."
+  (let* ((n (length errors))
+         (i 0)
+         (connectors (flycheck-annotate--connectors))
+         (lines nil))
+    (dolist (err errors)
+      (setq i (1+ i))
+      ;; Pad with spaces to the error's column.  Lines indented with tabs
+      ;; won't align exactly, since the synthetic line has no tabs to
+      ;; measure against; this is close enough and only cosmetic.
+      (let* ((col (max 0 (1- (or (flycheck-error-column err) 1))))
+             (pad (make-string col ?\s))
+             (face (flycheck-annotate--level-face (flycheck-error-level err)))
+             (conn (propertize (if (= i n) (cdr connectors) (car connectors))
+                               'face 'flycheck-annotate-connector))
+             (msg (propertize (funcall flycheck-annotate-format-function err)
+                              'face face)))
+        (push (concat "\n" pad conn msg) lines)))
+    (flycheck-annotate--make-overlay anchor 'after-string
+                                   (apply #'concat (nreverse lines)))))
+
+(defun flycheck-annotate--clear ()
+  "Delete all inline overlays in the current buffer."
+  (mapc #'delete-overlay flycheck-annotate--overlays)
+  (setq flycheck-annotate--overlays nil))
+
+(defun flycheck-annotate--filter-levels (errors)
+  "Keep the ERRORS whose level is enabled by `flycheck-annotate-levels'."
+  (if (eq flycheck-annotate-levels t)
+      errors
+    (seq-filter (lambda (err)
+                  (memq (flycheck-error-level err) flycheck-annotate-levels))
+                errors)))
+
+(defun flycheck-annotate--region ()
+  "Return the buffer region to annotate, as a cons (BEG . END).
+
+The visible portion of the window showing the current buffer, or the
+line at point when the buffer isn't displayed."
+  (if-let* ((win (get-buffer-window)))
+      ;; Derive the end from the window height rather than `window-end'
+      ;; with its update flag, which would force a redisplay simulation on
+      ;; this hot path.  A slight over-scan past the last visible line is
+      ;; harmless; we only use the region to collect errors to annotate.
+      (let ((start (window-start win)))
+        (cons start
+              (save-excursion
+                (goto-char start)
+                (forward-line (window-body-height win))
+                (point))))
+    (cons (line-beginning-position) (line-end-position))))
+
+(defun flycheck-annotate--group-errors (beg end)
+  "Group the errors overlaid between BEG and END by their anchor line.
+
+Return an alist mapping the end-of-line position of each line to the
+list of errors on it, in buffer order.  Skips errors that belong to
+another file."
+  (let ((groups nil))
+    (dolist (ov (flycheck-overlays-in beg end))
+      (when-let* ((err (overlay-get ov 'flycheck-error)))
+        (unless (flycheck-relevant-error-other-file-p err)
+          (let* ((anchor (save-excursion
+                           (goto-char (overlay-start ov))
+                           (line-end-position)))
+                 (cell (assq anchor groups)))
+            (if cell
+                (setcdr cell (cons err (cdr cell)))
+              (push (cons anchor (list err)) groups))))))
+    groups))
+
+(defun flycheck-annotate--refresh ()
+  "Rebuild the inline overlays for the visible part of the buffer.
+
+Records the line and window start the overlays were built for, so
+`flycheck-annotate--post-command' can skip rebuilds that would not change
+anything."
+  (setq flycheck-annotate--last-line-start (line-beginning-position)
+        flycheck-annotate--last-window-start (window-start))
+  (flycheck-annotate--clear)
+  (when (and (bound-and-true-p flycheck-annotate-mode) flycheck-mode)
+    (pcase-let ((`(,beg . ,end) (flycheck-annotate--region))
+                (point-anchor (line-end-position)))
+      (pcase-dolist (`(,anchor . ,errors)
+                     (flycheck-annotate--group-errors beg end))
+        (let* ((focused (= anchor point-anchor))
+               (style (if focused
+                          flycheck-annotate-current-line-style
+                        flycheck-annotate-other-lines-style)))
+          (when-let* ((style)
+                      (render (cdr (assq style
+                                         flycheck-annotate-style-functions)))
+                      (errors (flycheck-annotate--filter-levels errors)))
+            (funcall render
+                     (sort errors #'flycheck--excessive-errors-<)
+                     anchor focused)))))))
+
+(defun flycheck-annotate--post-command ()
+  "Rebuild the inline overlays if point or the window has moved.
+
+Only rebuilds when point changed line or the window scrolled, since the
+annotations are otherwise unaffected by point motion within a line."
+  (unless (and (eql (line-beginning-position) flycheck-annotate--last-line-start)
+               (eql (window-start) flycheck-annotate--last-window-start))
+    (flycheck-annotate--refresh)))
+
+(defun flycheck-annotate--suppresses-echo-p ()
+  "Return non-nil when inline display covers the at-point echo message.
+
+Only suppresses when the errors at point would actually be rendered
+inline, so an error that the inline display drops (because its level is
+disabled by `flycheck-annotate-levels', or it belongs to another file) is
+still shown through the echo area rather than nowhere."
+  (and (bound-and-true-p flycheck-annotate-mode)
+       flycheck-annotate-suppress-echo
+       flycheck-annotate-current-line-style
+       (seq-some (lambda (err)
+                   (not (flycheck-relevant-error-other-file-p err)))
+                 (flycheck-annotate--filter-levels
+                  (flycheck-overlay-errors-at (point))))))
+
+;;;###autoload
+(define-minor-mode flycheck-annotate-mode
+  "Minor mode to display Flycheck error messages inline in the buffer.
+
+When enabled, the error messages are rendered right next to the code
+they refer to, in addition to the fringe/margin indicators and the
+highlighting.  The line at point is annotated with
+`flycheck-annotate-current-line-style' and the rest with
+`flycheck-annotate-other-lines-style'; see those options and
+`flycheck-annotate-style-functions' for the available styles.
+
+This mode only shows errors while command `flycheck-mode' is on in the
+buffer.  With `flycheck-annotate-suppress-echo' (on by default), it also
+suppresses the redundant echo-area/Eldoc message for the errors at
+point.
+
+The annotations track the window showing the buffer and the line at
+point, and are rebuilt after a check, when point changes line, and when
+the window scrolls.  When a buffer is shown in more than one window they
+follow the selected one; lines revealed by an implicit scroll are
+annotated on the next command."
+  :lighter nil
+  :group 'flycheck
+  (cond
+   (flycheck-annotate-mode
+    (add-hook 'post-command-hook #'flycheck-annotate--post-command nil t)
+    (add-hook 'flycheck-after-syntax-check-hook
+              #'flycheck-annotate--refresh nil t)
+    (flycheck-annotate--refresh))
+   (t
+    (remove-hook 'post-command-hook #'flycheck-annotate--post-command t)
+    (remove-hook 'flycheck-after-syntax-check-hook
+                 #'flycheck-annotate--refresh t)
+    (flycheck-annotate--clear))))
 
 
 ;;; Working with errors

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -1,0 +1,207 @@
+;;; test-annotate.el --- Flycheck Specs: Inline display  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for the inline display of errors (`flycheck-annotate-mode').
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(defun test-annotate/setup ()
+  "Fill the current buffer with four lines and errors on lines 2 and 4.
+
+Line 2 gets an error and a warning; line 4 gets a warning."
+  (insert "line one here\nline two here\nline three ok\nline four here\n")
+  (setq-local flycheck-mode t)
+  (let ((e2 (flycheck-error-new-at 2 6 'error "bad thing" :id "E1"
+                                   :buffer (current-buffer) :checker 'emacs-lisp))
+        (e2b (flycheck-error-new-at 2 1 'warning "also warn"
+                                    :buffer (current-buffer) :checker 'emacs-lisp))
+        (e4 (flycheck-error-new-at 4 3 'warning "watch out"
+                                   :buffer (current-buffer) :checker 'emacs-lisp)))
+    (setq flycheck-current-errors (list e2 e2b e4))
+    (mapc #'flycheck-add-overlay flycheck-current-errors)))
+
+(defun test-annotate/anchors ()
+  "Return an alist mapping each inline overlay's line to its text."
+  (mapcar (lambda (ov)
+            (cons (line-number-at-pos (overlay-start ov))
+                  (substring-no-properties (overlay-get ov 'after-string))))
+          flycheck-annotate--overlays))
+
+(describe "Inline display"
+
+  (describe "the default format function"
+    (it "renders the message and the id"
+      (expect (substring-no-properties
+               (funcall flycheck-annotate-format-function
+                        (flycheck-error-new-at 1 1 'error "boom" :id "X9")))
+              :to-match "boom")
+      (expect (substring-no-properties
+               (funcall flycheck-annotate-format-function
+                        (flycheck-error-new-at 1 1 'error "boom" :id "X9")))
+              :to-match "X9")))
+
+  (describe "flycheck-annotate--level-face"
+    (it "maps the built-in levels to the inline faces"
+      (expect (flycheck-annotate--level-face 'error) :to-be 'flycheck-annotate-error)
+      (expect (flycheck-annotate--level-face 'warning) :to-be 'flycheck-annotate-warning)
+      (expect (flycheck-annotate--level-face 'info) :to-be 'flycheck-annotate-info)))
+
+  (describe "flycheck-annotate--filter-levels"
+    (it "keeps every error when set to t"
+      (let ((flycheck-annotate-levels t)
+            (errs (list (flycheck-error-new-at 1 1 'error)
+                        (flycheck-error-new-at 1 1 'warning))))
+        (expect (flycheck-annotate--filter-levels errs) :to-equal errs)))
+    (it "keeps only errors of the listed levels"
+      (let* ((flycheck-annotate-levels '(error))
+             (err (flycheck-error-new-at 1 1 'error))
+             (warn (flycheck-error-new-at 1 1 'warning)))
+        (expect (flycheck-annotate--filter-levels (list err warn))
+                :to-equal (list err)))))
+
+  (describe "flycheck-annotate-eol-style"
+    (it "shows the most severe message and a count of the rest"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abcdef\n")
+        (let* ((errs (list (flycheck-error-new-at 1 1 'error "big"
+                                                  :checker 'emacs-lisp)
+                           (flycheck-error-new-at 1 2 'warning "small"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate-eol-style errs (line-end-position) nil))
+               (s (substring-no-properties (overlay-get ov 'after-string))))
+          (expect s :to-match "big")
+          (expect s :to-match (regexp-quote "(+1)"))
+          (expect (string-prefix-p "\n" s) :to-be nil)))))
+
+  (describe "flycheck-annotate-below-style"
+    (it "stacks each message on its own line under the code"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abcdef\n")
+        (let* ((errs (list (flycheck-error-new-at 1 3 'error "one"
+                                                  :checker 'emacs-lisp)
+                           (flycheck-error-new-at 1 1 'warning "two"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate-below-style errs (line-end-position) t))
+               (s (substring-no-properties (overlay-get ov 'after-string))))
+          (expect (string-prefix-p "\n" s) :to-be t)
+          (expect s :to-match "one")
+          (expect s :to-match "two")
+          ;; leading newline plus one line per error
+          (expect (length (split-string s "\n")) :to-equal 3)))))
+
+  (describe "flycheck-annotate--make-overlay"
+    (it "tags and tracks the overlay"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abc\n")
+        (let* ((flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate--make-overlay (point-min) 'after-string "x")))
+          (expect (overlay-get ov 'flycheck-annotate) :to-be t)
+          (expect (memq ov flycheck-annotate--overlays) :not :to-be nil)))))
+
+  (describe "flycheck-annotate--suppresses-echo-p"
+    (it "suppresses the echo message for an error rendered inline"
+      (flycheck-buttercup-with-temp-buffer
+        (test-annotate/setup)
+        (goto-char (point-min))
+        (forward-line 3)                ; line 4 warning at column 3
+        (forward-char 2)                ; onto the warning
+        (let ((flycheck-annotate-mode t)
+              (flycheck-annotate-suppress-echo t)
+              (flycheck-annotate-current-line-style 'below)
+              (flycheck-annotate-levels t))
+          (expect (flycheck-annotate--suppresses-echo-p) :to-be t))))
+    (it "is nil when the current line is not annotated"
+      (let ((flycheck-annotate-mode t)
+            (flycheck-annotate-suppress-echo t)
+            (flycheck-annotate-current-line-style nil))
+        (expect (flycheck-annotate--suppresses-echo-p) :to-be nil)))
+    (it "is nil when suppression is disabled"
+      (let ((flycheck-annotate-mode t)
+            (flycheck-annotate-suppress-echo nil)
+            (flycheck-annotate-current-line-style 'below))
+        (expect (flycheck-annotate--suppresses-echo-p) :to-be nil)))
+    (it "does not suppress an error the inline display would filter out"
+      (flycheck-buttercup-with-temp-buffer
+        (test-annotate/setup)
+        (goto-char (point-min))
+        (forward-line 3)                ; line 4 has a warning at column 3
+        (forward-char 2)                ; onto the warning
+        (let ((flycheck-annotate-mode t)
+              (flycheck-annotate-suppress-echo t)
+              (flycheck-annotate-current-line-style 'below)
+              (flycheck-annotate-levels '(error)))
+          ;; the only error at point is a warning, excluded by the level
+          ;; filter, so it must still reach the echo area
+          (expect (flycheck-annotate--suppresses-echo-p) :to-be nil)))))
+
+  (describe "the two-tier layout"
+    (it "uses the below style on the line at point and eol elsewhere"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (goto-char (point-min))
+          (forward-line 1)              ; line 2
+          (flycheck-annotate-mode 1)
+          (let ((anchors (test-annotate/anchors)))
+            ;; line 2 is focused -> below (after-string begins with a newline)
+            (expect (string-prefix-p "\n" (cdr (assq 2 anchors))) :to-be t)
+            ;; line 4 is unfocused -> eol
+            (expect (string-prefix-p "\n" (cdr (assq 4 anchors))) :to-be nil)))))
+
+    (it "swaps the styles as point moves between lines"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (goto-char (point-min))
+          (forward-line 3)              ; line 4
+          (flycheck-annotate-mode 1)
+          (let ((anchors (test-annotate/anchors)))
+            (expect (string-prefix-p "\n" (cdr (assq 4 anchors))) :to-be t)
+            (expect (string-prefix-p "\n" (cdr (assq 2 anchors))) :to-be nil))))))
+
+  (describe "flycheck-annotate-mode"
+    (it "clears the overlays when disabled"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (flycheck-annotate-mode 1)
+          (expect flycheck-annotate--overlays :not :to-be nil)
+          (flycheck-annotate-mode -1)
+          (expect flycheck-annotate--overlays :to-be nil))))
+
+    (it "drops the overlays on a manual clear"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (flycheck-annotate-mode 1)
+          (expect flycheck-annotate--overlays :not :to-be nil)
+          (flycheck-clear)
+          (expect flycheck-annotate--overlays :to-be nil))))))
+
+;;; test-annotate.el ends here


### PR DESCRIPTION
Adds `flycheck-annotate-mode`, which shows error messages right next to the code they refer to, the way Error Lens (VS Code) and the inline diagnostics in Neovim, Helix and Zed do.

Two layouts ship: a compact message at the end of the line, and the full messages on their own lines below. By default the line at point gets the roomy below treatment and the rest a terse end-of-line summary, so the error you're working on is spelled out without every other line competing for attention.

This obsoletes the third-party flycheck-inline package; the manual notes how the built-in mode differs. A whole-line background tint and a right-aligned sideline style will follow as separate PRs.
