### PR TITLE
Add a right-aligned sideline annotation style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 ``master`` (unreleased)
 =======================
 
+- [#2204]: ``flycheck-annotate-mode`` gains a ``sideline`` style that flushes the
+  compact message to the window's right edge, in the manner of
+  ``lsp-ui-sideline``.  Set ``flycheck-annotate-current-line-style`` or
+  ``flycheck-annotate-other-lines-style`` to ``sideline`` to use it.
 - [#2203]: ``flycheck-annotate-mode`` can now tint the whole line of each error
   with a subtle background in its severity colour, in the spirit of VS Code's
   Error Lens.  Set ``flycheck-annotate-background`` to enable it; the tint

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -271,6 +271,11 @@ competing for attention.
       Lay the full messages out on their own lines underneath the code, one
       per error, each pointing at its column.
 
+   ``sideline``
+      Like ``eol``, but flush the message to the window's right edge, the way
+      ``lsp-ui-sideline`` does.  When the code leaves no room, the message
+      simply follows it.
+
    ``nil``
       Do not annotate those lines.  Setting ``flycheck-annotate-other-lines-style``
       to ``nil`` annotates only the line at point, the way Neovim and Helix

--- a/flycheck.el
+++ b/flycheck.el
@@ -7286,7 +7286,8 @@ Used only when `flycheck-annotate-background' is non-nil."
 
 (defcustom flycheck-annotate-style-functions
   '((eol . flycheck-annotate-eol-style)
-    (below . flycheck-annotate-below-style))
+    (below . flycheck-annotate-below-style)
+    (sideline . flycheck-annotate-sideline-style))
   "Alist mapping inline display styles to their renderers.
 
 Each entry is a cons cell (STYLE . FUNCTION) where STYLE is a symbol
@@ -7309,12 +7310,13 @@ Add to this alist to register additional styles."
   "Inline display style for the line at point.
 
 A style symbol resolved through `flycheck-annotate-style-functions'
-\(`below' or `eol' out of the box), or nil to leave the current line
-unannotated.  See `flycheck-annotate-other-lines-style' for every other
-line."
+\(`below', `eol' or `sideline' out of the box), or nil to leave the
+current line unannotated.  See `flycheck-annotate-other-lines-style' for
+every other line."
   :group 'flycheck
   :type '(choice (const :tag "Full messages below the line" below)
                  (const :tag "Compact message at end of line" eol)
+                 (const :tag "Compact message at the right edge" sideline)
                  (const :tag "Do not annotate the current line" nil)
                  (symbol :tag "Other style"))
   :package-version '(flycheck . "38"))
@@ -7323,12 +7325,14 @@ line."
   "Inline display style for lines other than the one at point.
 
 A style symbol resolved through `flycheck-annotate-style-functions'
-\(`below' or `eol' out of the box), or nil to annotate only the line at
-point (the way Neovim and Helix show diagnostics for the cursor line
-only).  See `flycheck-annotate-current-line-style' for the line at point."
+\(`below', `eol' or `sideline' out of the box), or nil to annotate only
+the line at point (the way Neovim and Helix show diagnostics for the
+cursor line only).  See `flycheck-annotate-current-line-style' for the
+line at point."
   :group 'flycheck
   :type '(choice (const :tag "Compact message at end of line" eol)
                  (const :tag "Full messages below the line" below)
+                 (const :tag "Compact message at the right edge" sideline)
                  (const :tag "Annotate only the line at point" nil)
                  (symbol :tag "Other style"))
   :package-version '(flycheck . "38"))
@@ -7454,17 +7458,36 @@ per render so the font probe stays out of the per-error loop."
             "\N{BOX DRAWINGS LIGHT UP AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL} ")
     (cons "`- " "`- ")))
 
