### PR TITLE
Offer Eglot code-action fixes as Flycheck fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``master`` (unreleased)
 =======================
 
+- [#2211]: With ``flycheck-eglot-mode``, an LSP diagnostic's ``quickfix`` code
+  action is now offered as a Flycheck fix: ``C-c ! f`` applies it (``C-c ! F`` applies all,
+  ``[fix]`` marks it in the error list).  The action is fetched from the server
+  only when you apply a fix.  Customize ``flycheck-eglot-code-actions`` to turn
+  it off.  This is something Flymake, which shows Eglot's diagnostics but not its
+  fixes, does not offer.
 - [#2210]: A ``flycheck-error``'s fix (the ``:fix`` slot) may now be a function
   that produces the fix on demand instead of a ready ``flycheck-fix``.  Flycheck
   resolves it with ``flycheck-error-resolve-fix`` only when the fix is applied,

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -211,5 +211,17 @@ display, navigation and the error list:
    checker that supports the buffer's major mode, so an LSP server and a
    command checker both contribute.
 
+When the server supports code actions, an Eglot diagnostic's ``quickfix``
+action is offered as a Flycheck fix: press ``C-c ! f`` on the error to apply it
+(or ``C-c ! F`` to apply all).  The action is fetched from the server only when
+you apply a fix, so every diagnostic is shown as potentially fixable even if the
+server has nothing for it.
+
+.. defcustom:: flycheck-eglot-code-actions
+
+   When non-nil (the default), offer LSP ``quickfix`` code actions as fixes, as
+   described above.  Set to nil to turn this off (and stop marking every
+   diagnostic as fixable).
+
 This obsoletes the third-party ``flycheck-eglot`` package; drop it from your
 configuration if you used it.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10075,6 +10075,25 @@ SYMBOL with `flycheck-def-executable-var'."
 (declare-function flymake-diagnostic-type "flymake" (diag))
 (declare-function flymake-diagnostic-text "flymake" (diag))
 (declare-function flymake-diagnostic-data "flymake" (diag))
+(declare-function eglot-code-actions "eglot" (beg &optional end action-kind interactive))
+(declare-function eglot-server-capable "eglot" (&rest feats))
+(declare-function eglot-uri-to-path "eglot" (uri))
+(declare-function eglot--request "eglot" (server method params &rest _))
+(declare-function eglot--current-server-or-lose "eglot" ())
+
+(defcustom flycheck-eglot-code-actions t
+  "Whether `eglot-check' offers LSP quick-fix code actions as fixes.
+
+When non-nil (the default) and the server supports code actions, each
+Eglot diagnostic carries a lazy fix (see `flycheck-error-resolve-fix')
+that requests the server's \"quickfix\" code action for it when applied
+with \\[flycheck-fix-error-at-point].  Because the fix is only computed on
+demand, every diagnostic is shown as potentially fixable even when the
+server has no action for it; set this to nil to turn the feature off."
+  :group 'flycheck
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38"))
 
 (defcustom flycheck-eglot-exclusive t
   "Whether `eglot-check' is the only checker or chains to others.
@@ -10159,9 +10178,119 @@ as a fallback."
        (format "%s" (flymake-diagnostic-text diag)))
      :end-pos (flymake-diagnostic-end diag)
      :id (and lsp (flycheck-eglot--diagnostic-id lsp))
+     :fix (flycheck-eglot--fix-provider)
      :checker 'eglot-check
      :buffer (current-buffer)
      :filename (buffer-file-name))))
