### PR TITLE
Report Eglot's LSP diagnostics through Flycheck

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 ``master`` (unreleased)
 =======================
 
+- [#2209]: Flycheck now integrates with Eglot out of the box.  Enable
+  ``global-flycheck-eglot-mode`` to report an LSP server's diagnostics (as seen
+  by Eglot) through Flycheck via the new ``eglot-check`` checker, so a buffer
+  can use Eglot for LSP features while Flycheck owns the error display,
+  navigation and the error list.  ``flycheck-eglot-exclusive`` (on by default)
+  makes it the sole checker, or chains to the command checkers when nil.  This
+  obsoletes the third-party ``flycheck-eglot`` package.
 - [#2208]: A line whose error carries a fix now gets a distinct fringe bitmap or
   margin string, in the error's colour, so fixable errors stand out like an
   editor's "fix available" lightbulb.  Customize ``flycheck-fixable-indicator``

--- a/doc/community/extensions.rst
+++ b/doc/community/extensions.rst
@@ -52,9 +52,12 @@ use Eglot and its maintainer (who's also the maintainer of Flymake) didn't want
 to provide Flycheck integration (backend) for it (see the relevant `discussion
 <https://github.com/joaotavora/eglot/issues/42>`_).
 
-Fortunately, you have options if you want to stick with Flycheck:
+Flycheck now bridges this gap itself: enable ``global-flycheck-eglot-mode`` (see
+:doc:`/user/syntax-checks`) to route Eglot's LSP diagnostics through Flycheck.
+This obsoletes the third-party :flyc:`flycheck-eglot` package.
 
-* :flyc:`flycheck-eglot` (*official*) provides a simple “glue” minor mode that allows Flycheck and Eglot to work together.
+Other options:
+
 * :gh:`doomemacs/doomemacs` has built-in integration for Flycheck and Eglot (that served as foundation for ``flycheck-eglot``)
 * You can use :gh:`emacs-lsp/lsp-mode` (an alternative to Eglot) which has built-in support for Flycheck.
 

--- a/doc/user/flycheck-versus-flymake.rst
+++ b/doc/user/flycheck-versus-flymake.rst
@@ -82,8 +82,8 @@ detail.
 |List of all errors         |yes; filterable by     |yes; project-wide      |
 |                           |error level            |diagnostics (28+)      |
 +---------------------------+-----------------------+-----------------------+
-|`Supported by Eglot`_      |yes, via               |yes (built-in)         |
-|                           |``flycheck-eglot``     |                       |
+|`Supported by Eglot`_      |yes                    |yes (built-in)         |
+|                           |(``flycheck-eglot-mode``)|                     |
 +---------------------------+-----------------------+-----------------------+
 |`Supported by lsp-mode`_   |yes                    |yes                    |
 +---------------------------+-----------------------+-----------------------+
@@ -298,11 +298,11 @@ Supported by Eglot
 Emacs (since version 29).  It uses Flymake internally to display diagnostics
 from the LSP server.
 
-Eglot does not provide built-in Flycheck support, but the
-`flycheck-eglot <https://github.com/flycheck/flycheck-eglot>`_ package bridges
-this gap.  It routes Eglot's LSP diagnostics through Flycheck, so you can use
-Eglot for LSP features while keeping Flycheck for error display, navigation
-and your existing non-LSP checkers.
+Eglot does not provide built-in Flycheck support, but Flycheck bridges the gap
+itself with ``flycheck-eglot-mode`` (see :doc:`syntax-checks`).  It routes
+Eglot's LSP diagnostics through Flycheck, so you can use Eglot for LSP features
+while keeping Flycheck for error display, navigation and your existing non-LSP
+checkers.  This obsoletes the third-party ``flycheck-eglot`` package.
 
 Supported by lsp-mode
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -179,3 +179,37 @@ You can also start a syntax check explicitly with `C-c ! c`:
                 M-x flycheck-buffer
 
    Check syntax in the current buffer.
+
+
+LSP diagnostics via Eglot
+=========================
+
+Eglot, Emacs' built-in LSP client, renders its diagnostics through Flymake and
+provides no Flycheck backend of its own.  ``flycheck-eglot-mode`` bridges the
+gap, so a buffer can use Eglot for LSP features while Flycheck owns the error
+display, navigation and the error list:
+
+.. code-block:: elisp
+
+   (global-flycheck-eglot-mode 1)
+
+.. minor-mode:: flycheck-eglot-mode
+
+   Report the diagnostics Eglot receives from the LSP server through Flycheck,
+   via the ``eglot-check`` checker, and turn Flymake off in the buffer.  Only
+   active in Eglot-managed buffers.
+
+.. minor-mode:: global-flycheck-eglot-mode
+
+   Enable ``flycheck-eglot-mode`` in every Eglot-managed buffer.  This is the
+   usual way to turn the integration on.
+
+.. defcustom:: flycheck-eglot-exclusive
+
+   When non-nil (the default), an Eglot buffer reports only the LSP server's
+   diagnostics.  Set to nil to have ``eglot-check`` chain to the first command
+   checker that supports the buffer's major mode, so an LSP server and a
+   command checker both contribute.
+
+This obsoletes the third-party ``flycheck-eglot`` package; drop it from your
+configuration if you used it.

--- a/flycheck.el
+++ b/flycheck.el
@@ -241,7 +241,9 @@
     xml-xmllint
     yaml-actionlint
     yaml-jsyaml
-    yaml-yamllint)
+    yaml-yamllint
+    ;; Only ever selected when `flycheck-eglot-mode' is on (see its predicate).
+    eglot-check)
   "Syntax checkers available for automatic selection.
 
 A list of Flycheck syntax checkers to choose from when syntax
@@ -10020,6 +10022,242 @@ SYMBOL with `flycheck-def-executable-var'."
              `(:verify #',verify-fn))
          :standard-input ',(plist-get properties :standard-input)
          :working-directory ',(plist-get properties :working-directory)))))
+
+
+;;; Eglot integration
+;;
+;; Eglot, Emacs' built-in LSP client, renders its diagnostics through
+;; Flymake and deliberately offers no Flycheck support.  `flycheck-eglot-mode'
+;; bridges the gap: it feeds the diagnostics an LSP server reports to Eglot
+;; into Flycheck, so a buffer can use Eglot for LSP features while Flycheck
+;; owns the error display, navigation and the error list -- alongside the
+;; usual command checkers.
+;;
+;; This obsoletes the third-party `flycheck-eglot' package.
+;;
+;; Eglot pushes diagnostics whenever the server sends them, which does not
+;; line up with Flycheck's on-demand checking model.  The `eglot-check'
+;; generic checker adapts the two: its `:start' pulls Eglot's current
+;; diagnostics (via `eglot-flymake-backend') and reports them, and a report
+;; function caches later pushes and re-triggers a check so they reach the
+;; buffer.  Diagnostics are converted from the original LSP object Eglot
+;; stashes in each Flymake diagnostic's data slot, which is richer and more
+;; stable across Eglot versions than the Flymake fields.
+
+(declare-function eglot-managed-p "eglot")
+(declare-function eglot-flymake-backend "eglot" (report-fn &rest _))
+(declare-function flymake-mode "flymake" (&optional arg))
+(declare-function flymake-diagnostics "flymake" (&optional beg end))
+(declare-function flymake-diagnostic-beg "flymake" (diag))
+(declare-function flymake-diagnostic-end "flymake" (diag))
+(declare-function flymake-diagnostic-type "flymake" (diag))
+(declare-function flymake-diagnostic-text "flymake" (diag))
+(declare-function flymake-diagnostic-data "flymake" (diag))
+
+(defcustom flycheck-eglot-exclusive t
+  "Whether `eglot-check' is the only checker or chains to others.
+
+When non-nil (the default), a buffer using `flycheck-eglot-mode' reports
+only Eglot's diagnostics.  When nil, `eglot-check' chains to the first
+other checker that supports the buffer's major mode, so an LSP server and
+a command checker can both contribute.
+
+Note that this takes effect globally when a buffer enables the mode: it is
+stored in `eglot-check's chain, not per buffer."
+  :group 'flycheck
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38"))
+
+(defvar-local flycheck-eglot--diagnostics nil
+  "Latest diagnostics Eglot reported for this buffer, in Flymake format.")
+
+(defvar-local flycheck-eglot--suppress-recheck nil
+  "When non-nil, `flycheck-eglot--report' does not re-trigger a check.
+Bound while pulling diagnostics from `:start', so the synchronous report
+that pull may produce does not recurse into another check.")
+
+(defun flycheck-eglot--available-p ()
+  "Return non-nil when Eglot is managing the current buffer."
+  (and (fboundp 'eglot-managed-p) (eglot-managed-p)))
+
+(defun flycheck-eglot--enabled-p ()
+  "Return non-nil when `eglot-check' may run in the current buffer.
+
+That is, `flycheck-eglot-mode' is on and Eglot manages the buffer.  Used
+as the checker's predicate so `eglot-check', though a registered checker,
+is never selected unless the mode opted in."
+  (and (bound-and-true-p flycheck-eglot-mode)
+       (flycheck-eglot--available-p)))
+
+(defun flycheck-eglot--severity-level (severity)
+  "Map an LSP diagnostic SEVERITY (1-4) to a Flycheck error level.
+A missing severity is treated as an error, as Eglot does."
+  (pcase severity
+    (1 'error)
+    (2 'warning)
+    (3 'info)
+    (4 'info)                           ; LSP \"hint\"
+    (_ 'error)))
+
+(defun flycheck-eglot--type-level (type)
+  "Map an Eglot Flymake diagnostic TYPE to a Flycheck error level."
+  (pcase type
+    ('eglot-note 'info)
+    ('eglot-warning 'warning)
+    (_ 'error)))
+
+(defun flycheck-eglot--diagnostic-id (lsp)
+  "Return the Flycheck error id for the LSP diagnostic plist LSP.
+
+Built from the diagnostic's `code', carrying its `codeDescription' href
+\(if any) as an `explainer-url' text property so
+`flycheck-explain-error-at-point' can open it."
+  (when-let* ((code (plist-get lsp :code)))
+    (let ((id (format "%s" code))
+          (href (plist-get (plist-get lsp :codeDescription) :href)))
+      (if href (propertize id 'explainer-url href) id))))
+
+(defun flycheck-eglot--convert-diagnostic (diag)
+  "Convert the Eglot Flymake diagnostic DIAG to a `flycheck-error'.
+
+The buffer positions come from DIAG, which Eglot has already resolved.
+The level, message and id come from the original LSP diagnostic Eglot
+stashes in DIAG's data slot; if it is absent, the Flymake fields are used
+as a fallback."
+  (let ((lsp (and (fboundp 'flymake-diagnostic-data)
+                  (alist-get 'eglot-lsp-diag (flymake-diagnostic-data diag)))))
+    (flycheck-error-new-at-pos
+     (flymake-diagnostic-beg diag)
+     (if lsp
+         (flycheck-eglot--severity-level (plist-get lsp :severity))
+       (flycheck-eglot--type-level (flymake-diagnostic-type diag)))
+     (if lsp
+         (plist-get lsp :message)
+       (format "%s" (flymake-diagnostic-text diag)))
+     :end-pos (flymake-diagnostic-end diag)
+     :id (and lsp (flycheck-eglot--diagnostic-id lsp))
+     :checker 'eglot-check
+     :buffer (current-buffer)
+     :filename (buffer-file-name))))
+
+(defun flycheck-eglot--report (diags &rest _)
+  "Cache Eglot's DIAGS and re-run Flycheck to publish them.
+Registered with `eglot-flymake-backend' as its report function."
+  (setq flycheck-eglot--diagnostics (append diags nil))
+  (unless flycheck-eglot--suppress-recheck
+    (let ((flycheck-eglot--suppress-recheck t))
+      (flycheck-buffer-automatically))))
+
+(defun flycheck-eglot--start (_checker callback)
+  "Start the `eglot-check' syntax check, reporting through CALLBACK.
+Pull Eglot's current diagnostics and report their Flycheck conversions."
+  (let ((flycheck-eglot--suppress-recheck t))
+    (eglot-flymake-backend #'flycheck-eglot--report))
+  (funcall callback 'finished
+           (mapcar #'flycheck-eglot--convert-diagnostic
+                   flycheck-eglot--diagnostics)))
+
+(flycheck-define-generic-checker 'eglot-check
+  "Report the diagnostics Eglot receives from an LSP server.
+
+Enabled by `flycheck-eglot-mode'; only usable in Eglot-managed buffers."
+  :start #'flycheck-eglot--start
+  :predicate #'flycheck-eglot--enabled-p
+  :modes '(prog-mode text-mode))
+
+(defun flycheck-eglot--flymake-diagnostics (orig &optional beg end &rest args)
+  "Serve the cached Eglot diagnostics while `flycheck-eglot-mode' is on.
+
+`flycheck-eglot-mode' turns Flymake's own mode off, which would otherwise
+leave `flymake-diagnostics' (used e.g. by `eglot-code-actions') empty.
+ORIG is the advised function; BEG, END and ARGS are its arguments."
+  (if (not (bound-and-true-p flycheck-eglot-mode))
+      (apply orig beg end args)
+    ;; Mirror `flymake-diagnostics': return the diagnostics that OVERLAP
+    ;; [BEG, END] (nil means unbounded), not just those contained in it, so
+    ;; callers like `eglot-code-actions' still see a wide diagnostic at point.
+    (seq-filter (lambda (d)
+                  (let ((db (flymake-diagnostic-beg d))
+                        (de (flymake-diagnostic-end d)))
+                    (and (or (null end) (<= db end))
+                         (or (null beg) (<= beg de)))))
+                flycheck-eglot--diagnostics)))
+
+(defun flycheck-eglot--register ()
+  "Prepare `eglot-check' for the current buffer's major mode.
+
+`eglot-check' is already in `flycheck-checkers'; this just teaches it the
+buffer's major mode when needed and sets up chaining per
+`flycheck-eglot-exclusive'."
+  (unless (flycheck-checker-supports-major-mode-p 'eglot-check major-mode)
+    (flycheck-add-mode 'eglot-check major-mode))
+  (if flycheck-eglot-exclusive
+      (setf (flycheck-checker-get 'eglot-check 'next-checkers) nil)
+    (when-let* ((next (seq-find
+                       (lambda (c)
+                         (and (not (eq c 'eglot-check))
+                              (flycheck-checker-supports-major-mode-p c major-mode)))
+                       flycheck-checkers)))
+      (flycheck-add-next-checker 'eglot-check next 'append))))
+
+(defun flycheck-eglot--enable ()
+  "Set up the current buffer to report Eglot diagnostics through Flycheck."
+  (when (flycheck-eglot--available-p)
+    (flycheck-eglot--register)
+    (setq flycheck-checker 'eglot-check)
+    ;; Suppress the recheck the synchronous report may fire; the trailing
+    ;; `flycheck-buffer-deferred' triggers the first check instead.
+    (let ((flycheck-eglot--suppress-recheck t))
+      (eglot-flymake-backend #'flycheck-eglot--report))
+    (advice-add 'flymake-diagnostics :around
+                #'flycheck-eglot--flymake-diagnostics)
+    (when (bound-and-true-p flymake-mode)
+      (flymake-mode -1))
+    (unless flycheck-mode
+      (flycheck-mode 1))
+    (flycheck-buffer-deferred)))
+
+(defun flycheck-eglot--disable ()
+  "Undo `flycheck-eglot--enable' in the current buffer."
+  (when (flycheck-eglot--available-p)
+    (ignore-errors (eglot-flymake-backend #'ignore)))
+  (when (eq flycheck-checker 'eglot-check)
+    (setq flycheck-checker nil))
+  (setq flycheck-eglot--diagnostics nil)
+  (when flycheck-mode
+    (flycheck-buffer-deferred)))
+
+;;;###autoload
+(define-minor-mode flycheck-eglot-mode
+  "Minor mode to report Eglot's LSP diagnostics through Flycheck.
+
+When enabled in an Eglot-managed buffer, Flycheck shows the diagnostics
+the LSP server reports (via the `eglot-check' checker) instead of Flymake,
+which is turned off.  With `flycheck-eglot-exclusive' nil, `eglot-check'
+chains to the command checkers so both contribute.
+
+Usually enabled for every Eglot buffer via `global-flycheck-eglot-mode'."
+  :lighter nil
+  :group 'flycheck
+  (if flycheck-eglot-mode
+      (flycheck-eglot--enable)
+    (flycheck-eglot--disable)))
+
+(defun flycheck-eglot--managed-mode-update ()
+  "Turn `flycheck-eglot-mode' on or off to track Eglot managing the buffer.
+For `eglot-managed-mode-hook', which fires on both enter and exit."
+  (flycheck-eglot-mode (if (flycheck-eglot--available-p) 1 -1)))
+
+;;;###autoload
+(define-globalized-minor-mode global-flycheck-eglot-mode
+  flycheck-eglot-mode
+  (lambda () (when (flycheck-eglot--available-p) (flycheck-eglot-mode 1)))
+  :group 'flycheck
+  (if global-flycheck-eglot-mode
+      (add-hook 'eglot-managed-mode-hook #'flycheck-eglot--managed-mode-update)
+    (remove-hook 'eglot-managed-mode-hook
+                 #'flycheck-eglot--managed-mode-update)))
 
 
 ;;; Built-in checkers

--- a/test/specs/test-documentation.el
+++ b/test/specs/test-documentation.el
@@ -66,7 +66,9 @@
                                                 languages)))
 
         (it "documents all syntax checkers"
-          (expect (seq-difference flycheck-checkers checkers)
+          ;; `eglot-check' is not a per-language command checker; it is
+          ;; documented in the Eglot section of the manual, not languages.rst.
+          (expect (seq-difference (remq 'eglot-check flycheck-checkers) checkers)
                   :to-equal nil))
 
         (it "doesn't document syntax checkers that don't exist"

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -1,0 +1,144 @@
+;;; test-eglot.el --- Flycheck Specs: Eglot integration  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for the built-in Eglot bridge (`flycheck-eglot-mode' and the
+;; `eglot-check' checker).  The diagnostic conversion is tested against
+;; synthetic Flymake diagnostics; the mode wiring stubs Eglot.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+(require 'flymake)
+
+(defun test-eglot--diag (buffer beg end type text &optional lsp)
+  "Build a Flymake diagnostic, stashing LSP as Eglot's data payload."
+  (flymake-make-diagnostic buffer beg end type text
+                           (and lsp (list (cons 'eglot-lsp-diag lsp)))))
+
+(describe "Eglot integration"
+
+  (describe "flycheck-eglot--severity-level"
+    (it "maps LSP severities to Flycheck levels"
+      (expect (flycheck-eglot--severity-level 1) :to-be 'error)
+      (expect (flycheck-eglot--severity-level 2) :to-be 'warning)
+      (expect (flycheck-eglot--severity-level 3) :to-be 'info)
+      (expect (flycheck-eglot--severity-level 4) :to-be 'info))
+    (it "treats a missing severity as an error"
+      (expect (flycheck-eglot--severity-level nil) :to-be 'error)))
+
+  (describe "flycheck-eglot--diagnostic-id"
+    (it "uses the diagnostic code"
+      (expect (substring-no-properties
+               (flycheck-eglot--diagnostic-id '(:code "E501")))
+              :to-equal "E501"))
+    (it "carries a codeDescription href as an explainer URL"
+      (let ((id (flycheck-eglot--diagnostic-id
+                 '(:code "E501" :codeDescription (:href "https://x/E501")))))
+        (expect (get-text-property 0 'explainer-url id)
+                :to-equal "https://x/E501")))
+    (it "is nil without a code"
+      (expect (flycheck-eglot--diagnostic-id '(:message "x")) :to-be nil)))
+
+  (describe "flycheck-eglot--convert-diagnostic"
+    (it "reads level, message and id from the LSP diagnostic in the data slot"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "line one here\n")
+        (let* ((diag (test-eglot--diag
+                      (current-buffer) 1 5 :warning "flymake text"
+                      '(:severity 2 :message "unused" :code "F841")))
+               (err (flycheck-eglot--convert-diagnostic diag)))
+          (expect (flycheck-error-level err) :to-be 'warning)
+          (expect (flycheck-error-message err) :to-equal "unused")
+          (expect (substring-no-properties (flycheck-error-id err))
+                  :to-equal "F841")
+          (expect (flycheck-error-checker err) :to-be 'eglot-check))))
+
+    (it "falls back to the Flymake fields when there is no data payload"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "line one here\n")
+        (let* ((diag (test-eglot--diag (current-buffer) 1 5 :error "raw"))
+               (err (flycheck-eglot--convert-diagnostic diag)))
+          (expect (flycheck-error-level err) :to-be 'error)
+          (expect (flycheck-error-message err) :to-equal "raw")
+          (expect (flycheck-error-id err) :to-be nil)))))
+
+  (describe "flycheck-eglot--report"
+    (it "caches the diagnostics and re-triggers a check"
+      (flycheck-buttercup-with-temp-buffer
+        (spy-on 'flycheck-buffer-automatically)
+        (let ((diags (list (test-eglot--diag (current-buffer) 1 2 :error "x"))))
+          (flycheck-eglot--report diags)
+          (expect flycheck-eglot--diagnostics :to-equal diags)
+          (expect 'flycheck-buffer-automatically :to-have-been-called))))
+    (it "does not re-trigger while suppressed"
+      (flycheck-buttercup-with-temp-buffer
+        (spy-on 'flycheck-buffer-automatically)
+        (let ((flycheck-eglot--suppress-recheck t))
+          (flycheck-eglot--report nil))
+        (expect 'flycheck-buffer-automatically :not :to-have-been-called))))
+
+  (describe "flycheck-eglot--flymake-diagnostics"
+    (it "serves the cached diagnostics that overlap the query range"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abcdefghij\n")
+        (let* ((flycheck-eglot-mode t)
+               (wide (test-eglot--diag (current-buffer) 1 8 :error "x"))
+               (flycheck-eglot--diagnostics (list wide)))
+          ;; a narrow query inside a wider diagnostic must still find it
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 3 4)
+                  :to-equal (list wide)))))
+    (it "delegates to the original when the mode is off"
+      (let ((flycheck-eglot-mode nil))
+        (expect (flycheck-eglot--flymake-diagnostics
+                 (lambda (&rest _) 'delegated) 1 2)
+                :to-be 'delegated))))
+
+  (describe "the eglot-check checker"
+    (it "is a valid generic checker"
+      (expect (flycheck-valid-checker-p 'eglot-check) :to-be-truthy))
+    (it "is defined for prog-mode and text-mode"
+      (expect (flycheck-checker-get 'eglot-check 'modes)
+              :to-equal '(prog-mode text-mode))))
+
+  (describe "flycheck-eglot-mode"
+    ;; Stub Eglot with `cl-letf' rather than `spy-on': Emacs 28 does not bundle
+    ;; Eglot, so the symbols may be unbound, and `cl-letf' can still define them.
+    (it "selects eglot-check when enabled and clears it when disabled"
+      (flycheck-buttercup-with-temp-buffer
+        (text-mode)                     ; a mode eglot-check already supports
+        (let ((flycheck-checkers (copy-sequence flycheck-checkers))
+              (backend-calls 0))
+          (cl-letf (((symbol-function 'eglot-managed-p) (lambda () t))
+                    ((symbol-function 'eglot-flymake-backend)
+                     (lambda (&rest _) (cl-incf backend-calls)))
+                    ((symbol-function 'flycheck-mode) #'ignore)
+                    ((symbol-function 'flymake-mode) #'ignore)
+                    ((symbol-function 'flycheck-buffer-deferred) #'ignore))
+            (flycheck-eglot-mode 1)
+            (expect flycheck-checker :to-be 'eglot-check)
+            (expect backend-calls :to-be-greater-than 0)
+            (flycheck-eglot-mode -1)
+            (expect flycheck-checker :to-be nil)
+            (expect flycheck-eglot--diagnostics :to-be nil))
+          (advice-remove 'flymake-diagnostics
+                         #'flycheck-eglot--flymake-diagnostics))))))
+
+;;; test-eglot.el ends here


### PR DESCRIPTION
Flycheck now integrates with Eglot out of the box, so you don't need the external flycheck-eglot package. Enable `global-flycheck-eglot-mode` to route an LSP server's diagnostics (as seen by Eglot) through Flycheck via a new `eglot-check` checker: a buffer keeps Eglot for LSP features while Flycheck owns the error display, navigation and the error list, alongside the usual command checkers when `flycheck-eglot-exclusive` is nil.

Diagnostics are converted from the raw LSP object Eglot stashes in each Flymake diagnostic's data slot, so the mapping carries the code and severity directly and stays stable across Eglot versions. Eglot and Flymake stay optional (used only via `declare-function` behind runtime guards).

This obsoletes the third-party `flycheck-eglot`; the manual and the Flymake comparison are updated accordingly.
