### PR TITLE
Mark fixable errors with a distinct indicator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 ``master`` (unreleased)
 =======================
 
+- [#2208]: A line whose error carries a fix now gets a distinct fringe bitmap or
+  margin string, in the error's colour, so fixable errors stand out like an
+  editor's "fix available" lightbulb.  Customize ``flycheck-fixable-indicator``
+  to turn it off.
 - [#2207]: ``C-c ! F`` (``flycheck-fix-all-errors``) applies every machine-applicable
   fix in the buffer at once, as a single undoable change, skipping fixes that
   would conflict; ``X`` does the same from the error list.  ``flycheck-annotate-mode``

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -193,6 +193,17 @@ automatically, and restores it when you disable ``flycheck-mode``.  Margins
 that you or other packages configured are never touched, and neither are the
 fringes.
 
+A line whose error carries a machine-applicable fix (``C-c ! f``) gets a
+distinct indicator, in the error's colour, so you can spot fixable errors at a
+glance, much like an editor's "fix available" lightbulb.
+
+.. defcustom:: flycheck-fixable-indicator
+
+   When non-nil (the default) and indicators are shown, a fixable error's line
+   uses a distinct fringe bitmap or margin string
+   (``flycheck-fixable-margin-str``) instead of the usual level indicator.  Set
+   to nil to use the same indicator for fixable and non-fixable errors.
+
 To switch the indication mode interactively in the current buffer, use
 ``M-x flycheck-set-indication-mode``.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -609,6 +609,20 @@ highlight them according to `flycheck-highlighting-mode'."
   :safe #'symbolp
   :package-version '(flycheck . "37"))
 
+(defcustom flycheck-fixable-indicator t
+  "Whether to mark lines whose error carries a fix with a distinct indicator.
+
+When non-nil and `flycheck-indication-mode' shows indicators, a line
+whose error has a machine-applicable fix (applicable with
+\\[flycheck-fix-error-at-point]) uses a distinct fringe bitmap or margin
+string in the error's colour, in the spirit of an editor's \"fix
+available\" lightbulb.  Set to nil to use the usual level indicator for
+fixable and non-fixable errors alike."
+  :group 'flycheck
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38"))
+
 (defcustom flycheck-highlighting-mode 'symbols
   "The highlighting mode for Flycheck errors and warnings.
 
@@ -5071,6 +5085,9 @@ Returns MARGIN-STR with FACE applied."
 (defconst flycheck-default-margin-str "»"
   "String used to indicate errors in the margins.")
 
+(defconst flycheck-fixable-margin-str "●"
+  "String marking a line whose error carries a fix, in the margins.")
+
 (defconst flycheck-default-margin-continuation-str "⋮"
   "String used to indicate continuation lines in the margins.")
 
@@ -5199,7 +5216,7 @@ will be the high resolution version."
   "Get the error list face for LEVEL."
   (get level 'flycheck-error-list-face))
 
-(defun flycheck-error-level-make-indicator (level side &optional continuation)
+(defun flycheck-error-level-make-indicator (level side &optional continuation fixable)
   "Create the fringe or margin icon for LEVEL at SIDE.
 
 Return a propertized string that shows an indicator according
@@ -5214,6 +5231,11 @@ either the `:fringe-bitmap' and `:margin-spec' properties of
 LEVEL when CONTINUATION is nil or omitted, or bitmaps and specs
 indicating an error spanning more than one line.
 
+FIXABLE non-nil marks a line whose error carries a fix: the
+indicator uses the distinct `flycheck-fringe-bitmap-fixable' bitmap
+or `flycheck-fixable-margin-str' string, kept in LEVEL's colour.
+CONTINUATION takes precedence over FIXABLE.
+
 Return a propertized string representing the fringe icon,
 intended for use as `before-string' of an overlay to actually
 show the indicator."
@@ -5221,20 +5243,26 @@ show the indicator."
    "!" 'display
    (pcase side
      ((or `left-fringe `right-fringe)
-      (list side
-            (if continuation 'flycheck-fringe-bitmap-continuation
-              (let* ((fringe-width
-                      (pcase side
-                        (`left-fringe (car (window-fringes)))
-                        (`right-fringe (cadr (window-fringes)))))
-                     (high-res (>= fringe-width 16)))
-                (flycheck-error-level-fringe-bitmap level high-res)))
-            (flycheck-error-level-fringe-face level)))
+      (let* ((fringe-width
+              (pcase side
+                (`left-fringe (car (window-fringes)))
+                (`right-fringe (cadr (window-fringes)))))
+             (high-res (>= fringe-width 16)))
+        (list side
+              (cond
+               (continuation 'flycheck-fringe-bitmap-continuation)
+               (fixable (if high-res 'flycheck-fringe-bitmap-fixable-hi-res
+                          'flycheck-fringe-bitmap-fixable))
+               (t (flycheck-error-level-fringe-bitmap level high-res)))
+              (flycheck-error-level-fringe-face level))))
      ((or `left-margin `right-margin)
       `((margin ,side)
-        ,(or (if continuation
-                 (flycheck-error-level-margin-continuation-spec level)
-               (flycheck-error-level-margin-spec level))
+        ,(or (cond
+              (continuation (flycheck-error-level-margin-continuation-spec level))
+              (fixable (flycheck-make-margin-spec
+                        flycheck-fixable-margin-str
+                        (flycheck-error-level-fringe-face level)))
+              (t (flycheck-error-level-margin-spec level)))
              "")))
      (_ (error "Invalid fringe side: %S" side)))))
 
@@ -5298,6 +5326,33 @@ show the indicator."
    #b0000001000000010]
   "Bitmap used to indicate continuation lines in the fringes.")
 
+(defconst flycheck-fringe-bitmap-fixable
+  [#b00111100
+   #b01111110
+   #b11111111
+   #b11111111
+   #b11111111
+   #b01111110
+   #b00111100]
+  "Bitmap marking a line whose error carries a fix, in the fringes.")
+
+(defconst flycheck-fringe-bitmap-fixable-hi-res
+  [#b0000001111000000
+   #b0000111111110000
+   #b0001111111111000
+   #b0011111111111100
+   #b0111111111111110
+   #b0111111111111110
+   #b1111111111111111
+   #b1111111111111111
+   #b0111111111111110
+   #b0111111111111110
+   #b0011111111111100
+   #b0001111111111000
+   #b0000111111110000
+   #b0000001111000000]
+  "High-resolution bitmap marking a fixable line in the fringes.")
+
 (when (fboundp 'define-fringe-bitmap) ;; #ifdef HAVE_WINDOW_SYSTEM
   (define-fringe-bitmap
     'flycheck-fringe-bitmap-double-arrow
@@ -5316,7 +5371,14 @@ show the indicator."
   (define-fringe-bitmap
     'flycheck-fringe-bitmap-continuation
     flycheck-fringe-bitmap-continuation
-    nil 16 '(top repeat)))
+    nil 16 '(top repeat))
+  (define-fringe-bitmap
+    'flycheck-fringe-bitmap-fixable
+    flycheck-fringe-bitmap-fixable)
+  (define-fringe-bitmap
+    'flycheck-fringe-bitmap-fixable-hi-res
+    flycheck-fringe-bitmap-fixable-hi-res
+    nil 16))
 
 (defun flycheck-redefine-standard-error-levels
     (&optional margin-str fringe-bitmap)
@@ -5657,8 +5719,12 @@ function resolves `conditional' style specifications."
       ;; Erase the highlighting from the overlay if requested by the user
       (setf (overlay-get overlay 'face) nil))
     (when-let* ((side (flycheck--resolve-indication-mode)))
-      (setf (overlay-get overlay 'before-string)
-            (flycheck-error-level-make-indicator level side))
+      (let ((fixable (and flycheck-fixable-indicator
+                          (flycheck-error-fix err)
+                          (flycheck--error-fix-buffer err)
+                          t)))
+        (setf (overlay-get overlay 'before-string)
+              (flycheck-error-level-make-indicator level side nil fixable)))
       (setf (overlay-get overlay 'wrap-prefix)
             (flycheck-error-level-make-indicator level side t))
       ;; Preserve existing text-property prefixes so the overlay doesn't

--- a/test/specs/test-error-levels.el
+++ b/test/specs/test-error-levels.el
@@ -99,7 +99,28 @@
     (it "rejects an invalid side"
       (let ((err (should-error (flycheck-error-level-make-indicator
                                 'test-level 'up-fringe))))
-        (expect (cadr err) :to-equal "Invalid fringe side: up-fringe"))))
+        (expect (cadr err) :to-equal "Invalid fringe side: up-fringe")))
+
+    (it "uses the fixable fringe bitmap when FIXABLE"
+      (pcase-let* ((icon (flycheck-error-level-make-indicator
+                          'test-level 'left-fringe nil t))
+                   (`(_ ,bitmap ,face) (get-text-property 0 'display icon)))
+        (expect bitmap :to-be 'flycheck-fringe-bitmap-fixable)
+        ;; the level's own colour is kept
+        (expect face :to-be 'highlight)))
+
+    (it "uses the fixable margin string when FIXABLE"
+      (pcase-let* ((icon (flycheck-error-level-make-indicator
+                          'test-level 'left-margin nil t))
+                   (`(_ ,spec) (get-text-property 0 'display icon)))
+        (expect (substring-no-properties spec)
+                :to-equal flycheck-fixable-margin-str)))
+
+    (it "lets continuation take precedence over FIXABLE"
+      (pcase-let* ((icon (flycheck-error-level-make-indicator
+                          'test-level 'left-fringe t t))
+                   (`(_ ,bitmap _) (get-text-property 0 'display icon)))
+        (expect bitmap :to-be 'flycheck-fringe-bitmap-continuation))))
 
   (describe "Built-in error levels"
     (describe "flycheck-error-level-error"

--- a/test/specs/test-overlays.el
+++ b/test/specs/test-overlays.el
@@ -170,6 +170,43 @@
             (expect face :to-be 'flycheck-fringe-error)
             (expect bitmap :to-be 'flycheck-fringe-bitmap-double-arrow)))))
 
+    (it "marks a fixable error with the fixable fringe bitmap"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "Hello\n    World")
+        (let ((flycheck-indication-mode 'left-fringe))
+          (pcase-let* ((err (flycheck-error-new-at
+                             1 1 'error nil :buffer (current-buffer)
+                             :fix (flycheck-fix-new
+                                   :edits (list (flycheck-fix-edit-new
+                                                 :line 1 :column 1
+                                                 :end-line 1 :end-column 2
+                                                 :replacement "x")))))
+                       (overlay (flycheck-add-overlay err))
+                       (`(_ ,bitmap ,face)
+                        (get-text-property
+                         0 'display (overlay-get overlay 'before-string))))
+            (expect bitmap :to-be 'flycheck-fringe-bitmap-fixable)
+            ;; the error's own colour is kept
+            (expect face :to-be 'flycheck-fringe-error)))))
+
+    (it "uses the normal bitmap for a fixable error when the indicator is off"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "Hello\n    World")
+        (let ((flycheck-indication-mode 'left-fringe)
+              (flycheck-fixable-indicator nil))
+          (pcase-let* ((err (flycheck-error-new-at
+                             1 1 'error nil :buffer (current-buffer)
+                             :fix (flycheck-fix-new
+                                   :edits (list (flycheck-fix-edit-new
+                                                 :line 1 :column 1
+                                                 :end-line 1 :end-column 2
+                                                 :replacement "x")))))
+                       (overlay (flycheck-add-overlay err))
+                       (`(_ ,bitmap _)
+                        (get-text-property
+                         0 'display (overlay-get overlay 'before-string))))
+            (expect bitmap :to-be 'flycheck-fringe-bitmap-double-arrow)))))
+
     (it "has a left fringe icon"
       (flycheck-buttercup-with-temp-buffer
         (insert "Hello\n    World")


### PR DESCRIPTION
Follow-up to #2207. A line whose error carries a machine-applicable fix now gets a distinct fringe bitmap (a filled dot) or margin string, in the error's colour, so fixable errors stand out at a glance, much like an editor's "fix available" lightbulb.

`flycheck-error-level-make-indicator` gained a FIXABLE argument that swaps the bitmap/string while keeping the level's colour (continuation lines still take precedence). `flycheck-fixable-indicator` turns it off.
