### PR TITLE
Allow lazy, on-demand quick-fix resolution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 ``master`` (unreleased)
 =======================
 
+- [#2210]: A ``flycheck-error``'s fix (the ``:fix`` slot) may now be a function
+  that produces the fix on demand instead of a ready ``flycheck-fix``.  Flycheck
+  resolves it with ``flycheck-error-resolve-fix`` only when the fix is applied,
+  so a checker can offer fixes that are expensive to compute (such as an LSP
+  code action) without paying the cost up front.
 - [#2209]: Flycheck now integrates with Eglot out of the box.  Enable
   ``global-flycheck-eglot-mode`` to report an LSP server's diagnostics (as seen
   by Eglot) through Flycheck via the new ``eglot-check`` checker, so a buffer

--- a/flycheck.el
+++ b/flycheck.el
@@ -4286,7 +4286,12 @@ Slots:
   "Return the suggested fix of a Flycheck error ERR, or nil.
 
 The value is a `flycheck-fix' object when the checker offered a
-machine-applicable fix for ERR; see `flycheck-apply-fix'."
+machine-applicable fix for ERR; see `flycheck-apply-fix'.  It may instead
+be a function of one argument (ERR) that produces the fix on demand -- a
+lazy fix provider, used when computing the fix is expensive (e.g. an LSP
+code-action request).  Call `flycheck-error-resolve-fix' to get the
+concrete fix; a non-nil value here means ERR is presented as fixable
+either way."
   (condition-case nil (flycheck-error--fix err)
     (args-out-of-range nil)))
 
@@ -4296,6 +4301,16 @@ machine-applicable fix for ERR; see `flycheck-apply-fix'."
     (args-out-of-range nil)))
 
 (gv-define-simple-setter flycheck-error-fix flycheck-error--set-fix)
+
+(defun flycheck-error-resolve-fix (err)
+  "Return the concrete `flycheck-fix' for ERR, or nil.
+
+If ERR's fix slot holds a lazy provider (a function, see
+`flycheck-error-fix'), call it with ERR to produce the fix; otherwise
+return the stored fix as-is.  A provider may return nil when no fix turns
+out to be available."
+  (let ((fix (flycheck-error-fix err)))
+    (if (functionp fix) (funcall fix err) fix)))
 
 (cl-defstruct (flycheck-fix-edit (:constructor flycheck-fix-edit-new))
   "A single text edit of a `flycheck-fix'.
@@ -6970,18 +6985,23 @@ POS defaults to `point'.  Signal a `user-error' when the error
 has no fix."
   (interactive)
   (let* ((error (tabulated-list-get-id pos))
-         (fix (and (flycheck-error-p error) (flycheck-error-fix error)))
-         (buffer (and fix (flycheck--error-fix-buffer error))))
-    (unless fix
+         (fixable (and (flycheck-error-p error) (flycheck-error-fix error)))
+         (buffer (and fixable (flycheck--error-fix-buffer error))))
+    (unless fixable
       (user-error "The error at point has no fix"))
     (unless buffer
       (user-error "This fix cannot be applied here (the error is in another \
 file, or its buffer is gone)"))
-    (flycheck-apply-fix fix buffer)
-    (flycheck-error-list-refresh)
-    (message "Applied fix%s"
-             (if-let* ((description (flycheck-fix-description fix)))
-                 (concat ": " description) ""))))
+    ;; Resolve a lazy fix provider in the error's own buffer.
+    (if-let* ((fix (with-current-buffer buffer
+                     (flycheck-error-resolve-fix error))))
+        (progn
+          (flycheck-apply-fix fix buffer)
+          (flycheck-error-list-refresh)
+          (message "Applied fix%s"
+                   (if-let* ((description (flycheck-fix-description fix)))
+                       (concat ": " description) "")))
+      (user-error "The fix for this error is not available"))))
 
 (defun flycheck-error-list-fix-all ()
   "Apply every fixable error's fix in the error list's source buffer."
@@ -7944,11 +7964,13 @@ point has a fix."
                               (and (flycheck-error-fix err)
                                    (flycheck--error-fix-buffer err)))
                             (flycheck-overlay-errors-at (point)))))