+(defun flycheck-annotate--compact-text (errors)
+  "Return the one-line summary of ERRORS for the compact styles.
+
+Shows the most severe error's message (ERRORS is sorted most-severe
+first) with a count of the rest, propertized with its level face."
+  (let* ((err (car errors))
+         (face (flycheck-annotate--level-face (flycheck-error-level err)))
+         (more (when (cdr errors) (format " (+%d)" (length (cdr errors)))))
+         (msg (funcall flycheck-annotate-format-function err)))
+    (propertize (concat msg more) 'face face)))
+
 (defun flycheck-annotate-eol-style (errors anchor _focused)
   "Render ERRORS as a compact message after the line ending at ANCHOR.
 
 Only the most severe error's message is shown, with a count of the rest.
 FOCUSED is ignored."
-  (let* ((err (car errors))
-         (face (flycheck-annotate--level-face (flycheck-error-level err)))
-         (msg (funcall flycheck-annotate-format-function err))
-         (more (when (cdr errors) (format " (+%d)" (length (cdr errors)))))
-         (text (propertize (concat "  " msg more) 'face face)))
-    (flycheck-annotate--make-overlay anchor 'after-string text)))
+  (flycheck-annotate--make-overlay
+   anchor 'after-string (concat "  " (flycheck-annotate--compact-text errors))))
+
+(defun flycheck-annotate-sideline-style (errors anchor _focused)
+  "Render ERRORS flushed to the window's right edge past line ANCHOR.
+
+Like `flycheck-annotate-eol-style', but the message is right-aligned with
+a stretch of whitespace, in the manner of `lsp-ui-sideline'.  When the
+code on the line is too long to leave room, the message simply follows it
+instead.  FOCUSED is ignored."
+  (let* ((text (flycheck-annotate--compact-text errors))
+         (width (string-width text))
+         (spacer (propertize " " 'display `(space :align-to (- right ,width)))))
+    (flycheck-annotate--make-overlay anchor 'after-string (concat spacer text))))
 
 (defun flycheck-annotate-below-style (errors anchor _focused)
   "Render ERRORS on their own lines below the line ending at ANCHOR.

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -120,6 +120,45 @@ Line 2 gets an error and a warning; line 4 gets a warning."
           ;; leading newline plus one line per error
           (expect (length (split-string s "\n")) :to-equal 3)))))
 
+  (describe "flycheck-annotate-sideline-style"
+    (it "right-aligns the compact message with an align-to spacer"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abcdef\n")
+        (let* ((errs (list (flycheck-error-new-at 1 1 'error "big"
+                                                  :checker 'emacs-lisp)
+                           (flycheck-error-new-at 1 2 'warning "small"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate-sideline-style errs (line-end-position) nil))
+               (s (overlay-get ov 'after-string)))
+          ;; most severe message plus a count, no leading newline
+          (expect (substring-no-properties s) :to-match "big")
+          (expect (substring-no-properties s) :to-match (regexp-quote "(+1)"))
+          (expect (string-prefix-p "\n" s) :to-be nil)
+          ;; the leading char is a right-aligning stretch of whitespace
+          (expect (car (get-text-property 0 'display s)) :to-be 'space)
+          (expect (get-text-property 0 'display s)
+                  :to-equal '(space :align-to (- right 8)))))) ; width of "big (+1)"
+
+    (it "is registered as a built-in style"
+      (expect (cdr (assq 'sideline flycheck-annotate-style-functions))
+              :to-be 'flycheck-annotate-sideline-style))
+
+    (it "renders on the current line when selected as the style"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (goto-char (point-min))
+          (forward-line 1)              ; line 2
+          (let ((flycheck-annotate-current-line-style 'sideline)
+                (flycheck-annotate-other-lines-style nil))
+            (flycheck-annotate-mode 1)
+            (let* ((ov (seq-find (lambda (o) (overlay-get o 'after-string))
+                                 flycheck-annotate--overlays))
+                   (s (overlay-get ov 'after-string)))
+              (expect (car (get-text-property 0 'display s)) :to-be 'space)))))))
+
   (describe "flycheck-annotate--make-overlay"
     (it "tags and tracks the overlay"
       (flycheck-buttercup-with-temp-buffer


### PR DESCRIPTION
Follow-up to #2202. Adds a third annotation style, `sideline`, that flushes the compact error message to the window's right edge, the way `lsp-ui-sideline` does. Set `flycheck-annotate-current-line-style` or `flycheck-annotate-other-lines-style` to `sideline` to use it.

It uses a `(space :align-to (- right N))` stretch to right-align; when the code on the line leaves no room, the message just follows it. The `eol` and `sideline` styles share a small helper for the "most severe message plus a count" summary.
