### PR TITLE
Tint error lines by severity, Error Lens style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 ``master`` (unreleased)
 =======================
 
+- [#2203]: ``flycheck-annotate-mode`` can now tint the whole line of each error
+  with a subtle background in its severity colour, in the spirit of VS Code's
+  Error Lens.  Set ``flycheck-annotate-background`` to enable it; the tint
+  applies to every visible error line, independent of the message style.
 - [#2202]: Flycheck can now show error messages inline in the buffer, next to
   the code they refer to, in the spirit of VS Code's Error Lens and the inline
   diagnostics of Neovim, Helix and Zed.  ``flycheck-annotate-mode`` enables

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -292,6 +292,14 @@ competing for attention.
    ``flycheck-display-errors-function`` (Eldoc or the echo area), to avoid
    displaying the same message twice.  Set to ``nil`` to keep both.
 
+.. defcustom:: flycheck-annotate-background
+
+   When non-nil, tint the whole line of each error with a subtle background in
+   the colour of its most severe level, in the spirit of VS Code's Error Lens.
+   The tint applies to every visible error line that passes
+   ``flycheck-annotate-levels``, independent of the message style, so it shows
+   even on lines whose style is ``nil``.  Off by default.
+
 .. defcustom:: flycheck-annotate-format-function
 
    The function used to format an error for inline display.  It receives a
@@ -315,6 +323,14 @@ competing for attention.
 .. defface:: flycheck-annotate-connector
 
    The face for the connectors that precede ``below``-style messages.
+
+.. defface:: flycheck-annotate-error-background
+             flycheck-annotate-warning-background
+             flycheck-annotate-info-background
+
+   The whole-line tint faces for ``error``, ``warning`` and ``info`` lines,
+   used when ``flycheck-annotate-background`` is non-nil.  Each sets only a
+   background, with ``:extend t`` so it reaches the window edge.
 
 .. note::
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7257,6 +7257,33 @@ Hide the error buffer if there is no error under point."
   :package-version '(flycheck . "38")
   :group 'flycheck-faces)
 
+(defface flycheck-annotate-error-background
+  '((((background dark)) :background "#402626" :extend t)
+    (((background light)) :background "#fbe9e9" :extend t))
+  "Flycheck face for the whole-line tint of error lines.
+
+Used only when `flycheck-annotate-background' is non-nil."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
+(defface flycheck-annotate-warning-background
+  '((((background dark)) :background "#403626" :extend t)
+    (((background light)) :background "#fbf3e0" :extend t))
+  "Flycheck face for the whole-line tint of warning lines.
+
+Used only when `flycheck-annotate-background' is non-nil."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
+(defface flycheck-annotate-info-background
+  '((((background dark)) :background "#26323f" :extend t)
+    (((background light)) :background "#e6f0fb" :extend t))
+  "Flycheck face for the whole-line tint of info lines.
+
+Used only when `flycheck-annotate-background' is non-nil."
+  :package-version '(flycheck . "38")
+  :group 'flycheck-faces)
+
 (defcustom flycheck-annotate-style-functions
   '((eol . flycheck-annotate-eol-style)
     (below . flycheck-annotate-below-style))
@@ -7340,6 +7367,20 @@ message twice.  Set to nil to keep both."
   :safe #'booleanp
   :package-version '(flycheck . "38"))
 
+(defcustom flycheck-annotate-background nil
+  "Whether to tint the whole line of each annotated error by severity.
+
+When non-nil, every visible line carrying an error that passes
+`flycheck-annotate-levels' gets a subtle background in the colour of its
+most severe error, in the spirit of VS Code's Error Lens.  The tint uses
+the `flycheck-annotate-error-background', `flycheck-annotate-warning-background'
+and `flycheck-annotate-info-background' faces, and is independent of the
+message style, so it applies even to lines whose style is nil."
+  :group 'flycheck
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38"))
+
 (defvar-local flycheck-annotate--overlays nil
   "Inline display overlays in the current buffer.")
 
@@ -7360,6 +7401,12 @@ start of the buffer on every command.")
     ('info 'flycheck-annotate-info)
     (_ (flycheck-error-level-error-list-face level))))
 
+(defun flycheck-annotate--track (overlay)
+  "Tag OVERLAY as ours and track it for teardown.  Return OVERLAY."
+  (overlay-put overlay 'flycheck-annotate t)
+  (push overlay flycheck-annotate--overlays)
+  overlay)
+
 (defun flycheck-annotate--make-overlay (anchor &rest props)
   "Create a tracked inline overlay at ANCHOR with PROPS.
 
@@ -7368,12 +7415,33 @@ ANCHOR is a buffer position; the overlay is empty and carries the
 plist of additional overlay properties, e.g. `after-string'.  Return the
 overlay."
   (let ((ov (make-overlay anchor anchor nil t)))
-    (overlay-put ov 'flycheck-annotate t)
     (overlay-put ov 'priority 100)
     (while props
       (overlay-put ov (pop props) (pop props)))
-    (push ov flycheck-annotate--overlays)
-    ov))
+    (flycheck-annotate--track ov)))
+
+(defun flycheck-annotate--background-face (level)
+  "Return the whole-line background face for error LEVEL, or nil."
+  (pcase level
+    ('error 'flycheck-annotate-error-background)
+    ('warning 'flycheck-annotate-warning-background)
+    ('info 'flycheck-annotate-info-background)
+    (_ nil)))
+
+(defun flycheck-annotate--tint-line (anchor level)
+  "Tint the whole line ending at ANCHOR with LEVEL's background face.
+
+Does nothing for a LEVEL without a background face.  The overlay spans
+the trailing newline so the tint reaches the window edge via the face's
+`:extend' attribute."
+  (when-let* ((face (flycheck-annotate--background-face level)))
+    (let* ((beg (save-excursion (goto-char anchor) (line-beginning-position)))
+           (end (min (point-max) (1+ anchor)))
+           (ov (make-overlay beg end nil t)))
+      ;; Below the message overlays (priority 100) so their strings win.
+      (overlay-put ov 'priority 1)
+      (overlay-put ov 'face face)
+      (flycheck-annotate--track ov))))
 
 (defun flycheck-annotate--connectors ()
   "Return the connector strings for `below'-style messages, as (MID . LAST).
@@ -7487,17 +7555,20 @@ anything."
                 (point-anchor (line-end-position)))
       (pcase-dolist (`(,anchor . ,errors)
                      (flycheck-annotate--group-errors beg end))
-        (let* ((focused (= anchor point-anchor))
-               (style (if focused
-                          flycheck-annotate-current-line-style
-                        flycheck-annotate-other-lines-style)))
-          (when-let* ((style)
-                      (render (cdr (assq style
-                                         flycheck-annotate-style-functions)))
-                      (errors (flycheck-annotate--filter-levels errors)))
-            (funcall render
-                     (sort errors #'flycheck--excessive-errors-<)
-                     anchor focused)))))))
+        (when-let* ((errors (flycheck-annotate--filter-levels errors)))
+          (setq errors (sort errors #'flycheck--excessive-errors-<))
+          ;; The tint applies to every filtered error line, independent of
+          ;; the message style, so it survives an other-lines style of nil.
+          (when flycheck-annotate-background
+            (flycheck-annotate--tint-line
+             anchor (flycheck-error-level (car errors))))
+          (let* ((focused (= anchor point-anchor))
+                 (style (if focused
+                            flycheck-annotate-current-line-style
+                          flycheck-annotate-other-lines-style)))
+            (when-let* ((render (cdr (assq style
+                                           flycheck-annotate-style-functions))))
+              (funcall render errors anchor focused))))))))
 
 (defun flycheck-annotate--post-command ()
   "Rebuild the inline overlays if point or the window has moved.

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -41,11 +41,20 @@ Line 2 gets an error and a warning; line 4 gets a warning."
     (mapc #'flycheck-add-overlay flycheck-current-errors)))
 
 (defun test-annotate/anchors ()
-  "Return an alist mapping each inline overlay's line to its text."
+  "Return an alist mapping each message overlay's line to its text."
   (mapcar (lambda (ov)
             (cons (line-number-at-pos (overlay-start ov))
                   (substring-no-properties (overlay-get ov 'after-string))))
-          flycheck-annotate--overlays))
+          (seq-filter (lambda (ov) (overlay-get ov 'after-string))
+                      flycheck-annotate--overlays)))
+
+(defun test-annotate/tints ()
+  "Return an alist mapping each tinted line to its background face."
+  (mapcar (lambda (ov)
+            (cons (line-number-at-pos (overlay-start ov))
+                  (overlay-get ov 'face)))
+          (seq-filter (lambda (ov) (overlay-get ov 'face))
+                      flycheck-annotate--overlays)))
 
 (describe "Inline display"
 
@@ -202,6 +211,61 @@ Line 2 gets an error and a warning; line 4 gets a warning."
           (flycheck-annotate-mode 1)
           (expect flycheck-annotate--overlays :not :to-be nil)
           (flycheck-clear)
-          (expect flycheck-annotate--overlays :to-be nil))))))
+          (expect flycheck-annotate--overlays :to-be nil)))))
+
+  (describe "the background tint"
+    (it "adds no tint when disabled"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (let ((flycheck-annotate-background nil))
+            (flycheck-annotate-mode 1)
+            (expect (test-annotate/tints) :to-be nil)))))
+
+    (it "tints each error line with its most severe level"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (let ((flycheck-annotate-background t))
+            (flycheck-annotate-mode 1)
+            (let ((tints (test-annotate/tints)))
+              ;; line 2 has an error and a warning -> error wins
+              (expect (cdr (assq 2 tints))
+                      :to-be 'flycheck-annotate-error-background)
+              (expect (cdr (assq 4 tints))
+                      :to-be 'flycheck-annotate-warning-background))))))
+
+    (it "tints error lines even when their message style is nil"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (goto-char (point-min))
+          (forward-line 1)              ; point on line 2
+          (let ((flycheck-annotate-background t)
+                (flycheck-annotate-other-lines-style nil))
+            (flycheck-annotate-mode 1)
+            ;; line 4 gets no message, but is still tinted
+            (expect (assq 4 (test-annotate/anchors)) :to-be nil)
+            (expect (cdr (assq 4 (test-annotate/tints)))
+                    :to-be 'flycheck-annotate-warning-background)))))
+
+    (it "spans the whole line so the tint extends past the text"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (let ((flycheck-annotate-background t))
+            (flycheck-annotate-mode 1)
+            (let ((ov (seq-find
+                       (lambda (o)
+                         (and (overlay-get o 'face)
+                              (= 4 (line-number-at-pos (overlay-start o)))))
+                       flycheck-annotate--overlays)))
+              (goto-char (overlay-start ov))
+              (expect (overlay-start ov) :to-equal (line-beginning-position))
+              (expect (overlay-end ov) :to-equal (1+ (line-end-position))))))))))
 
 ;;; test-annotate.el ends here


### PR DESCRIPTION
Follow-up to #2202. Adds `flycheck-annotate-background`: when enabled, `flycheck-annotate-mode` gives each error line a subtle whole-line background in its severity colour, the way VS Code's Error Lens does.

The tint is independent of the message style, so it applies to every visible error line even when the other-lines style is nil. Off by default, with `flycheck-annotate-{error,warning,info}-background` faces (each `:extend t` so the tint reaches the window edge).