-      (let ((fix (flycheck-error-fix error)))
-        (flycheck-apply-fix fix (flycheck--error-fix-buffer error))
-        (message "Applied fix%s"
-                 (if-let* ((description (flycheck-fix-description fix)))
-                     (concat ": " description) "")))
+      (if-let* ((fix (flycheck-error-resolve-fix error)))
+          (progn
+            (flycheck-apply-fix fix (flycheck--error-fix-buffer error))
+            (message "Applied fix%s"
+                     (if-let* ((description (flycheck-fix-description fix)))
+                         (concat ": " description) "")))
+        (user-error "The fix for the error at point is not available"))
     (user-error "No applicable fix at point")))
 
 (defun flycheck-fix-all-errors ()
@@ -7963,7 +7985,7 @@ are skipped; fixes for other files are ignored."
                      (mapcar (lambda (err)
                                (and (eq (flycheck--error-fix-buffer err)
                                         (current-buffer))
-                                    (flycheck-error-fix err)))
+                                    (flycheck-error-resolve-fix err)))
                              flycheck-current-errors))))
     (unless fixes
       (user-error "No applicable fixes in this buffer"))

--- a/test/specs/test-quick-fixes.el
+++ b/test/specs/test-quick-fixes.el
@@ -36,6 +36,23 @@
 
 (describe "Quick fixes"
 
+  (describe "flycheck-error-resolve-fix"
+    (it "returns a stored fix as-is"
+      (let* ((fix (flycheck-test--edit 1 1 1 2 "x"))
+             (err (flycheck-error-new-at 1 1 'error "e" :fix fix)))
+        (expect (flycheck-error-resolve-fix err) :to-be fix)))
+    (it "calls a lazy provider with the error and returns its fix"
+      (let* ((fix (flycheck-test--edit 1 1 1 2 "x"))
+             (seen nil)
+             (err (flycheck-error-new-at
+                   1 1 'error "e"
+                   :fix (lambda (e) (setq seen e) fix))))
+        (expect (flycheck-error-resolve-fix err) :to-be fix)
+        (expect seen :to-be err)))
+    (it "returns nil when the provider yields no fix"
+      (let ((err (flycheck-error-new-at 1 1 'error "e" :fix (lambda (_) nil))))
+        (expect (flycheck-error-resolve-fix err) :to-be nil))))
+
   (describe "flycheck-apply-fix"
 
     (it "replaces the edit's region"
@@ -160,6 +177,26 @@
           (spy-on 'flycheck-overlay-errors-at :and-return-value (list err))
           (flycheck-fix-error-at-point)
           (expect (buffer-string) :to-equal "hello world\n"))))
+
+    (it "resolves and applies a lazy fix provider"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "helo world\n")
+        (goto-char (point-min))
+        (let ((err (flycheck-error-new-at
+                    1 1 'error "typo" :buffer (current-buffer)
+                    :fix (lambda (_) (flycheck-test--edit 1 1 1 5 "hello")))))
+          (spy-on 'flycheck-overlay-errors-at :and-return-value (list err))
+          (flycheck-fix-error-at-point)
+          (expect (buffer-string) :to-equal "hello world\n"))))
+
+    (it "signals when a lazy provider yields no fix"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "helo\n")
+        (let ((err (flycheck-error-new-at 1 1 'error "typo"
+                                          :buffer (current-buffer)
+                                          :fix (lambda (_) nil))))
+          (spy-on 'flycheck-overlay-errors-at :and-return-value (list err))
+          (expect (flycheck-fix-error-at-point) :to-throw 'user-error))))
 
     (it "applies a fix whose error is for the current file"
       (flycheck-buttercup-with-temp-buffer


### PR DESCRIPTION
Groundwork for LSP code-action fixes. A `flycheck-error`'s `:fix` slot may now hold a function that produces the fix on demand, instead of only a ready `flycheck-fix`. `flycheck-error-resolve-fix` resolves it, and the apply commands (`flycheck-fix-error-at-point`, the error-list command, `flycheck-fix-all-errors`) call it only when a fix is actually applied.

This lets a checker offer fixes that are expensive to compute (e.g. an LSP code-action request) without paying the cost up front. An error with a provider is still shown as fixable; if the provider turns up nothing at apply time, the command reports that no fix is available.
