### PR TITLE
Ship more native LSP linters by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 ``master`` (unreleased)
 =======================
 
+- [#2214]: ``flycheck-lsp-servers`` gains built-in entries for Taplo (TOML),
+  TFLint (Terraform), Buf (Protobuf) and Harper (Markdown prose), alongside the
+  existing RuboCop, Ruff and Biome.  Each is only used when its program is
+  installed.
 - [#2213]: Flycheck can now talk to a diagnostics language server directly,
   without Eglot.  Enable ``global-flycheck-lsp-mode`` and configure a server
   per major mode in ``flycheck-lsp-servers`` (``rubocop --lsp`` out of the

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -242,10 +242,11 @@ Turn it on everywhere with:
 
    (global-flycheck-lsp-mode 1)
 
-Out of the box this covers RuboCop for Ruby, Ruff for Python and Biome for
-JavaScript, TypeScript, JSON and CSS.  A server is only used when its program
-is installed, so enabling the mode globally does nothing in a buffer whose
-language server you don't have.
+Out of the box this covers RuboCop (Ruby), Ruff (Python), Biome (JavaScript,
+TypeScript, JSON, CSS), Taplo (TOML), TFLint (Terraform), Buf (Protobuf) and
+Harper (Markdown prose).  A server is only used when its program is installed,
+so enabling the mode globally does nothing in a buffer whose language server
+you don't have.
 
 .. minor-mode:: flycheck-lsp-mode
 
@@ -304,19 +305,32 @@ Configuring servers
 .. defcustom:: flycheck-lsp-servers
 
    An alist mapping a major mode to the server command, as ``(MAJOR-MODE
-   PROGRAM ARG...)``.  The defaults map the Ruby, Python, JavaScript,
-   TypeScript, JSON and CSS modes to RuboCop, Ruff and Biome.
+   PROGRAM ARG...)``.  The defaults are:
 
-   To add a server for another mode, push an entry.  For example, TFLint for
-   Terraform, or Vale for prose::
+   ==============================  ========  ========================
+   Language / mode                 Server    Command
+   ==============================  ========  ========================
+   Ruby                            RuboCop   ``rubocop --lsp``
+   Python                          Ruff      ``ruff server``
+   JavaScript/TypeScript/JSON/CSS  Biome     ``biome lsp-proxy``
+   TOML                            Taplo     ``taplo lsp stdio``
+   Terraform                       TFLint    ``tflint --langserver``
+   Protobuf                        Buf       ``buf lsp serve``
+   Markdown (prose)                Harper    ``harper-ls --stdio``
+   ==============================  ========  ========================
 
-      (add-to-list 'flycheck-lsp-servers '(terraform-mode "tflint" "--langserver"))
-      (add-to-list 'flycheck-lsp-servers '(markdown-mode "vale-ls"))
+   A major mode maps to a single server.  To use a different one, replace the
+   entry - e.g. Standard instead of RuboCop, or Oxlint instead of Biome::
 
-   To point a mode at a different server, or drop one of the defaults, edit the
-   alist - e.g. use Ruff for Python but nothing for CSS::
+      (setf (alist-get 'ruby-mode flycheck-lsp-servers) '("standardrb" "--lsp"))
+      (setf (alist-get 'js-ts-mode flycheck-lsp-servers) '("oxlint" "--lsp"))
 
-      (setf (alist-get 'python-mode flycheck-lsp-servers) '("ruff" "server"))
+   To cover a mode that has no default, add an entry - e.g. Psalm for PHP::
+
+      (add-to-list 'flycheck-lsp-servers '(php-mode "psalm-language-server"))
+
+   To drop a default, remove it::
+
       (setq flycheck-lsp-servers
             (assq-delete-all 'css-mode flycheck-lsp-servers))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -10483,7 +10483,14 @@ backend and a command checker both contribute.  Shared by the `lsp' and
     (json-ts-mode "biome" "lsp-proxy")
     (jsonc-mode "biome" "lsp-proxy")
     (css-mode "biome" "lsp-proxy")
-    (css-ts-mode "biome" "lsp-proxy"))
+    (css-ts-mode "biome" "lsp-proxy")
+    (toml-mode "taplo" "lsp" "stdio")
+    (toml-ts-mode "taplo" "lsp" "stdio")
+    (conf-toml-mode "taplo" "lsp" "stdio")
+    (terraform-mode "tflint" "--langserver")
+    (protobuf-mode "buf" "lsp" "serve")
+    (markdown-mode "harper-ls" "--stdio")
+    (gfm-mode "harper-ls" "--stdio"))
   "Alist mapping a major mode to a diagnostics LSP server command.
 
 Each entry is (MAJOR-MODE PROGRAM ARG...): a buffer in MAJOR-MODE that
@@ -10491,14 +10498,23 @@ enables `flycheck-lsp-mode' has PROGRAM started with the ARGs as an LSP
 server, is fed the buffer's text, and reports the diagnostics the server
 pushes back through the `lsp' checker.
 
-The default entries cover single-purpose linters that ship an LSP mode --
-RuboCop (Ruby), Ruff (Python) and Biome (JavaScript, TypeScript, JSON,
-CSS).  An entry is only used when its PROGRAM is on `exec-path' (see
-`executable-find'), so listing a server you have not installed is
-harmless; add your own the same way, e.g.
+The default entries cover single-purpose linters that ship a native LSP
+mode: RuboCop (Ruby), Ruff (Python), Biome (JavaScript, TypeScript, JSON,
+CSS), Taplo (TOML), TFLint (Terraform), Buf (Protobuf) and Harper
+(Markdown prose).  An entry is only used when its PROGRAM is on
+`exec-path' (see `executable-find'), so listing a server you have not
+installed is harmless.
 
-    (add-to-list \\='flycheck-lsp-servers
-                 \\='(terraform-mode \"tflint\" \"--langserver\"))
+A major mode maps to a single server.  To use a different one, replace
+the entry -- e.g. Standard instead of RuboCop for Ruby, or Oxlint instead
+of Biome for JavaScript:
+
+    (setf (alist-get \\='ruby-mode flycheck-lsp-servers)
+          \\='(\"standardrb\" \"--lsp\"))
+
+To cover a mode that has no default, add an entry:
+
+    (add-to-list \\='flycheck-lsp-servers \\='(php-mode \"psalm-language-server\"))
 
 The server needs to speak LSP over stdio and publish diagnostics.  For a
 full language server (hover, completion, rename) you usually want Eglot

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -114,6 +114,17 @@
                   :to-equal '("rubocop" "--lsp"))
           (expect (flycheck-lsp--command 'python-mode) :to-be nil))))
 
+    (describe "the default flycheck-lsp-servers"
+      (it "maps every mode to a non-empty command of strings"
+        (dolist (entry flycheck-lsp-servers)
+          (expect (symbolp (car entry)) :to-be-truthy)
+          (expect (cdr entry) :to-be-truthy)
+          (expect (seq-every-p #'stringp (cdr entry)) :to-be-truthy)))
+      (it "covers the shipped languages"
+        (dolist (mode '(ruby-mode python-mode js-ts-mode toml-mode
+                        terraform-mode protobuf-mode markdown-mode))
+          (expect (flycheck-lsp--command mode) :to-be-truthy))))
+
     (describe "flycheck-lsp--position-to-point"
       (it "converts a 0-based line and column to a buffer point"
         (flycheck-buttercup-with-temp-buffer


### PR DESCRIPTION
Expands the built-in `flycheck-lsp-servers` with more linters that ship their own stdio LSP server: Taplo (TOML), TFLint (Terraform), Buf (Protobuf) and Harper (Markdown prose), alongside the existing RuboCop, Ruff and Biome. Each was verified against the tool's own docs, and every entry is gated on `executable-find`, so it stays inert until you install the tool.

Also clarifies (docstring + manual) that a mode maps to one server, with examples for swapping one in (Standard for RuboCop, Oxlint for Biome) and covering a mode that has no default.