### PR TITLE
Add a native LSP diagnostics client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 ``master`` (unreleased)
 =======================
 
+- [#2213]: Flycheck can now talk to a diagnostics language server directly,
+  without Eglot.  Enable ``global-flycheck-lsp-mode`` and configure a server
+  per major mode in ``flycheck-lsp-servers`` (``rubocop --lsp`` out of the
+  box); the new ``lsp`` checker starts it over the built-in ``jsonrpc``
+  library, feeds it the buffer's text, and reports its diagnostics.  This suits
+  single-purpose LSP linters (rubocop, ruff, biome) you want as a Flycheck
+  checker without handing the buffer to a full LSP client - for that, keep
+  using ``flycheck-eglot-mode``.
 - [#2212]: Flycheck errors can now carry secondary source locations - the
   earlier definition behind a redefinition, the borrow behind a Rust lifetime
   error, and so on.

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -225,3 +225,121 @@ server has nothing for it.
 
 This obsoletes the third-party ``flycheck-eglot`` package; drop it from your
 configuration if you used it.
+
+
+LSP diagnostics without Eglot
+=============================
+
+Some language servers do nothing but report diagnostics - linters like
+``rubocop --lsp``, ``ruff server`` or ``biome lsp-proxy``.  For those you may
+not want a full LSP client at all.  ``flycheck-lsp-mode`` talks to such a
+server directly, over Emacs' built-in ``jsonrpc`` library, and reports its
+diagnostics through the ``lsp`` checker - no Eglot involved.
+
+Turn it on everywhere with:
+
+.. code-block:: elisp
+
+   (global-flycheck-lsp-mode 1)
+
+Out of the box this covers RuboCop for Ruby, Ruff for Python and Biome for
+JavaScript, TypeScript, JSON and CSS.  A server is only used when its program
+is installed, so enabling the mode globally does nothing in a buffer whose
+language server you don't have.
+
+.. minor-mode:: flycheck-lsp-mode
+
+   Start the LSP server configured for the buffer's major mode, send it the
+   buffer's text, and report the diagnostics it pushes back through the ``lsp``
+   checker.  Does nothing in a buffer whose major mode has no configured,
+   installed server.
+
+.. minor-mode:: global-flycheck-lsp-mode
+
+   Enable ``flycheck-lsp-mode`` in every buffer whose major mode has an
+   installed server in `flycheck-lsp-servers`.
+
+Which LSP integration should I use?
+-----------------------------------
+
+Flycheck can get LSP diagnostics three ways.  Pick by how much of a language
+server you actually want:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 25 25 26
+
+   * -
+     - ``flycheck-lsp-mode``
+     - ``flycheck-eglot-mode``
+     - ``lsp-mode``
+   * - Runs the server
+     - Flycheck, over built-in ``jsonrpc``
+     - Eglot
+     - ``lsp-mode``
+   * - Extra dependency
+     - none
+     - Eglot (built in since Emacs 29)
+     - the external ``lsp-mode`` package
+   * - Provides
+     - diagnostics only
+     - full LSP (hover, completion, rename, ...)
+     - full LSP
+   * - Owns the buffer
+     - no - runs like any checker, can chain to a command checker
+     - yes
+     - yes
+   * - Best for
+     - single-purpose linters as a Flycheck checker
+     - a real language server you also edit with
+     - if you already run ``lsp-mode``
+
+In short: reach for ``flycheck-lsp-mode`` when you just want a linter that
+happens to speak LSP, and for ``flycheck-eglot-mode`` (see above) when you want
+a full language server whose diagnostics Flycheck should own.
+
+Configuring servers
+-------------------
+
+.. defcustom:: flycheck-lsp-servers
+
+   An alist mapping a major mode to the server command, as ``(MAJOR-MODE
+   PROGRAM ARG...)``.  The defaults map the Ruby, Python, JavaScript,
+   TypeScript, JSON and CSS modes to RuboCop, Ruff and Biome.
+
+   To add a server for another mode, push an entry.  For example, TFLint for
+   Terraform, or Vale for prose::
+
+      (add-to-list 'flycheck-lsp-servers '(terraform-mode "tflint" "--langserver"))
+      (add-to-list 'flycheck-lsp-servers '(markdown-mode "vale-ls"))
+
+   To point a mode at a different server, or drop one of the defaults, edit the
+   alist - e.g. use Ruff for Python but nothing for CSS::
+
+      (setf (alist-get 'python-mode flycheck-lsp-servers) '("ruff" "server"))
+      (setq flycheck-lsp-servers
+            (assq-delete-all 'css-mode flycheck-lsp-servers))
+
+   The server must speak LSP over stdio and publish diagnostics; a full
+   language server works too, but for one of those you usually want Eglot.  An
+   entry whose PROGRAM is not on `exec-path` is ignored, so listing a server
+   you have not installed is harmless.  Flycheck starts one process per project
+   root and command, feeds it the buffer's unsaved text, and shuts it down when
+   Emacs exits.
+
+.. defcustom:: flycheck-lsp-exclusive
+
+   When non-nil (the default), a buffer reports only the language server's
+   diagnostics.  Set to nil to have ``lsp`` chain to the first command checker
+   that supports the buffer's major mode, so the server and a command checker
+   both contribute.
+
+.. defcustom:: flycheck-lsp-initialize-timeout
+
+   How many seconds to wait for a server to answer the ``initialize``
+   handshake, which runs synchronously on the first check of a buffer.
+   Defaults to 5.
+
+Diagnostics from the ``lsp`` checker carry the same detail as Eglot's - error
+level, id, an explanation URL from ``codeDescription``, and the secondary
+locations of ``relatedInformation`` (visit them with ``C-c ! j``).

--- a/flycheck.el
+++ b/flycheck.el
@@ -10345,6 +10345,86 @@ SYMBOL with `flycheck-def-executable-var'."
          :working-directory ',(plist-get properties :working-directory)))))
 
 
+;;; LSP diagnostics
+;;
+;; Shared machinery for turning a Language Server Protocol diagnostic into a
+;; `flycheck-error'.  Both the Eglot bridge (`eglot-check', below) and the
+;; native `lsp' checker use it, so the two produce identical errors -- the
+;; same level, id, related locations and codeDescription -- regardless of how
+;; the diagnostic reached Flycheck.  These helpers operate on the raw LSP
+;; diagnostic object (a plist), not on any client's data structures.
+
+(defun flycheck-lsp--severity-level (severity)
+  "Map an LSP diagnostic SEVERITY (1-4) to a Flycheck error level.
+A missing severity is treated as an error, as Eglot does."
+  (pcase severity
+    (1 'error)
+    (2 'warning)
+    (3 'info)
+    (4 'info)                           ; LSP \"hint\"
+    (_ 'error)))
+
+(defun flycheck-lsp--diagnostic-id (lsp)
+  "Return the Flycheck error id for the LSP diagnostic plist LSP.
+
+Built from the diagnostic's `code', carrying its `codeDescription' href
+\(if any) as an `explainer-url' text property so
+`flycheck-explain-error-at-point' can open it."
+  (when-let* ((code (plist-get lsp :code)))
+    (let ((id (format "%s" code))
+          (href (plist-get (plist-get lsp :codeDescription) :href)))
+      (if href (propertize id 'explainer-url href) id))))
+
+(defun flycheck-lsp--uri-to-path (uri)
+  "Convert a `file:' URI to a local file path.
+
+Handles percent-encoding and the leading slash of a Windows drive URI
+\(file:///c:/...).  A non-`file:' URI is returned unchanged."
+  (if (string-prefix-p "file://" uri)
+      (let* ((enc (substring uri (length "file://")))
+             ;; Drop an authority component (file://host/path).
+             (enc (if (string-prefix-p "/" enc) enc
+                    (if-let* ((slash (string-search "/" enc)))
+                        (substring enc slash) enc)))
+             (path (url-unhex-string enc)))
+        (if (string-match-p "\\`/[a-zA-Z]:" path) (substring path 1) path))
+    uri))
+
+(defun flycheck-lsp--path-to-uri (path)
+  "Return a `file:' URI for the local PATH."
+  (let ((enc (url-hexify-string (expand-file-name path)
+                                (cons ?/ url-unreserved-chars))))
+    (concat "file://" (if (string-prefix-p "/" enc) enc (concat "/" enc)))))
+
+(defun flycheck-lsp--related-location (info)
+  "Convert one LSP `relatedInformation' entry INFO to a related location.
+
+INFO is a plist with a `location' (a `uri' and a `range') and a
+`message'.  LSP positions are 0-based; Flycheck columns are 1-based, so
+each is incremented.  The range end is exclusive in both, so it maps
+directly to Flycheck's right-open end column."
+  (let* ((location (plist-get info :location))
+         (uri (plist-get location :uri))
+         (range (plist-get location :range))
+         (start (plist-get range :start))
+         (end (plist-get range :end)))
+    (flycheck-related-location-new
+     :filename (and uri (flycheck-lsp--uri-to-path uri))
+     :line (and start (1+ (plist-get start :line)))
+     :column (and start (1+ (plist-get start :character)))
+     :end-line (and end (1+ (plist-get end :line)))
+     :end-column (and end (1+ (plist-get end :character)))
+     :message (plist-get info :message))))
+
+(defun flycheck-lsp--related-locations (lsp)
+  "Return the related locations of the LSP diagnostic plist LSP, as a list.
+
+Maps the diagnostic's `relatedInformation' entries to
+`flycheck-related-location' objects; nil when there are none."
+  (mapcar #'flycheck-lsp--related-location
+          (append (plist-get lsp :relatedInformation) nil)))
+
+
 ;;; Eglot integration
 ;;
 ;; Eglot, Emacs' built-in LSP client, renders its diagnostics through
@@ -10431,67 +10511,12 @@ is never selected unless the mode opted in."
   (and (bound-and-true-p flycheck-eglot-mode)
        (flycheck-eglot--available-p)))
 
-(defun flycheck-eglot--severity-level (severity)
-  "Map an LSP diagnostic SEVERITY (1-4) to a Flycheck error level.
-A missing severity is treated as an error, as Eglot does."
-  (pcase severity
-    (1 'error)
-    (2 'warning)
-    (3 'info)
-    (4 'info)                           ; LSP \"hint\"
-    (_ 'error)))
-
 (defun flycheck-eglot--type-level (type)
   "Map an Eglot Flymake diagnostic TYPE to a Flycheck error level."
   (pcase type
     ('eglot-note 'info)
     ('eglot-warning 'warning)
     (_ 'error)))
-
-(defun flycheck-eglot--diagnostic-id (lsp)
-  "Return the Flycheck error id for the LSP diagnostic plist LSP.
-
-Built from the diagnostic's `code', carrying its `codeDescription' href
-\(if any) as an `explainer-url' text property so
-`flycheck-explain-error-at-point' can open it."
-  (when-let* ((code (plist-get lsp :code)))
-    (let ((id (format "%s" code))
-          (href (plist-get (plist-get lsp :codeDescription) :href)))
-      (if href (propertize id 'explainer-url href) id))))
-
-(defun flycheck-eglot--uri-to-path (uri)
-  "Convert an LSP document URI to a file path, across Eglot versions."
-  (cond ((fboundp 'eglot-uri-to-path) (eglot-uri-to-path uri))
-        ((fboundp 'eglot--uri-to-path) (eglot--uri-to-path uri))
-        (t uri)))
-
-(defun flycheck-eglot--related-location (info)
-  "Convert one LSP `relatedInformation' entry INFO to a related location.
-
-INFO is a plist with a `location' (a `uri' and a `range') and a
-`message'.  LSP positions are 0-based; Flycheck columns are 1-based, so
-each is incremented.  The range end is exclusive in both, so it maps
-directly to Flycheck's right-open end column."
-  (let* ((location (plist-get info :location))
-         (uri (plist-get location :uri))
-         (range (plist-get location :range))
-         (start (plist-get range :start))
-         (end (plist-get range :end)))
-    (flycheck-related-location-new
-     :filename (and uri (flycheck-eglot--uri-to-path uri))
-     :line (and start (1+ (plist-get start :line)))
-     :column (and start (1+ (plist-get start :character)))
-     :end-line (and end (1+ (plist-get end :line)))
-     :end-column (and end (1+ (plist-get end :character)))
-     :message (plist-get info :message))))
-
-(defun flycheck-eglot--related-locations (lsp)
-  "Return the related locations of the LSP diagnostic plist LSP, as a list.
-
-Maps the diagnostic's `relatedInformation' entries to
-`flycheck-related-location' objects; nil when there are none."
-  (mapcar #'flycheck-eglot--related-location
-          (append (plist-get lsp :relatedInformation) nil)))
 
 (defun flycheck-eglot--convert-diagnostic (diag)
   "Convert the Eglot Flymake diagnostic DIAG to a `flycheck-error'.
@@ -10505,14 +10530,14 @@ as a fallback."
     (flycheck-error-new-at-pos
      (flymake-diagnostic-beg diag)
      (if lsp
-         (flycheck-eglot--severity-level (plist-get lsp :severity))
+         (flycheck-lsp--severity-level (plist-get lsp :severity))
        (flycheck-eglot--type-level (flymake-diagnostic-type diag)))
      (if lsp
          (plist-get lsp :message)
        (format "%s" (flymake-diagnostic-text diag)))
      :end-pos (flymake-diagnostic-end diag)
-     :id (and lsp (flycheck-eglot--diagnostic-id lsp))
-     :relations (and lsp (flycheck-eglot--related-locations lsp))
+     :id (and lsp (flycheck-lsp--diagnostic-id lsp))
+     :relations (and lsp (flycheck-lsp--related-locations lsp))
      :fix (flycheck-eglot--fix-provider)
      :checker 'eglot-check
      :buffer (current-buffer)

--- a/flycheck.el
+++ b/flycheck.el
@@ -244,7 +244,9 @@
     yaml-jsyaml
     yaml-yamllint
     ;; Only ever selected when `flycheck-eglot-mode' is on (see its predicate).
-    eglot-check)
+    eglot-check
+    ;; Only ever selected when `flycheck-lsp-mode' is on (see its predicate).
+    lsp)
   "Syntax checkers available for automatic selection.
 
 A list of Flycheck syntax checkers to choose from when syntax
@@ -10131,20 +10133,23 @@ information about SARIF."
             .results))))
      .runs)))
 
+(defun flycheck--file-uri-to-path (uri)
+  "Strip a `file://' scheme and authority from URI and percent-decode it.
+
+Both file:///abs/path and file://host/abs/path leave the leading slash of
+the path.  `url-unhex-string' returns the raw bytes of the percent
+escapes, which must be decoded, as file URIs percent-encode UTF-8."
+  (when uri
+    (when (string-match "\\`file://[^/]*" uri)
+      (setq uri (substring uri (match-end 0))))
+    (decode-coding-string (url-unhex-string uri) 'utf-8)))
+
 (defun flycheck-parse-sarif--uri (uri)
   "Turn a SARIF artifact-location URI into a file name.
 
-Strip a `file://' scheme and percent-decode URI; return relative
-URIs unchanged, for Flycheck to expand against the working
-directory."
-  (when uri
-    ;; Strip a file:// scheme and any authority: file:///abs/path and
-    ;; file://host/abs/path both leave the leading slash of the path
-    (when (string-match "\\`file://[^/]*" uri)
-      (setq uri (substring uri (match-end 0))))
-    ;; `url-unhex-string' returns the raw bytes of percent escapes, which
-    ;; must be decoded, as file URIs percent-encode UTF-8
-    (decode-coding-string (url-unhex-string uri) 'utf-8)))
+Strip a `file://' scheme and percent-decode URI; return relative URIs
+unchanged, for Flycheck to expand against the working directory."
+  (and uri (flycheck--file-uri-to-path uri)))
 
 (defun flycheck-parse-rustc (output checker buffer)
   "Parse rustc errors from OUTPUT and return a list of `flycheck-error'.
@@ -10378,15 +10383,12 @@ Built from the diagnostic's `code', carrying its `codeDescription' href
 (defun flycheck-lsp--uri-to-path (uri)
   "Convert a `file:' URI to a local file path.
 
-Handles percent-encoding and the leading slash of a Windows drive URI
-\(file:///c:/...).  A non-`file:' URI is returned unchanged."
+Percent-decoding and authority stripping are shared with the SARIF parser
+via `flycheck--file-uri-to-path'; this additionally trims the leading
+slash of a Windows drive URI (file:///c:/...).  A non-`file:' URI is
+returned unchanged."
   (if (string-prefix-p "file://" uri)
-      (let* ((enc (substring uri (length "file://")))
-             ;; Drop an authority component (file://host/path).
-             (enc (if (string-prefix-p "/" enc) enc
-                    (if-let* ((slash (string-search "/" enc)))
-                        (substring enc slash) enc)))
-             (path (url-unhex-string enc)))
+      (let ((path (flycheck--file-uri-to-path uri)))
         (if (string-match-p "\\`/[a-zA-Z]:" path) (substring path 1) path))
     uri))
 
@@ -10423,6 +10425,459 @@ Maps the diagnostic's `relatedInformation' entries to
 `flycheck-related-location' objects; nil when there are none."
   (mapcar #'flycheck-lsp--related-location
           (append (plist-get lsp :relatedInformation) nil)))
+
+(defun flycheck-lsp--register-checker (checker exclusive)
+  "Teach CHECKER the current buffer's major mode and set up its chaining.
+
+With EXCLUSIVE non-nil, CHECKER is the buffer's sole checker; otherwise it
+chains to the first other checker that supports the mode, so an LSP
+backend and a command checker both contribute.  Shared by the `lsp' and
+`eglot-check' bridges."
+  (unless (flycheck-checker-supports-major-mode-p checker major-mode)
+    (flycheck-add-mode checker major-mode))
+  (if exclusive
+      (setf (flycheck-checker-get checker 'next-checkers) nil)
+    (when-let* ((next (seq-find
+                       (lambda (c)
+                         (and (not (eq c checker))
+                              (flycheck-checker-supports-major-mode-p c major-mode)))
+                       flycheck-checkers)))
+      (flycheck-add-next-checker checker next 'append))))
+
+
+;;; Native LSP diagnostics client
+;;
+;; The `lsp' checker talks to a diagnostics language server directly, over
+;; the built-in `jsonrpc' library -- no Eglot required.  It is meant for the
+;; single-purpose LSP linters (`rubocop --lsp', `ruff server', ...), letting
+;; Flycheck use them like any other checker without handing the buffer to a
+;; full LSP client.
+;;
+;; LSP pushes diagnostics whenever it wants, which does not line up with
+;; Flycheck's on-demand model.  The reconciliation mirrors the Eglot bridge:
+;; a `:start' syncs the buffer to its server and reports the diagnostics
+;; cached so far; the server's later `publishDiagnostics' push updates the
+;; cache and re-triggers a check so the fresh diagnostics reach the buffer.
+;;
+;; One server process is shared per (project root, command); a buffer opens
+;; its document on the matching server on the first check and closes it when
+;; the buffer or the mode goes away, shutting the server down once its last
+;; document closes.
+
+(declare-function jsonrpc-request "jsonrpc" (connection method params &rest _))
+(declare-function jsonrpc-notify "jsonrpc" (connection method params))
+(declare-function jsonrpc-shutdown "jsonrpc" (connection &optional cleanup))
+(declare-function jsonrpc-running-p "jsonrpc" (connection))
+(declare-function project-current "project" (&optional maybe-prompt directory))
+
+(defcustom flycheck-lsp-servers
+  '((ruby-mode "rubocop" "--lsp")
+    (ruby-ts-mode "rubocop" "--lsp")
+    (python-mode "ruff" "server")
+    (python-ts-mode "ruff" "server")
+    (js-mode "biome" "lsp-proxy")
+    (js-ts-mode "biome" "lsp-proxy")
+    (typescript-ts-mode "biome" "lsp-proxy")
+    (tsx-ts-mode "biome" "lsp-proxy")
+    (json-mode "biome" "lsp-proxy")
+    (json-ts-mode "biome" "lsp-proxy")
+    (jsonc-mode "biome" "lsp-proxy")
+    (css-mode "biome" "lsp-proxy")
+    (css-ts-mode "biome" "lsp-proxy"))
+  "Alist mapping a major mode to a diagnostics LSP server command.
+
+Each entry is (MAJOR-MODE PROGRAM ARG...): a buffer in MAJOR-MODE that
+enables `flycheck-lsp-mode' has PROGRAM started with the ARGs as an LSP
+server, is fed the buffer's text, and reports the diagnostics the server
+pushes back through the `lsp' checker.
+
+The default entries cover single-purpose linters that ship an LSP mode --
+RuboCop (Ruby), Ruff (Python) and Biome (JavaScript, TypeScript, JSON,
+CSS).  An entry is only used when its PROGRAM is on `exec-path' (see
+`executable-find'), so listing a server you have not installed is
+harmless; add your own the same way, e.g.
+
+    (add-to-list \\='flycheck-lsp-servers
+                 \\='(terraform-mode \"tflint\" \"--langserver\"))
+
+The server needs to speak LSP over stdio and publish diagnostics.  For a
+full language server (hover, completion, rename) you usually want Eglot
+and `flycheck-eglot-mode' instead."
+  :type '(alist :key-type (symbol :tag "Major mode")
+                :value-type (repeat (string :tag "Command argument")))
+  :group 'flycheck
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-lsp-exclusive t
+  "Whether the `lsp' checker is the only checker or chains to others.
+
+When non-nil (the default), a buffer using `flycheck-lsp-mode' reports
+only the language server's diagnostics.  When nil, `lsp' chains to the
+first other checker that supports the buffer's major mode, so the server
+and a command checker can both contribute."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'flycheck
+  :package-version '(flycheck . "38"))
+
+(defcustom flycheck-lsp-initialize-timeout 5
+  "Seconds to wait for a language server to answer `initialize'.
+
+The handshake is synchronous, so the first check of a buffer whose server
+is not running yet blocks Emacs for up to this long while the server
+starts.  A server that does not answer in time is treated as failed to
+start."
+  :type 'number
+  :group 'flycheck
+  :package-version '(flycheck . "38"))
+
+(cl-defstruct (flycheck-lsp--doc (:constructor flycheck-lsp--doc-create)
+                                 (:copier nil))
+  "The state of one document open on a server.
+VERSION is nil until the document has been opened."
+  buffer version tick
+  (diags nil))                          ; latest raw LSP diagnostics
+
+(cl-defstruct (flycheck-lsp--server (:constructor flycheck-lsp--server-create)
+                                    (:copier nil))
+  "A running diagnostics LSP server and the state of its open documents.
+
+The `documents' table maps a document's canonical path (see
+`flycheck-lsp--doc-key') to a `flycheck-lsp--doc'."
+  connection root command stderr
+  (documents (make-hash-table :test 'equal)))
+
+(defvar flycheck-lsp--servers (make-hash-table :test 'equal)
+  "Live `flycheck-lsp--server's, keyed by (ROOT . COMMAND).")
+
+(defvar flycheck-lsp--suppress-recheck nil
+  "When non-nil, a diagnostics push does not re-trigger a check.
+Bound while a push-triggered check runs, so it cannot recurse.")
+
+(defun flycheck-lsp--command (mode)
+  "Return the LSP server command configured for major MODE, or nil."
+  (alist-get mode flycheck-lsp-servers))
+
+(defun flycheck-lsp--available-command (mode)
+  "Return the server command for MODE if its program is installed, else nil.
+Uses `flycheck-executable-find', so it honours the user's setting and TRAMP."
+  (when-let* ((command (flycheck-lsp--command mode)))
+    (and (funcall flycheck-executable-find (car command)) command)))
+
+(defun flycheck-lsp--language-id (mode)
+  "Return a best-effort LSP languageId string for major MODE."
+  (replace-regexp-in-string "\\(?:-ts\\)?-mode\\'" "" (symbol-name mode)))
+
+(defvar-local flycheck-lsp--cached-root nil
+  "Cached workspace root for this buffer; see `flycheck-lsp--root'.")
+
+(defun flycheck-lsp--root ()
+  "Return the workspace root for the current buffer, as an absolute path.
+The result is cached buffer-locally, as `project-current' is not free and
+the root does not change over a buffer's life."
+  (or flycheck-lsp--cached-root
+      (setq flycheck-lsp--cached-root
+            (or (when-let* ((project (and (fboundp 'project-current)
+                                          (project-current))))
+                  (expand-file-name (project-root project)))
+                (and buffer-file-name (file-name-directory buffer-file-name))
+                (expand-file-name default-directory)))))
+
+(defun flycheck-lsp--buffer-uri ()
+  "Return the `file:' URI of the current buffer's file, or nil."
+  (and buffer-file-name (flycheck-lsp--path-to-uri buffer-file-name)))
+
+(defun flycheck-lsp--doc-key (uri)
+  "Return the canonical key (an absolute path) for the document URI.
+
+The client and the server may spell the same file's URI differently (a
+re-encoded percent escape, an authority component, a Windows drive
+case).  Keying open documents and their diagnostics on the decoded,
+expanded path -- rather than the raw URI -- makes both sides agree."
+  (expand-file-name (flycheck-lsp--uri-to-path uri)))
+
+(defun flycheck-lsp--server-live-p (server)
+  "Return non-nil when SERVER's connection is still running."
+  (let ((conn (flycheck-lsp--server-connection server)))
+    (and conn (jsonrpc-running-p conn))))
+
+(defun flycheck-lsp--handle-notification (server method params)
+  "Handle an LSP notification METHOD with PARAMS from SERVER.
+
+Only `textDocument/publishDiagnostics' is used: cache the diagnostics on
+their document and, if a live buffer owns it, re-trigger its check so the
+fresh diagnostics are published (guarded against recursion)."
+  (when (eq method 'textDocument/publishDiagnostics)
+    (let ((doc (flycheck-lsp--document
+                server (flycheck-lsp--doc-key (plist-get params :uri)))))
+      (setf (flycheck-lsp--doc-diags doc)
+            (append (plist-get params :diagnostics) nil))
+      (when-let* ((buffer (flycheck-lsp--doc-buffer doc))
+                  ((buffer-live-p buffer)))
+        (with-current-buffer buffer
+          (when (and flycheck-mode (not flycheck-lsp--suppress-recheck))
+            (let ((flycheck-lsp--suppress-recheck t))
+              (flycheck-buffer-automatically))))))))
+
+(defun flycheck-lsp--document (server key)
+  "Return the `flycheck-lsp--doc' for KEY on SERVER, creating it if needed."
+  (or (gethash key (flycheck-lsp--server-documents server))
+      (puthash key (flycheck-lsp--doc-create)
+               (flycheck-lsp--server-documents server))))
+
+(defun flycheck-lsp--start-server (root command)
+  "Start and initialize an LSP server running COMMAND under ROOT.
+Return the `flycheck-lsp--server', or nil if it could not be started."
+  (require 'jsonrpc)
+  (add-hook 'kill-emacs-hook #'flycheck-lsp--shutdown-all)
+  (let* ((default-directory root)
+         (name (format "flycheck-lsp:%s" (car command)))
+         (stderr (get-buffer-create (format " *%s stderr*" name)))
+         (server (flycheck-lsp--server-create :root root :command command
+                                              :stderr stderr))
+         (proc (make-process
+                :name name :command command :connection-type 'pipe
+                :coding 'utf-8-emacs-unix :noquery t :stderr stderr)))
+    (condition-case err
+        (let ((conn (make-instance
+                     'jsonrpc-process-connection
+                     :name name :process proc
+                     :notification-dispatcher
+                     (lambda (_conn method params)
+                       (flycheck-lsp--handle-notification server method params))
+                     :request-dispatcher (lambda (&rest _) nil))))
+          (setf (flycheck-lsp--server-connection server) conn)
+          ;; The handshake is synchronous, so this can block Emacs briefly on
+          ;; the first check; `flycheck-lsp-initialize-timeout' bounds the wait.
+          (jsonrpc-request conn 'initialize
+                           (list :processId (emacs-pid)
+                                 :rootUri (flycheck-lsp--path-to-uri root)
+                                 :capabilities
+                                 '(:textDocument
+                                   (:publishDiagnostics (:relatedInformation t))))
+                           :timeout flycheck-lsp-initialize-timeout)
+          (jsonrpc-notify conn 'initialized (make-hash-table :test 'eq))
+          server)
+      (error
+       (ignore-errors (delete-process proc))
+       (ignore-errors (kill-buffer stderr))
+       (message "Flycheck LSP: %s failed to start: %s"
+                (car command) (error-message-string err))
+       nil))))
+
+(defun flycheck-lsp--ensure-server (root command)
+  "Return a live server for ROOT and COMMAND, starting one if needed."
+  (let* ((key (cons root command))
+         (server (gethash key flycheck-lsp--servers)))
+    (unless (and server (flycheck-lsp--server-live-p server))
+      (setq server (flycheck-lsp--start-server root command))
+      (if server
+          (puthash key server flycheck-lsp--servers)
+        (remhash key flycheck-lsp--servers)))
+    server))
+
+(defun flycheck-lsp--notify (server method params)
+  "Send an LSP notification METHOD with PARAMS to SERVER."
+  (jsonrpc-notify (flycheck-lsp--server-connection server) method params))
+
+(defun flycheck-lsp--sync-document (server doc uri language)
+  "Send the current buffer's text to SERVER for the document DOC at URI.
+
+LANGUAGE is the LSP languageId.  Send `textDocument/didOpen' the first
+time the document is seen (DOC's version is nil), then
+`textDocument/didChange' with the whole text whenever the buffer changed
+since the last sync (tracked by `buffer-chars-modified-tick'), and nothing
+when it did not -- so a push-triggered recheck does not re-send.  The
+whole-buffer copy is taken only when a message is actually sent."
+  (let ((tick (buffer-chars-modified-tick))
+        (version (flycheck-lsp--doc-version doc)))
+    (cond
+     ((null version)
+      (flycheck-lsp--notify
+       server 'textDocument/didOpen
+       (list :textDocument
+             (list :uri uri :languageId language :version 1
+                   :text (buffer-substring-no-properties (point-min) (point-max)))))
+      (setf (flycheck-lsp--doc-version doc) 1
+            (flycheck-lsp--doc-tick doc) tick))
+     ((/= (flycheck-lsp--doc-tick doc) tick)
+      (cl-incf (flycheck-lsp--doc-version doc))
+      (flycheck-lsp--notify
+       server 'textDocument/didChange
+       (list :textDocument (list :uri uri :version (flycheck-lsp--doc-version doc))
+             :contentChanges
+             (vector (list :text (buffer-substring-no-properties
+                                  (point-min) (point-max))))))
+      (setf (flycheck-lsp--doc-tick doc) tick)))))
+
+(defun flycheck-lsp--position-to-point (line character)
+  "Return the buffer point for 0-based LINE and UTF-16 CHARACTER.
+
+LSP counts a character offset in UTF-16 code units, so a character
+outside the Basic Multilingual Plane counts as two; step over the line
+accordingly to land on the right buffer position."
+  (save-excursion
+    (save-restriction
+      (widen)
+      (goto-char (point-min))
+      (forward-line line)
+      (let ((remaining character)
+            (eol (line-end-position)))
+        (while (and (> remaining 0) (< (point) eol))
+          (setq remaining (- remaining (if (<= #x10000 (char-after)) 2 1)))
+          (forward-char 1))
+        (point)))))
+
+(defun flycheck-lsp--diagnostic->error (lsp buffer)
+  "Convert the raw LSP diagnostic plist LSP for BUFFER to a `flycheck-error'.
+Reuses the shared LSP mapping for the level, id and related locations."
+  (with-current-buffer buffer
+    (let* ((range (plist-get lsp :range))
+           (start (plist-get range :start))
+           (end (plist-get range :end)))
+      (flycheck-error-new-at-pos
+       (flycheck-lsp--position-to-point
+        (plist-get start :line) (plist-get start :character))
+       (flycheck-lsp--severity-level (plist-get lsp :severity))
+       (plist-get lsp :message)
+       :end-pos (flycheck-lsp--position-to-point
+                 (plist-get end :line) (plist-get end :character))
+       :id (flycheck-lsp--diagnostic-id lsp)
+       :relations (flycheck-lsp--related-locations lsp)
+       :checker 'lsp
+       :buffer buffer
+       :filename (buffer-file-name buffer)))))
+
+(defun flycheck-lsp--start (_checker callback)
+  "Start the `lsp' syntax check, reporting through CALLBACK.
+
+Ensure the buffer's server is running, sync the document to it, and report
+the diagnostics cached for the buffer so far.  The server's later push
+re-triggers the check to deliver fresh diagnostics.  The command, file and
+server are all guaranteed by the checker's predicate, but a server that
+fails to start still yields no diagnostics rather than an error."
+  (condition-case err
+      (let* ((command (flycheck-lsp--command major-mode))
+             (uri (flycheck-lsp--buffer-uri))
+             (server (and command uri
+                          (flycheck-lsp--ensure-server (flycheck-lsp--root)
+                                                       command))))
+        (if (not server)
+            (funcall callback 'finished nil)
+          (let* ((buffer (current-buffer))
+                 (doc (flycheck-lsp--document
+                       server (expand-file-name buffer-file-name))))
+            (setf (flycheck-lsp--doc-buffer doc) buffer)
+            (flycheck-lsp--sync-document
+             server doc uri (flycheck-lsp--language-id major-mode))
+            (funcall callback 'finished
+                     (mapcar (lambda (d) (flycheck-lsp--diagnostic->error d buffer))
+                             (flycheck-lsp--doc-diags doc))))))
+    (error (funcall callback 'errored (error-message-string err)))))
+
+(defun flycheck-lsp--enabled-p ()
+  "Return non-nil when the `lsp' checker may run in the current buffer.
+
+That is, `flycheck-lsp-mode' is on, the buffer visits a file, and its
+major mode has a server in `flycheck-lsp-servers' whose program is
+installed.  Used as the checker's predicate so `lsp' is never selected
+unless the mode opted in and the server is actually available."
+  (and (bound-and-true-p flycheck-lsp-mode)
+       buffer-file-name
+       (flycheck-lsp--available-command major-mode)
+       t))
+
+(flycheck-define-generic-checker 'lsp
+  "Report the diagnostics of a Language Server Protocol server.
+
+Talks to the server configured for the buffer's major mode in
+`flycheck-lsp-servers' directly, over the built-in `jsonrpc' library, with
+no Eglot involved.  Enabled by `flycheck-lsp-mode'."
+  :start #'flycheck-lsp--start
+  :predicate #'flycheck-lsp--enabled-p
+  :modes '(prog-mode text-mode))
+
+(defun flycheck-lsp--shutdown-server (server)
+  "Politely shut SERVER's language server down and free its buffers."
+  (let ((conn (flycheck-lsp--server-connection server)))
+    (when (and conn (jsonrpc-running-p conn))
+      (ignore-errors (jsonrpc-request conn 'shutdown nil :timeout 1))
+      (ignore-errors (jsonrpc-notify conn 'exit nil))
+      (ignore-errors (jsonrpc-shutdown conn t))))
+  (when-let* ((stderr (flycheck-lsp--server-stderr server)))
+    (when (buffer-live-p stderr) (kill-buffer stderr))))
+
+(defun flycheck-lsp--close-buffer ()
+  "Close the current buffer's document on any server holding it.
+
+The server itself is left running -- like Eglot, it is kept for the rest
+of the session and torn down only when Emacs exits (see
+`flycheck-lsp--shutdown-all') -- so reopening or checking another of its
+files does not pay to restart it."
+  (when-let* ((uri (flycheck-lsp--buffer-uri))
+              (key (expand-file-name buffer-file-name)))
+    (maphash
+     (lambda (_server-key server)
+       (when (gethash key (flycheck-lsp--server-documents server))
+         (remhash key (flycheck-lsp--server-documents server))
+         (when (flycheck-lsp--server-live-p server)
+           (ignore-errors
+             (flycheck-lsp--notify server 'textDocument/didClose
+                                   (list :textDocument (list :uri uri)))))))
+     flycheck-lsp--servers)))
+
+(defun flycheck-lsp--shutdown-all ()
+  "Shut down every running LSP server.
+Added to `kill-emacs-hook' the first time a server starts."
+  (maphash (lambda (key server)
+             (flycheck-lsp--shutdown-server server)
+             (remhash key flycheck-lsp--servers))
+           flycheck-lsp--servers))
+
+(defun flycheck-lsp--enable ()
+  "Set up the current buffer to report its LSP server's diagnostics.
+A no-op unless the mode's server is configured and installed."
+  (when (flycheck-lsp--available-command major-mode)
+    (flycheck-lsp--register-checker 'lsp flycheck-lsp-exclusive)
+    (setq flycheck-checker 'lsp)
+    (unless flycheck-mode (flycheck-mode 1))
+    (flycheck-buffer-deferred)))
+
+(defun flycheck-lsp--disable ()
+  "Undo `flycheck-lsp--enable' in the current buffer."
+  (flycheck-lsp--close-buffer)
+  (when (eq flycheck-checker 'lsp)
+    (setq flycheck-checker nil))
+  (when flycheck-mode
+    (flycheck-buffer-deferred)))
+
+;;;###autoload
+(define-minor-mode flycheck-lsp-mode
+  "Minor mode to report a Language Server's diagnostics through Flycheck.
+
+When enabled, and the buffer's major mode has a server configured in
+`flycheck-lsp-servers', Flycheck starts that server and shows the
+diagnostics it reports (via the `lsp' checker), talking LSP directly
+without Eglot.  With `flycheck-lsp-exclusive' nil, `lsp' chains to the
+command checkers so both contribute.
+
+Enable it for every configured buffer with `global-flycheck-lsp-mode'.
+For a full language server, prefer Eglot and `flycheck-eglot-mode'."
+  :lighter nil
+  :group 'flycheck
+  (if flycheck-lsp-mode
+      (progn
+        (add-hook 'kill-buffer-hook #'flycheck-lsp--close-buffer nil t)
+        (flycheck-lsp--enable))
+    (remove-hook 'kill-buffer-hook #'flycheck-lsp--close-buffer t)
+    (flycheck-lsp--disable)))
+
+;;;###autoload
+(define-globalized-minor-mode global-flycheck-lsp-mode
+  flycheck-lsp-mode
+  (lambda ()
+    (when (flycheck-lsp--available-command major-mode) (flycheck-lsp-mode 1)))
+  :group 'flycheck)
 
 
 ;;; Eglot integration
@@ -10695,27 +11150,10 @@ ORIG is the advised function; BEG, END and ARGS are its arguments."
                          (or (null beg) (<= beg de)))))
                 flycheck-eglot--diagnostics)))
 
-(defun flycheck-eglot--register ()
-  "Prepare `eglot-check' for the current buffer's major mode.
-
-`eglot-check' is already in `flycheck-checkers'; this just teaches it the
-buffer's major mode when needed and sets up chaining per
-`flycheck-eglot-exclusive'."
-  (unless (flycheck-checker-supports-major-mode-p 'eglot-check major-mode)
-    (flycheck-add-mode 'eglot-check major-mode))
-  (if flycheck-eglot-exclusive
-      (setf (flycheck-checker-get 'eglot-check 'next-checkers) nil)
-    (when-let* ((next (seq-find
-                       (lambda (c)
-                         (and (not (eq c 'eglot-check))
-                              (flycheck-checker-supports-major-mode-p c major-mode)))
-                       flycheck-checkers)))
-      (flycheck-add-next-checker 'eglot-check next 'append))))
-
 (defun flycheck-eglot--enable ()
   "Set up the current buffer to report Eglot diagnostics through Flycheck."
   (when (flycheck-eglot--available-p)
-    (flycheck-eglot--register)
+    (flycheck-lsp--register-checker 'eglot-check flycheck-eglot-exclusive)
     (setq flycheck-checker 'eglot-check)
     ;; Suppress the recheck the synchronous report may fire; the trailing
     ;; `flycheck-buffer-deferred' triggers the first check instead.

--- a/test/specs/test-documentation.el
+++ b/test/specs/test-documentation.el
@@ -66,9 +66,12 @@
                                                 languages)))
 
         (it "documents all syntax checkers"
-          ;; `eglot-check' is not a per-language command checker; it is
-          ;; documented in the Eglot section of the manual, not languages.rst.
-          (expect (seq-difference (remq 'eglot-check flycheck-checkers) checkers)
+          ;; `eglot-check' and `lsp' are not per-language command checkers;
+          ;; they are documented in the LSP sections of the manual, not
+          ;; languages.rst.
+          (expect (seq-difference
+                   (seq-difference flycheck-checkers '(eglot-check lsp))
+                   checkers)
                   :to-equal nil))
 
         (it "doesn't document syntax checkers that don't exist"

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -35,28 +35,6 @@
 
 (describe "Eglot integration"
 
-  (describe "flycheck-eglot--severity-level"
-    (it "maps LSP severities to Flycheck levels"
-      (expect (flycheck-eglot--severity-level 1) :to-be 'error)
-      (expect (flycheck-eglot--severity-level 2) :to-be 'warning)
-      (expect (flycheck-eglot--severity-level 3) :to-be 'info)
-      (expect (flycheck-eglot--severity-level 4) :to-be 'info))
-    (it "treats a missing severity as an error"
-      (expect (flycheck-eglot--severity-level nil) :to-be 'error)))
-
-  (describe "flycheck-eglot--diagnostic-id"
-    (it "uses the diagnostic code"
-      (expect (substring-no-properties
-               (flycheck-eglot--diagnostic-id '(:code "E501")))
-              :to-equal "E501"))
-    (it "carries a codeDescription href as an explainer URL"
-      (let ((id (flycheck-eglot--diagnostic-id
-                 '(:code "E501" :codeDescription (:href "https://x/E501")))))
-        (expect (get-text-property 0 'explainer-url id)
-                :to-equal "https://x/E501")))
-    (it "is nil without a code"
-      (expect (flycheck-eglot--diagnostic-id '(:message "x")) :to-be nil)))
-
   (describe "flycheck-eglot--convert-diagnostic"
     (it "reads level, message and id from the LSP diagnostic in the data slot"
       (flycheck-buttercup-with-temp-buffer
@@ -83,48 +61,23 @@
     (it "maps the diagnostic's relatedInformation to related locations"
       (flycheck-buttercup-with-temp-buffer
         (insert "line one here\n")
-        (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity))
-          (let* ((diag (test-eglot--diag
-                        (current-buffer) 1 5 :error "redefined"
-                        '(:severity 1 :message "redefined"
-                          :relatedInformation
-                          [(:location (:uri "other.el"
-                                       :range (:start (:line 1 :character 4)
-                                               :end (:line 1 :character 9)))
-                            :message "first defined here")])))
-                 (err (flycheck-eglot--convert-diagnostic diag))
-                 (rel (car (flycheck-error-relations err))))
-            (expect (length (flycheck-error-relations err)) :to-equal 1)
-            (expect (flycheck-related-location-filename rel) :to-equal "other.el")
-            (expect (flycheck-related-location-line rel) :to-equal 2)
-            (expect (flycheck-related-location-column rel) :to-equal 5)
-            (expect (flycheck-related-location-end-column rel) :to-equal 10)
-            (expect (flycheck-related-location-message rel)
-                    :to-equal "first defined here"))))))
-
-  (describe "flycheck-eglot--related-locations"
-    (it "returns nil when there is no relatedInformation"
-      (expect (flycheck-eglot--related-locations '(:message "x")) :to-be nil))
-
-    (it "converts each entry, incrementing LSP's 0-based positions"
-      (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity))
-        (let* ((locs (flycheck-eglot--related-locations
-                      '(:relatedInformation
-                        [(:location (:uri "a.el"
-                                     :range (:start (:line 0 :character 0)
-                                             :end (:line 0 :character 3)))
-                          :message "one")
-                         (:location (:uri "b.el"
-                                     :range (:start (:line 9 :character 2)
-                                             :end (:line 9 :character 2)))
-                          :message "two")]))))
-          (expect (length locs) :to-equal 2)
-          (expect (flycheck-related-location-line (nth 0 locs)) :to-equal 1)
-          (expect (flycheck-related-location-column (nth 0 locs)) :to-equal 1)
-          (expect (flycheck-related-location-filename (nth 1 locs))
-                  :to-equal "b.el")
-          (expect (flycheck-related-location-line (nth 1 locs))
-                  :to-equal 10)))))
+        (let* ((diag (test-eglot--diag
+                      (current-buffer) 1 5 :error "redefined"
+                      '(:severity 1 :message "redefined"
+                        :relatedInformation
+                        [(:location (:uri "other.el"
+                                     :range (:start (:line 1 :character 4)
+                                             :end (:line 1 :character 9)))
+                          :message "first defined here")])))
+               (err (flycheck-eglot--convert-diagnostic diag))
+               (rel (car (flycheck-error-relations err))))
+          (expect (length (flycheck-error-relations err)) :to-equal 1)
+          (expect (flycheck-related-location-filename rel) :to-equal "other.el")
+          (expect (flycheck-related-location-line rel) :to-equal 2)
+          (expect (flycheck-related-location-column rel) :to-equal 5)
+          (expect (flycheck-related-location-end-column rel) :to-equal 10)
+          (expect (flycheck-related-location-message rel)
+                  :to-equal "first defined here")))))
 
   (describe "flycheck-eglot--report"
     (it "caches the diagnostics and re-triggers a check"

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -54,6 +54,9 @@
     (it "decodes a file URI to a local path"
       (expect (flycheck-lsp--uri-to-path "file:///tmp/a%20b.rb")
               :to-equal "/tmp/a b.rb"))
+    (it "decodes percent-encoded UTF-8 back to a multibyte path"
+      (expect (flycheck-lsp--uri-to-path "file:///tmp/caf%C3%A9.rb")
+              :to-equal "/tmp/café.rb"))
     (it "strips the leading slash of a Windows drive URI"
       (expect (flycheck-lsp--uri-to-path "file:///c:/x/y.rb")
               :to-equal "c:/x/y.rb"))
@@ -61,10 +64,17 @@
       (expect (flycheck-lsp--uri-to-path "untitled:1") :to-equal "untitled:1")))
 
   (describe "flycheck-lsp--path-to-uri"
-    (it "round-trips with uri-to-path"
+    ;; The round-trip normalizes through `expand-file-name' (which on Windows
+    ;; adds the current drive), so compare against the expanded path, not the
+    ;; literal, to stay portable.
+    (it "round-trips an ASCII path with uri-to-path"
       (expect (flycheck-lsp--uri-to-path
                (flycheck-lsp--path-to-uri "/tmp/a b.rb"))
-              :to-equal "/tmp/a b.rb")))
+              :to-equal (expand-file-name "/tmp/a b.rb")))
+    (it "round-trips a non-ASCII path with uri-to-path"
+      (expect (flycheck-lsp--uri-to-path
+               (flycheck-lsp--path-to-uri "/tmp/café.rb"))
+              :to-equal (expand-file-name "/tmp/café.rb"))))
 
   (describe "flycheck-lsp--related-locations"
     (it "returns nil when there is no relatedInformation"
@@ -87,6 +97,154 @@
         (expect (flycheck-related-location-filename (nth 1 locs))
                 :to-equal "b.el")
         (expect (flycheck-related-location-line (nth 1 locs))
-                :to-equal 10)))))
+                :to-equal 10))))
+
+  (describe "the native lsp checker"
+
+    (describe "flycheck-lsp--language-id"
+      (it "strips the -mode and -ts-mode suffixes"
+        (expect (flycheck-lsp--language-id 'ruby-mode) :to-equal "ruby")
+        (expect (flycheck-lsp--language-id 'ruby-ts-mode) :to-equal "ruby")
+        (expect (flycheck-lsp--language-id 'js-mode) :to-equal "js")))
+
+    (describe "flycheck-lsp--command"
+      (it "returns the configured command for a mode, nil otherwise"
+        (let ((flycheck-lsp-servers '((ruby-mode "rubocop" "--lsp"))))
+          (expect (flycheck-lsp--command 'ruby-mode)
+                  :to-equal '("rubocop" "--lsp"))
+          (expect (flycheck-lsp--command 'python-mode) :to-be nil))))
+
+    (describe "flycheck-lsp--position-to-point"
+      (it "converts a 0-based line and column to a buffer point"
+        (flycheck-buttercup-with-temp-buffer
+          (insert "abc\ndef\n")
+          ;; line 1 (\"def\"), character 2 -> the \"f\"
+          (expect (char-after (flycheck-lsp--position-to-point 1 2))
+                  :to-equal ?f)))
+      (it "counts an astral character as two UTF-16 code units"
+        (flycheck-buttercup-with-temp-buffer
+          (insert "\U0001D54Fyz\n")   ; one astral char, then y z
+          ;; character offset 2 is past the 2-unit astral char, on the \"y\"
+          (expect (char-after (flycheck-lsp--position-to-point 0 2))
+                  :to-equal ?y))))
+
+    (describe "flycheck-lsp--diagnostic->error"
+      (it "maps a raw LSP diagnostic to a flycheck-error"
+        (flycheck-buttercup-with-temp-buffer
+          (insert "abcdef\n")
+          (let ((err (flycheck-lsp--diagnostic->error
+                      '(:severity 2 :message "oops" :code "C1"
+                        :range (:start (:line 0 :character 1)
+                                :end (:line 0 :character 4)))
+                      (current-buffer))))
+            (expect (flycheck-error-level err) :to-be 'warning)
+            (expect (flycheck-error-message err) :to-equal "oops")
+            (expect (substring-no-properties (flycheck-error-id err))
+                    :to-equal "C1")
+            (expect (flycheck-error-line err) :to-equal 1)
+            (expect (flycheck-error-column err) :to-equal 2)
+            (expect (flycheck-error-checker err) :to-be 'lsp)))))
+
+    (describe "flycheck-lsp--enabled-p"
+      (it "is non-nil only with the mode on, a file, and an installed server"
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local major-mode 'ruby-mode)
+          (cl-letf (((symbol-function 'executable-find)
+                     (lambda (program &rest _) (concat "/usr/bin/" program))))
+            (let ((flycheck-lsp-servers '((ruby-mode "rubocop" "--lsp")))
+                  (flycheck-lsp-mode t)
+                  (buffer-file-name "/x/a.rb"))
+              (expect (flycheck-lsp--enabled-p) :to-be-truthy)
+              (setq-local major-mode 'python-mode)
+              (expect (flycheck-lsp--enabled-p) :to-be nil)
+              (setq-local major-mode 'ruby-mode)
+              (setq buffer-file-name nil)
+              (expect (flycheck-lsp--enabled-p) :to-be nil)))))
+      (it "is nil when the configured server is not installed"
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local major-mode 'ruby-mode)
+          (cl-letf (((symbol-function 'executable-find) (lambda (&rest _) nil)))
+            (let ((flycheck-lsp-servers '((ruby-mode "rubocop" "--lsp")))
+                  (flycheck-lsp-mode t)
+                  (buffer-file-name "/x/a.rb"))
+              (expect (flycheck-lsp--enabled-p) :to-be nil))))))
+
+    (describe "flycheck-lsp--handle-notification"
+      (it "caches diagnostics and re-triggers the owning buffer's check"
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local flycheck-mode t)
+          (spy-on 'flycheck-buffer-automatically)
+          (let* ((server (flycheck-lsp--server-create))
+                 (uri "file:///x/a.rb")
+                 (doc (flycheck-lsp--document server (flycheck-lsp--doc-key uri))))
+            (setf (flycheck-lsp--doc-buffer doc) (current-buffer))
+            (flycheck-lsp--handle-notification
+             server 'textDocument/publishDiagnostics
+             (list :uri uri :diagnostics (vector '(:severity 1 :message "m"))))
+            (expect (length (flycheck-lsp--doc-diags doc)) :to-equal 1)
+            (expect 'flycheck-buffer-automatically :to-have-been-called))))
+      (it "routes a re-encoded server URI to the same document"
+        ;; The buffer is registered under one URI spelling; a push under a
+        ;; different spelling of the same file must still reach it.
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local flycheck-mode t)
+          (spy-on 'flycheck-buffer-automatically)
+          (let* ((server (flycheck-lsp--server-create))
+                 (doc (flycheck-lsp--document
+                       server (flycheck-lsp--doc-key "file:///x/a.rb"))))
+            (setf (flycheck-lsp--doc-buffer doc) (current-buffer))
+            (flycheck-lsp--handle-notification
+             server 'textDocument/publishDiagnostics
+             (list :uri "file://localhost/x/a.rb"
+                   :diagnostics (vector '(:severity 1 :message "m"))))
+            (expect 'flycheck-buffer-automatically :to-have-been-called))))
+      (it "does not re-trigger while suppressed"
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local flycheck-mode t)
+          (spy-on 'flycheck-buffer-automatically)
+          (let* ((server (flycheck-lsp--server-create))
+                 (uri "file:///x/a.rb")
+                 (doc (flycheck-lsp--document server (flycheck-lsp--doc-key uri)))
+                 (flycheck-lsp--suppress-recheck t))
+            (setf (flycheck-lsp--doc-buffer doc) (current-buffer))
+            (flycheck-lsp--handle-notification
+             server 'textDocument/publishDiagnostics
+             (list :uri uri :diagnostics (vector '(:severity 1 :message "m"))))
+            (expect 'flycheck-buffer-automatically :not :to-have-been-called)))))
+
+    (describe "flycheck-lsp--sync-document"
+      (it "sends didOpen first, then didChange only when the text changed"
+        (flycheck-buttercup-with-temp-buffer
+          (insert "content")
+          (let ((server (flycheck-lsp--server-create :connection 'conn))
+                (doc (flycheck-lsp--doc-create))
+                (uri "file:///x/a.rb")
+                (methods nil))
+            (cl-letf (((symbol-function 'jsonrpc-notify)
+                       (lambda (_conn method _params) (push method methods))))
+              ;; first sync -> didOpen
+              (flycheck-lsp--sync-document server doc uri "ruby")
+              ;; unchanged buffer -> no message
+              (flycheck-lsp--sync-document server doc uri "ruby")
+              ;; change the buffer -> didChange
+              (goto-char (point-max)) (insert "!")
+              (flycheck-lsp--sync-document server doc uri "ruby"))
+            (expect (nreverse methods)
+                    :to-equal '(textDocument/didOpen textDocument/didChange))))))
+
+    (describe "flycheck-lsp--start"
+      (it "reports nothing when the mode has no configured server"
+        (flycheck-buttercup-with-temp-buffer
+          (let ((flycheck-lsp-servers nil)
+                (buffer-file-name "/x/a.rb")
+                (reported 'unset))
+            (flycheck-lsp--start 'lsp (lambda (status &optional data)
+                                        (setq reported (cons status data))))
+            (expect reported :to-equal '(finished))))))
+
+    (describe "the lsp generic checker"
+      (it "is a registered generic checker"
+        (expect (flycheck-valid-checker-p 'lsp) :to-be-truthy)
+        (expect (flycheck-checker-get 'lsp 'start) :to-be #'flycheck-lsp--start)))))
 
 ;;; test-lsp.el ends here

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -1,0 +1,92 @@
+;;; test-lsp.el --- Flycheck Specs: LSP diagnostics  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for the shared LSP diagnostic mapping (`flycheck-lsp--...') used by
+;; both the Eglot bridge and the native `lsp' checker.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(describe "LSP diagnostics"
+
+  (describe "flycheck-lsp--severity-level"
+    (it "maps LSP severities to Flycheck levels"
+      (expect (flycheck-lsp--severity-level 1) :to-be 'error)
+      (expect (flycheck-lsp--severity-level 2) :to-be 'warning)
+      (expect (flycheck-lsp--severity-level 3) :to-be 'info)
+      (expect (flycheck-lsp--severity-level 4) :to-be 'info))
+    (it "treats a missing severity as an error"
+      (expect (flycheck-lsp--severity-level nil) :to-be 'error)))
+
+  (describe "flycheck-lsp--diagnostic-id"
+    (it "uses the diagnostic code"
+      (expect (substring-no-properties
+               (flycheck-lsp--diagnostic-id '(:code "E501")))
+              :to-equal "E501"))
+    (it "carries a codeDescription href as an explainer URL"
+      (let ((id (flycheck-lsp--diagnostic-id
+                 '(:code "E501" :codeDescription (:href "https://x/E501")))))
+        (expect (get-text-property 0 'explainer-url id)
+                :to-equal "https://x/E501")))
+    (it "is nil without a code"
+      (expect (flycheck-lsp--diagnostic-id '(:message "x")) :to-be nil)))
+
+  (describe "flycheck-lsp--uri-to-path"
+    (it "decodes a file URI to a local path"
+      (expect (flycheck-lsp--uri-to-path "file:///tmp/a%20b.rb")
+              :to-equal "/tmp/a b.rb"))
+    (it "strips the leading slash of a Windows drive URI"
+      (expect (flycheck-lsp--uri-to-path "file:///c:/x/y.rb")
+              :to-equal "c:/x/y.rb"))
+    (it "returns a non-file URI unchanged"
+      (expect (flycheck-lsp--uri-to-path "untitled:1") :to-equal "untitled:1")))
+
+  (describe "flycheck-lsp--path-to-uri"
+    (it "round-trips with uri-to-path"
+      (expect (flycheck-lsp--uri-to-path
+               (flycheck-lsp--path-to-uri "/tmp/a b.rb"))
+              :to-equal "/tmp/a b.rb")))
+
+  (describe "flycheck-lsp--related-locations"
+    (it "returns nil when there is no relatedInformation"
+      (expect (flycheck-lsp--related-locations '(:message "x")) :to-be nil))
+
+    (it "converts each entry, incrementing LSP's 0-based positions"
+      (let* ((locs (flycheck-lsp--related-locations
+                    '(:relatedInformation
+                      [(:location (:uri "a.el"
+                                   :range (:start (:line 0 :character 0)
+                                           :end (:line 0 :character 3)))
+                        :message "one")
+                       (:location (:uri "b.el"
+                                   :range (:start (:line 9 :character 2)
+                                           :end (:line 9 :character 2)))
+                        :message "two")]))))
+        (expect (length locs) :to-equal 2)
+        (expect (flycheck-related-location-line (nth 0 locs)) :to-equal 1)
+        (expect (flycheck-related-location-column (nth 0 locs)) :to-equal 1)
+        (expect (flycheck-related-location-filename (nth 1 locs))
+                :to-equal "b.el")
+        (expect (flycheck-related-location-line (nth 1 locs))
+                :to-equal 10)))))
+
+;;; test-lsp.el ends here


### PR DESCRIPTION
Flycheck already bridges Eglot, but that means Eglot has to own the buffer. For single-purpose LSP linters - `rubocop --lsp`, `ruff server`, `biome lsp-proxy` - you often don't want a full LSP client at all, just the diagnostics.

This adds a native `lsp` checker that talks to such a server directly over the built-in `jsonrpc` library, no Eglot involved. `flycheck-lsp-servers` maps a major mode to a server command (RuboCop, Ruff and Biome ship as defaults, each used only when its program is installed), and `global-flycheck-lsp-mode` turns it on. Flycheck runs one server per project root, syncs the buffer text, and reports what the server pushes back, reusing the diagnostic mapping so the errors match the Eglot bridge's - level, id, codeDescription URL and related locations included.

The first commit pulls the shared LSP-diagnostic mapping out of the Eglot bridge so both paths use it; the manual gets a section with a table comparing this, `flycheck-eglot-mode` and `lsp-mode`.