### PR TITLE
Align below-style connectors to the display column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 ``master`` (unreleased)
 =======================
 
+- [#2205]: ``flycheck-annotate-mode``'s ``below`` style now aligns each message's
+  connector to the error's real display column, so it lines up correctly under
+  tab-indented code and past a line-number gutter.
 - [#2204]: ``flycheck-annotate-mode`` gains a ``sideline`` style that flushes the
   compact message to the window's right edge, in the manner of
   ``lsp-ui-sideline``.  Set ``flycheck-annotate-current-line-style`` or

--- a/flycheck.el
+++ b/flycheck.el
@@ -7489,22 +7489,37 @@ instead.  FOCUSED is ignored."
          (spacer (propertize " " 'display `(space :align-to (- right ,width)))))
     (flycheck-annotate--make-overlay anchor 'after-string (concat spacer text))))
 
+(defun flycheck-annotate--display-column (err bol eol)
+  "Return the display column of ERR's start on the line from BOL to EOL.
+
+Uses the display column (via `current-column'), so tabs and other wide
+characters before the error are accounted for.  The error's column is
+clamped to the line so a checker column past the end still lands on it."
+  (let ((offset (min (1- (max 1 (or (flycheck-error-column err) 1)))
+                     (- eol bol))))
+    (save-excursion
+      (goto-char bol)
+      (forward-char offset)
+      (current-column))))
+
 (defun flycheck-annotate-below-style (errors anchor _focused)
   "Render ERRORS on their own lines below the line ending at ANCHOR.
 
-Each error gets its own message, prefixed with a connector padded to its
-column.  FOCUSED is ignored."
+Each error gets its own message, prefixed with a connector aligned under
+its column.  Alignment uses a `:align-to' stretch measured in display
+columns, so it lines up under tab-indented code and past a line-number
+gutter.  FOCUSED is ignored."
   (let* ((n (length errors))
          (i 0)
          (connectors (flycheck-annotate--connectors))
+         (bol (save-excursion (goto-char anchor) (line-beginning-position)))
          (lines nil))
     (dolist (err errors)
       (setq i (1+ i))
-      ;; Pad with spaces to the error's column.  Lines indented with tabs
-      ;; won't align exactly, since the synthetic line has no tabs to
-      ;; measure against; this is close enough and only cosmetic.
-      (let* ((col (max 0 (1- (or (flycheck-error-column err) 1))))
-             (pad (make-string col ?\s))
+      (let* ((col (flycheck-annotate--display-column err bol anchor))
+             (pad (if (> col 0)
+                      (propertize " " 'display `(space :align-to ,col))
+                    ""))
              (face (flycheck-annotate--level-face (flycheck-error-level err)))
              (conn (propertize (if (= i n) (cdr connectors) (car connectors))
                                'face 'flycheck-annotate-connector))

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -107,18 +107,46 @@ Line 2 gets an error and a warning; line 4 gets a warning."
     (it "stacks each message on its own line under the code"
       (flycheck-buttercup-with-temp-buffer
         (insert "abcdef\n")
-        (let* ((errs (list (flycheck-error-new-at 1 3 'error "one"
+        (let* ((eol (save-excursion (goto-char (point-min)) (line-end-position)))
+               (errs (list (flycheck-error-new-at 1 3 'error "one"
                                                   :checker 'emacs-lisp)
                            (flycheck-error-new-at 1 1 'warning "two"
                                                   :checker 'emacs-lisp)))
                (flycheck-annotate--overlays nil)
-               (ov (flycheck-annotate-below-style errs (line-end-position) t))
+               (ov (flycheck-annotate-below-style errs eol t))
                (s (substring-no-properties (overlay-get ov 'after-string))))
           (expect (string-prefix-p "\n" s) :to-be t)
           (expect s :to-match "one")
           (expect s :to-match "two")
           ;; leading newline plus one line per error
-          (expect (length (split-string s "\n")) :to-equal 3)))))
+          (expect (length (split-string s "\n")) :to-equal 3))))
+
+    (it "aligns the connector to the error's display column past a tab"
+      (flycheck-buttercup-with-temp-buffer
+        (setq-local tab-width 8)
+        (insert "\tx = 1\n")               ; one tab, then code
+        (let* ((eol (save-excursion (goto-char (point-min)) (line-end-position)))
+               ;; column 2 is the "x" right after the tab
+               (errs (list (flycheck-error-new-at 1 2 'error "m"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate-below-style errs eol t))
+               (s (overlay-get ov 'after-string)))
+          ;; the pad after the newline aligns to display column 8, not 1
+          (expect (get-text-property 1 'display s)
+                  :to-equal '(space :align-to 8)))))
+
+    (it "adds no pad for an error in the first column"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abc\n")
+        (let* ((eol (save-excursion (goto-char (point-min)) (line-end-position)))
+               (errs (list (flycheck-error-new-at 1 1 'error "m"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate-below-style errs eol t))
+               (s (overlay-get ov 'after-string)))
+          ;; char 1 is the connector itself, no stretch space
+          (expect (get-text-property 1 'display s) :to-be nil)))))
 
   (describe "flycheck-annotate-sideline-style"
     (it "right-aligns the compact message with an align-to spacer"


### PR DESCRIPTION
Follow-up to #2202. The `below` annotation style padded each connector with literal spaces counted from the error's character column, so under tab-indented code the connector landed in the wrong spot.

Now it computes the error's display column with `current-column` and aligns the connector with a `(space :align-to COL)` stretch, so it lines up correctly under tabs and past a line-number gutter.