+
+(defun flycheck-eglot--fix-provider ()
+  "Return the lazy code-action fix provider, or nil when unavailable.
+
+Non-nil only when `flycheck-eglot-code-actions' is on and the server
+advertises code actions; see `flycheck-eglot--code-action-fix'."
+  (when (and flycheck-eglot-code-actions
+             (fboundp 'eglot-server-capable)
+             (eglot-server-capable :codeActionProvider))
+    #'flycheck-eglot--code-action-fix))
+
+(defun flycheck-eglot--error-region (err)
+  "Return the (BEG . END) buffer region of ERR, for a code-action request."
+  (save-restriction
+    (widen)
+    (let* ((line (flycheck-error-line err))
+           (beg (flycheck-line-column-to-position
+                 line (or (flycheck-error-column err) 1)))
+           (end (if (and (flycheck-error-end-line err)
+                         (flycheck-error-end-column err))
+                    (flycheck-line-column-to-position
+                     (flycheck-error-end-line err)
+                     (flycheck-error-end-column err))
+                  beg)))
+      (cons beg end))))
+
+(defun flycheck-eglot--text-edit (tedit)
+  "Convert the LSP TextEdit TEDIT to a `flycheck-fix-edit'.
+LSP positions are zero-based and end-exclusive; Flycheck's are one-based
+and end-exclusive, so only the line/column need incrementing."
+  (let ((start (plist-get (plist-get tedit :range) :start))
+        (end (plist-get (plist-get tedit :range) :end)))
+    (flycheck-fix-edit-new
+     :line (1+ (plist-get start :line))
+     :column (1+ (plist-get start :character))
+     :end-line (1+ (plist-get end :line))
+     :end-column (1+ (plist-get end :character))
+     :replacement (plist-get tedit :newText))))
+
+(defun flycheck-eglot--workspace-edit-fix (wedit description)
+  "Build a `flycheck-fix' from WEDIT, or nil.
+
+WEDIT is an LSP WorkspaceEdit.  A fix is built only when WEDIT edits a
+single file that is the current buffer, since a `flycheck-fix' applies to
+one buffer; a multi-file edit, or one with resource operations (create,
+rename, delete), is declined and left to Eglot's own commands.
+DESCRIPTION becomes the fix's description.  The tick is the buffer's
+current one: the action was just fetched against this buffer state, and
+the fix is applied right after."
+  (let* ((this (buffer-file-name))
+         (dchanges (append (plist-get wedit :documentChanges) nil))
+         (targets
+          (cond
+           ;; `documentChanges' with a resource operation (an entry without a
+           ;; `:textDocument') is not a plain text fix; decline it whole.
+           ((seq-some (lambda (tde) (null (plist-get tde :textDocument)))
+                      dchanges)
+            nil)
+           ;; `documentChanges' (preferred): array of TextDocumentEdit.
+           (dchanges
+            (mapcar (lambda (tde)
+                      (cons (eglot-uri-to-path
+                             (plist-get (plist-get tde :textDocument) :uri))
+                            (plist-get tde :edits)))
+                    dchanges))
+           ;; `changes' (legacy): a plist of uri -> edits.
+           (t
+            (cl-loop for (uri edits) on (plist-get wedit :changes) by #'cddr
+                     collect (cons (eglot-uri-to-path uri) edits))))))
+    (when (and this
+               (= (length targets) 1)
+               (flycheck-same-files-p (caar targets) this)
+               (cdar targets))
+      (flycheck-fix-new
+       :description description
+       :edits (mapcar #'flycheck-eglot--text-edit (append (cdar targets) nil))
+       :tick (buffer-chars-modified-tick)))))
+
+(defun flycheck-eglot--resolve-action (action)
+  "Return ACTION with its edit filled in, resolving it if necessary.
+A server may omit the `edit' until the action is resolved via
+`codeAction/resolve'."
+  (if (and (null (plist-get action :edit))
+           (plist-get action :data)
+           (eglot-server-capable :codeActionProvider :resolveProvider))
+      (eglot--request (eglot--current-server-or-lose)
+                      :codeAction/resolve action)
+    action))
+
+(defun flycheck-eglot--code-action-fix (err)
+  "Resolve a \"quickfix\" code action for ERR into a `flycheck-fix', or nil.
+
+Used as a lazy fix provider (see `flycheck-error-fix'): requests the
+server's quickfix actions overlapping ERR, prefers an `isPreferred' one,
+resolves its edit, and converts a single-file edit into a fix.  Any error
+talking to the server yields nil, so the fix just reports as unavailable."
+  (when (flycheck-eglot--available-p)
+    (pcase-let ((`(,beg . ,end) (flycheck-eglot--error-region err)))
+      ;; A jsonrpc timeout or error from either request must degrade to nil,
+      ;; not abort the fix command (or a `flycheck-fix-all-errors' batch).
+      (ignore-errors
+        (when-let* ((actions (eglot-code-actions beg end "quickfix" nil))
+                    (action (or (seq-find (lambda (a) (plist-get a :isPreferred))
+                                          actions)
+                                (car actions)))
+                    (edit (plist-get (flycheck-eglot--resolve-action action)
+                                     :edit)))
+          (flycheck-eglot--workspace-edit-fix
+           edit (plist-get action :title)))))))
 
 (defun flycheck-eglot--report (diags &rest _)
   "Cache Eglot's DIAGS and re-run Flycheck to publish them.

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -111,6 +111,109 @@
                  (lambda (&rest _) 'delegated) 1 2)
                 :to-be 'delegated))))
 
+  (describe "code-action fixes"
+
+    (it "converts an LSP TextEdit to a fix edit, one-basing positions"
+      (let ((fe (flycheck-eglot--text-edit
+                 '(:range (:start (:line 0 :character 4)
+                           :end (:line 0 :character 9))
+                   :newText "hello"))))
+        (expect (flycheck-fix-edit-line fe) :to-equal 1)
+        (expect (flycheck-fix-edit-column fe) :to-equal 5)
+        (expect (flycheck-fix-edit-end-line fe) :to-equal 1)
+        (expect (flycheck-fix-edit-end-column fe) :to-equal 10)
+        (expect (flycheck-fix-edit-replacement fe) :to-equal "hello")))
+
+    (it "builds a fix from a single-file WorkspaceEdit"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity)
+                  ((symbol-function 'flycheck-same-files-p) #'equal))
+          (let ((fix (flycheck-eglot--workspace-edit-fix
+                      '(:documentChanges
+                        [(:textDocument (:uri "/proj/a.el")
+                          :edits [(:range (:start (:line 0 :character 0)
+                                           :end (:line 0 :character 3))
+                                   :newText "X")])])
+                      "Fix it")))
+            (expect (flycheck-fix-description fix) :to-equal "Fix it")
+            (expect (length (flycheck-fix-edits fix)) :to-equal 1)))))
+
+    (it "declines a multi-file WorkspaceEdit"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity)
+                  ((symbol-function 'flycheck-same-files-p) #'equal))
+          (expect (flycheck-eglot--workspace-edit-fix
+                   '(:documentChanges
+                     [(:textDocument (:uri "/proj/a.el")
+                       :edits [(:range (:start (:line 0 :character 0)
+                                        :end (:line 0 :character 1))
+                                :newText "X")])
+                      (:textDocument (:uri "/proj/b.el")
+                       :edits [(:range (:start (:line 0 :character 0)
+                                        :end (:line 0 :character 1))
+                                :newText "Y")])])
+                   "x")
+                  :to-be nil))))
+
+    (it "declines a WorkspaceEdit with a resource operation"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity)
+                  ((symbol-function 'flycheck-same-files-p) #'equal))
+          ;; a file-creation op alongside a text edit is not a plain fix
+          (expect (flycheck-eglot--workspace-edit-fix
+                   '(:documentChanges
+                     [(:kind "create" :uri "/proj/new.el")
+                      (:textDocument (:uri "/proj/a.el")
+                       :edits [(:range (:start (:line 0 :character 0)
+                                        :end (:line 0 :character 1))
+                                :newText "X")])])
+                   "mix")
+                  :to-be nil))))
+
+    (it "provides the code-action fix only when enabled and supported"
+      (let ((flycheck-eglot-code-actions t))
+        (cl-letf (((symbol-function 'eglot-server-capable) (lambda (&rest _) t)))
+          (expect (flycheck-eglot--fix-provider)
+                  :to-be 'flycheck-eglot--code-action-fix))
+        (cl-letf (((symbol-function 'eglot-server-capable) (lambda (&rest _) nil)))
+          (expect (flycheck-eglot--fix-provider) :to-be nil)))
+      (let ((flycheck-eglot-code-actions nil))
+        (expect (flycheck-eglot--fix-provider) :to-be nil)))
+
+    (it "resolves the preferred quickfix action into a fix"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (insert "line one\n")
+        (cl-letf (((symbol-function 'eglot-managed-p) (lambda () t))
+                  ((symbol-function 'eglot-uri-to-path) #'identity)
+                  ((symbol-function 'flycheck-same-files-p) #'equal)
+                  ((symbol-function 'eglot-code-actions)
+                   (lambda (&rest _)
+                     (list '(:title "Meh")
+                           '(:title "Quick fix" :isPreferred t
+                             :edit (:documentChanges
+                                    [(:textDocument (:uri "/proj/a.el")
+                                      :edits [(:range (:start (:line 0 :character 0)
+                                                       :end (:line 0 :character 4))
+                                               :newText "LINE")])]))))))
+          (let ((fix (flycheck-eglot--code-action-fix
+                      (flycheck-error-new-at 1 1 'error "x"
+                                             :buffer (current-buffer)))))
+            (expect (flycheck-fix-p fix) :to-be t)
+            (expect (flycheck-fix-description fix) :to-equal "Quick fix")))))
+
+    (it "returns no fix when the server offers no actions"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "x\n")
+        (cl-letf (((symbol-function 'eglot-managed-p) (lambda () t))
+                  ((symbol-function 'eglot-code-actions) (lambda (&rest _) nil)))
+          (expect (flycheck-eglot--code-action-fix
+                   (flycheck-error-new-at 1 1 'error "x"))
+                  :to-be nil)))))
+
   (describe "the eglot-check checker"
     (it "is a valid generic checker"
       (expect (flycheck-valid-checker-p 'eglot-check) :to-be-truthy))


### PR DESCRIPTION
The payoff of the Eglot work: with `flycheck-eglot-mode`, an LSP diagnostic's `quickfix` code action is now offered as a Flycheck fix. `C-c ! f` applies it, `C-c ! F` applies all, and the error list marks it `[fix]`. Built on the lazy-fix mechanism from #2210, the action is fetched from the server only when you apply a fix, and a single-file WorkspaceEdit is converted into a `flycheck-fix` (multi-file edits and resource operations are declined). `flycheck-eglot-code-actions` turns it off.

This is something Flymake, which renders Eglot's diagnostics but not its fixes, doesn't offer.
