### PR TITLE
Filter inline annotations per tier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``master`` (unreleased)
 =======================
 
+- [#2206]: ``flycheck-annotate-mode`` can now filter annotations per tier:
+  ``flycheck-annotate-current-line-levels`` and
+  ``flycheck-annotate-other-lines-levels`` restrict the line at point and the
+  other lines independently (each inheriting ``flycheck-annotate-levels`` by
+  default), so the focused line can show every level while the rest show only
+  errors, the way Helix limits its non-cursor lines.
 - [#2205]: ``flycheck-annotate-mode``'s ``below`` style now aligns each message's
   connector to the error's real display column, so it lines up correctly under
   tab-indented code and past a line-number gutter.

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -286,9 +286,19 @@ competing for attention.
 
 .. defcustom:: flycheck-annotate-levels
 
-   The error levels to display inline, either ``t`` for all levels or a list of
-   level symbols such as ``'(error warning)``.  Errors of other levels are
-   still highlighted and listed; they just get no inline annotation.
+   The base error levels to display inline, either ``t`` for all levels or a
+   list of level symbols such as ``'(error warning)``.  Errors of other levels
+   are still highlighted and listed; they just get no inline annotation.
+
+.. defcustom:: flycheck-annotate-current-line-levels
+               flycheck-annotate-other-lines-levels
+
+   Per-tier level filters for the line at point and for every other line.  Each
+   is either ``t`` to inherit ``flycheck-annotate-levels`` or a list of level
+   symbols to restrict that tier further.  Setting
+   ``flycheck-annotate-other-lines-levels`` to ``'(error)`` shows only errors
+   away from point while the line at point still shows everything, the way Helix
+   limits its non-cursor lines.
 
 .. defcustom:: flycheck-annotate-suppress-echo
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -7343,9 +7343,36 @@ line at point."
 Either t to display errors of every level, or a list of level symbols
 \(e.g. \\='(error warning)) to restrict the inline display to those
 levels.  Errors of other levels are still highlighted and listed as
-usual; they just get no inline annotation."
+usual; they just get no inline annotation.
+
+This is the base filter for both tiers; `flycheck-annotate-current-line-levels'
+and `flycheck-annotate-other-lines-levels' can narrow it per tier."
   :group 'flycheck
   :type '(choice (const :tag "All levels" t)
+                 (repeat :tag "Only these levels" symbol))
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-annotate-current-line-levels t
+  "Error levels to annotate on the line at point.
+
+Either t to inherit `flycheck-annotate-levels', or a list of level
+symbols to restrict the line at point to those levels.  Together with
+`flycheck-annotate-other-lines-levels' this lets the focused line show
+more levels than the rest."
+  :group 'flycheck
+  :type '(choice (const :tag "Inherit flycheck-annotate-levels" t)
+                 (repeat :tag "Only these levels" symbol))
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-annotate-other-lines-levels t
+  "Error levels to annotate on lines other than the one at point.
+
+Either t to inherit `flycheck-annotate-levels', or a list of level
+symbols to restrict the other lines to those levels.  Set to
+\\='(error) to show only errors away from point, the way Helix limits
+its non-cursor lines."
+  :group 'flycheck
+  :type '(choice (const :tag "Inherit flycheck-annotate-levels" t)
                  (repeat :tag "Only these levels" symbol))
   :package-version '(flycheck . "38"))
 
@@ -7534,12 +7561,22 @@ gutter.  FOCUSED is ignored."
   (mapc #'delete-overlay flycheck-annotate--overlays)
   (setq flycheck-annotate--overlays nil))
 
-(defun flycheck-annotate--filter-levels (errors)
-  "Keep the ERRORS whose level is enabled by `flycheck-annotate-levels'."
-  (if (eq flycheck-annotate-levels t)
+(defun flycheck-annotate--effective-levels (tier)
+  "Resolve a per-tier levels setting TIER to a concrete filter.
+
+TIER is `flycheck-annotate-current-line-levels' or
+`flycheck-annotate-other-lines-levels'; t inherits
+`flycheck-annotate-levels'."
+  (if (eq tier t) flycheck-annotate-levels tier))
+
+(defun flycheck-annotate--filter-levels (errors levels)
+  "Keep the ERRORS whose level is a member of LEVELS.
+
+LEVELS is t (keep all) or a list of level symbols."
+  (if (eq levels t)
       errors
     (seq-filter (lambda (err)
-                  (memq (flycheck-error-level err) flycheck-annotate-levels))
+                  (memq (flycheck-error-level err) levels))
                 errors)))
 
 (defun flycheck-annotate--region ()
@@ -7593,17 +7630,23 @@ anything."
                 (point-anchor (line-end-position)))
       (pcase-dolist (`(,anchor . ,errors)
                      (flycheck-annotate--group-errors beg end))
-        (when-let* ((errors (flycheck-annotate--filter-levels errors)))
-          (setq errors (sort errors #'flycheck--excessive-errors-<))
-          ;; The tint applies to every filtered error line, independent of
-          ;; the message style, so it survives an other-lines style of nil.
-          (when flycheck-annotate-background
-            (flycheck-annotate--tint-line
-             anchor (flycheck-error-level (car errors))))
-          (let* ((focused (= anchor point-anchor))
-                 (style (if focused
-                            flycheck-annotate-current-line-style
-                          flycheck-annotate-other-lines-style)))
+        ;; The tier (focused vs not) selects both the style and the level
+        ;; filter, so a line can show more levels at point than elsewhere.
+        (let* ((focused (= anchor point-anchor))
+               (levels (flycheck-annotate--effective-levels
+                        (if focused
+                            flycheck-annotate-current-line-levels
+                          flycheck-annotate-other-lines-levels)))
+               (style (if focused
+                          flycheck-annotate-current-line-style
+                        flycheck-annotate-other-lines-style)))
+          (when-let* ((errors (flycheck-annotate--filter-levels errors levels)))
+            (setq errors (sort errors #'flycheck--excessive-errors-<))
+            ;; The tint applies to every filtered error line, independent of
+            ;; the message style, so it survives an other-lines style of nil.
+            (when flycheck-annotate-background
+              (flycheck-annotate--tint-line
+               anchor (flycheck-error-level (car errors))))
             (when-let* ((render (cdr (assq style
                                            flycheck-annotate-style-functions))))
               (funcall render errors anchor focused))))))))
@@ -7622,7 +7665,7 @@ annotations are otherwise unaffected by point motion within a line."
 
 Only suppresses when the errors at point would actually be rendered
 inline, so an error that the inline display drops (because its level is
-disabled by `flycheck-annotate-levels', or it belongs to another file) is
+disabled for the current-line tier, or it belongs to another file) is
 still shown through the echo area rather than nowhere."
   (and (bound-and-true-p flycheck-annotate-mode)
        flycheck-annotate-suppress-echo
@@ -7630,7 +7673,9 @@ still shown through the echo area rather than nowhere."
        (seq-some (lambda (err)
                    (not (flycheck-relevant-error-other-file-p err)))
                  (flycheck-annotate--filter-levels
-                  (flycheck-overlay-errors-at (point))))))
+                  (flycheck-overlay-errors-at (point))
+                  (flycheck-annotate--effective-levels
+                   flycheck-annotate-current-line-levels)))))
 
 ;;;###autoload
 (define-minor-mode flycheck-annotate-mode

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -76,17 +76,25 @@ Line 2 gets an error and a warning; line 4 gets a warning."
       (expect (flycheck-annotate--level-face 'info) :to-be 'flycheck-annotate-info)))
 
   (describe "flycheck-annotate--filter-levels"
-    (it "keeps every error when set to t"
-      (let ((flycheck-annotate-levels t)
-            (errs (list (flycheck-error-new-at 1 1 'error)
+    (it "keeps every error when levels is t"
+      (let ((errs (list (flycheck-error-new-at 1 1 'error)
                         (flycheck-error-new-at 1 1 'warning))))
-        (expect (flycheck-annotate--filter-levels errs) :to-equal errs)))
+        (expect (flycheck-annotate--filter-levels errs t) :to-equal errs)))
     (it "keeps only errors of the listed levels"
-      (let* ((flycheck-annotate-levels '(error))
-             (err (flycheck-error-new-at 1 1 'error))
+      (let* ((err (flycheck-error-new-at 1 1 'error))
              (warn (flycheck-error-new-at 1 1 'warning)))
-        (expect (flycheck-annotate--filter-levels (list err warn))
+        (expect (flycheck-annotate--filter-levels (list err warn) '(error))
                 :to-equal (list err)))))
+
+  (describe "flycheck-annotate--effective-levels"
+    (it "inherits flycheck-annotate-levels when the tier is t"
+      (let ((flycheck-annotate-levels '(error warning)))
+        (expect (flycheck-annotate--effective-levels t)
+                :to-equal '(error warning))))
+    (it "uses the tier's own levels when it is a list"
+      (let ((flycheck-annotate-levels t))
+        (expect (flycheck-annotate--effective-levels '(error))
+                :to-equal '(error)))))
 
   (describe "flycheck-annotate-eol-style"
     (it "shows the most severe message and a count of the rest"
@@ -258,6 +266,33 @@ Line 2 gets an error and a warning; line 4 gets a warning."
           (let ((anchors (test-annotate/anchors)))
             (expect (string-prefix-p "\n" (cdr (assq 4 anchors))) :to-be t)
             (expect (string-prefix-p "\n" (cdr (assq 2 anchors))) :to-be nil))))))
+
+  (describe "per-tier level filtering"
+    (it "can restrict other lines to a stricter level set than point"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (insert "aa\nbb\ncc\ndd\n")
+          (setq-local flycheck-mode t)
+          (let ((w2 (flycheck-error-new-at 2 1 'warning "w2"
+                                           :buffer (current-buffer)
+                                           :checker 'emacs-lisp))
+                (w4 (flycheck-error-new-at 4 1 'warning "w4"
+                                           :buffer (current-buffer)
+                                           :checker 'emacs-lisp)))
+            (setq flycheck-current-errors (list w2 w4))
+            (mapc #'flycheck-add-overlay flycheck-current-errors))
+          (goto-char (point-min))
+          (forward-line 1)              ; point on line 2
+          (let ((flycheck-annotate-current-line-style 'eol)
+                (flycheck-annotate-other-lines-style 'eol)
+                (flycheck-annotate-other-lines-levels '(error)))
+            (flycheck-annotate-mode 1)
+            (let ((anchors (test-annotate/anchors)))
+              ;; the current line's warning shows; the other line's warning,
+              ;; excluded by the stricter other-lines filter, does not
+              (expect (assq 2 anchors) :not :to-be nil)
+              (expect (assq 4 anchors) :to-be nil)))))))
 
   (describe "flycheck-annotate-mode"
     (it "clears the overlays when disabled"


### PR DESCRIPTION
Follow-up to #2202. Lets `flycheck-annotate-mode` filter which levels it annotates separately for the line at point and for the other lines, via `flycheck-annotate-current-line-levels` and `flycheck-annotate-other-lines-levels`.

Each inherits `flycheck-annotate-levels` by default, so the focused line can show every level while the rest show only errors, the way Helix limits its non-cursor lines.
