### PR TITLE
Native LSP checker: code-action fixes and async init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 ``master`` (unreleased)
 =======================
 
+- The native ``lsp`` checker now offers a server's ``quickfix`` code actions as
+  Flycheck fixes (``C-c ! f``, ``C-c ! F``, ``[fix]`` in the error list) when
+  the server advertises them, and its ``initialize`` handshake runs
+  asynchronously so starting a server no longer briefly blocks Emacs.
+  Customize ``flycheck-lsp-code-actions`` to turn the fixes off.
 - [#2214]: ``flycheck-lsp-servers`` gains built-in entries for Taplo (TOML),
   TFLint (Terraform), Buf (Protobuf) and Harper (Markdown prose), alongside the
   existing RuboCop, Ruff and Biome.  Each is only used when its program is

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -283,7 +283,7 @@ server you actually want:
      - Eglot (built in since Emacs 29)
      - the external ``lsp-mode`` package
    * - Provides
-     - diagnostics only
+     - diagnostics + quickfix code actions
      - full LSP (hover, completion, rename, ...)
      - full LSP
    * - Owns the buffer
@@ -348,12 +348,28 @@ Configuring servers
    that supports the buffer's major mode, so the server and a command checker
    both contribute.
 
+.. defcustom:: flycheck-lsp-code-actions
+
+   When non-nil (the default), offer the server's ``quickfix`` code actions as
+   Flycheck fixes: ``C-c ! f`` applies the fix of the error at point, ``C-c !
+   F`` applies all, and the error list marks fixable errors with ``[fix]``.
+   The action is fetched from the server only when you apply a fix, so every
+   diagnostic is shown as potentially fixable even if the server has nothing
+   for it.  Set to nil to turn this off.  Only servers that advertise code
+   actions offer fixes - Ruff, Biome and Harper do; RuboCop, which autocorrects
+   through formatting rather than per-diagnostic actions, does not.
+
 .. defcustom:: flycheck-lsp-initialize-timeout
 
    How many seconds to wait for a server to answer the ``initialize``
-   handshake, which runs synchronously on the first check of a buffer.
+   handshake.  The handshake runs asynchronously and does not block Emacs: the
+   first check of a buffer whose server is still starting reports no
+   diagnostics, and the buffer is rechecked once the handshake finishes.  A
+   server that does not answer in time is torn down and retried later.
    Defaults to 5.
 
 Diagnostics from the ``lsp`` checker carry the same detail as Eglot's - error
 level, id, an explanation URL from ``codeDescription``, and the secondary
-locations of ``relatedInformation`` (visit them with ``C-c ! j``).
+locations of ``relatedInformation`` (visit them with ``C-c ! j``).  When the
+server offers code actions, they are available as fixes as well (see
+``flycheck-lsp-code-actions`` above).

--- a/flycheck.el
+++ b/flycheck.el
@@ -10426,6 +10426,57 @@ Maps the diagnostic's `relatedInformation' entries to
   (mapcar #'flycheck-lsp--related-location
           (append (plist-get lsp :relatedInformation) nil)))
 
+(defun flycheck-lsp--text-edit (tedit)
+  "Convert the LSP TextEdit TEDIT to a `flycheck-fix-edit'.
+LSP positions are zero-based and end-exclusive; Flycheck's are one-based
+and end-exclusive, so only the line/column need incrementing."
+  (let ((start (plist-get (plist-get tedit :range) :start))
+        (end (plist-get (plist-get tedit :range) :end)))
+    (flycheck-fix-edit-new
+     :line (1+ (plist-get start :line))
+     :column (1+ (plist-get start :character))
+     :end-line (1+ (plist-get end :line))
+     :end-column (1+ (plist-get end :character))
+     :replacement (plist-get tedit :newText))))
+
+(defun flycheck-lsp--workspace-edit-fix (wedit description)
+  "Build a `flycheck-fix' from the LSP WorkspaceEdit WEDIT, or nil.
+
+A fix is built only when WEDIT edits a single file that is the current
+buffer, since a `flycheck-fix' applies to one buffer; a multi-file edit,
+or one with resource operations (create, rename, delete), is declined.
+DESCRIPTION becomes the fix's description.  The tick is the buffer's
+current one: the edit was just fetched against this buffer state, and the
+fix is applied right after."
+  (let* ((this (buffer-file-name))
+         (dchanges (append (plist-get wedit :documentChanges) nil))
+         (targets
+          (cond
+           ;; `documentChanges' with a resource operation (an entry without a
+           ;; `:textDocument') is not a plain text fix; decline it whole.
+           ((seq-some (lambda (tde) (null (plist-get tde :textDocument)))
+                      dchanges)
+            nil)
+           ;; `documentChanges' (preferred): array of TextDocumentEdit.
+           (dchanges
+            (mapcar (lambda (tde)
+                      (cons (flycheck-lsp--uri-to-path
+                             (plist-get (plist-get tde :textDocument) :uri))
+                            (plist-get tde :edits)))
+                    dchanges))
+           ;; `changes' (legacy): a plist of uri -> edits.
+           (t
+            (cl-loop for (uri edits) on (plist-get wedit :changes) by #'cddr
+                     collect (cons (flycheck-lsp--uri-to-path uri) edits))))))
+    (when (and this
+               (= (length targets) 1)
+               (flycheck-same-files-p (caar targets) this)
+               (cdar targets))
+      (flycheck-fix-new
+       :description description
+       :edits (mapcar #'flycheck-lsp--text-edit (append (cdar targets) nil))
+       :tick (buffer-chars-modified-tick)))))
+
 (defun flycheck-lsp--register-checker (checker exclusive)
   "Teach CHECKER the current buffer's major mode and set up its chaining.
 
@@ -10547,6 +10598,20 @@ start."
   :group 'flycheck
   :package-version '(flycheck . "38"))
 
+(defcustom flycheck-lsp-code-actions t
+  "Whether the `lsp' checker offers LSP quick-fix code actions as fixes.
+
+When non-nil (the default) and the server advertises code actions, each
+diagnostic carries a lazy fix (see `flycheck-error-resolve-fix') that
+requests the server's \"quickfix\" code action for it when applied with
+\\[flycheck-fix-error-at-point].  Because the fix is only computed on
+demand, every diagnostic is shown as potentially fixable even when the
+server has no action for it; set this to nil to turn the feature off."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'flycheck
+  :package-version '(flycheck . "38"))
+
 (cl-defstruct (flycheck-lsp--doc (:constructor flycheck-lsp--doc-create)
                                  (:copier nil))
   "The state of one document open on a server.
@@ -10559,8 +10624,9 @@ VERSION is nil until the document has been opened."
   "A running diagnostics LSP server and the state of its open documents.
 
 The `documents' table maps a document's canonical path (see
-`flycheck-lsp--doc-key') to a `flycheck-lsp--doc'."
-  connection root command stderr
+`flycheck-lsp--doc-key') to a `flycheck-lsp--doc'.  `capabilities' is the
+server's advertised capability plist from its `initialize' reply."
+  connection root command stderr capabilities
   (documents (make-hash-table :test 'equal)))
 
 (defvar flycheck-lsp--servers (make-hash-table :test 'equal)
@@ -10641,6 +10707,20 @@ fresh diagnostics are published (guarded against recursion)."
       (puthash key (flycheck-lsp--doc-create)
                (flycheck-lsp--server-documents server))))
 
+(defun flycheck-lsp--initialize-params (root)
+  "Return the LSP `initialize' params for a server rooted at ROOT."
+  (list :processId (emacs-pid)
+        :rootUri (flycheck-lsp--path-to-uri root)
+        :capabilities
+        (list :textDocument
+              (list :publishDiagnostics '(:relatedInformation t)
+                    ;; Advertise that we can apply a quickfix's edit, so a
+                    ;; server that gates code actions on client support offers
+                    ;; them (see `flycheck-lsp--code-action-fix').
+                    :codeAction
+                    '(:codeActionLiteralSupport
+                      (:codeActionKind (:valueSet ["quickfix"])))))))
+
 (defun flycheck-lsp--start-server (root command)
   "Start and initialize an LSP server running COMMAND under ROOT.
 Return the `flycheck-lsp--server', or nil if it could not be started."
@@ -10665,13 +10745,11 @@ Return the `flycheck-lsp--server', or nil if it could not be started."
           (setf (flycheck-lsp--server-connection server) conn)
           ;; The handshake is synchronous, so this can block Emacs briefly on
           ;; the first check; `flycheck-lsp-initialize-timeout' bounds the wait.
-          (jsonrpc-request conn 'initialize
-                           (list :processId (emacs-pid)
-                                 :rootUri (flycheck-lsp--path-to-uri root)
-                                 :capabilities
-                                 '(:textDocument
-                                   (:publishDiagnostics (:relatedInformation t))))
-                           :timeout flycheck-lsp-initialize-timeout)
+          (let ((result (jsonrpc-request conn 'initialize
+                                         (flycheck-lsp--initialize-params root)
+                                         :timeout flycheck-lsp-initialize-timeout)))
+            (setf (flycheck-lsp--server-capabilities server)
+                  (plist-get result :capabilities)))
           (jsonrpc-notify conn 'initialized (make-hash-table :test 'eq))
           server)
       (error
@@ -10695,6 +10773,21 @@ Return the `flycheck-lsp--server', or nil if it could not be started."
 (defun flycheck-lsp--notify (server method params)
   "Send an LSP notification METHOD with PARAMS to SERVER."
   (jsonrpc-notify (flycheck-lsp--server-connection server) method params))
+
+(defun flycheck-lsp--request (server method params)
+  "Send the LSP request METHOD with PARAMS to SERVER and return its result."
+  (jsonrpc-request (flycheck-lsp--server-connection server) method params))
+
+(defun flycheck-lsp--capable (server &rest path)
+  "Return SERVER's advertised capability at PATH, or nil.
+
+PATH is a sequence of keyword keys walked into the capability plist, e.g.
+\(flycheck-lsp--capable server :codeActionProvider :resolveProvider).  A
+JSON `false' (which `jsonrpc' decodes to `:json-false', truthy in Elisp)
+is treated as absent."
+  (let ((caps (flycheck-lsp--server-capabilities server)))
+    (dolist (key path (unless (eq caps :json-false) caps))
+      (setq caps (if (listp caps) (plist-get caps key) nil)))))
 
 (defun flycheck-lsp--sync-document (server doc uri language)
   "Send the current buffer's text to SERVER for the document DOC at URI.
@@ -10744,9 +10837,67 @@ accordingly to land on the right buffer position."
           (forward-char 1))
         (point)))))
 
-(defun flycheck-lsp--diagnostic->error (lsp buffer)
+(defun flycheck-lsp--resolve-action (server action)
+  "Return ACTION with its edit filled in, resolving it against SERVER if needed.
+A server may omit an action's `edit' until it is resolved via
+`codeAction/resolve'."
+  (if (and (null (plist-get action :edit))
+           (plist-get action :data)
+           (flycheck-lsp--capable server :codeActionProvider :resolveProvider))
+      (flycheck-lsp--request server 'codeAction/resolve action)
+    action))
+
+(defun flycheck-lsp--code-action-fix (server uri lsp)
+  "Resolve a \"quickfix\" code action for the LSP diagnostic into a fix, or nil.
+
+Runs at apply time.  Sync the buffer first, so the server computes the
+edit against its current text -- otherwise a change since the last check
+yields stale coordinates that the fix's tick guard cannot catch.  Then
+request SERVER's quickfix actions for the diagnostic LSP in the document
+URI, prefer an `isPreferred' one, resolve its edit, and convert a
+single-file WorkspaceEdit into a `flycheck-fix' stamped with the current
+tick.  Any error talking to the server yields nil, so the fix just reports
+as unavailable."
+  (when (flycheck-lsp--server-live-p server)
+    ;; A jsonrpc timeout or error must degrade to nil, not abort the fix
+    ;; command (or a `flycheck-fix-all-errors' batch).
+    (ignore-errors
+      (flycheck-lsp--sync-document
+       server (flycheck-lsp--document server (flycheck-lsp--doc-key uri))
+       uri (flycheck-lsp--language-id major-mode))
+      (when-let* ((actions (append
+                            (flycheck-lsp--request
+                             server 'textDocument/codeAction
+                             (list :textDocument (list :uri uri)
+                                   :range (plist-get lsp :range)
+                                   :context (list :diagnostics (vector lsp)
+                                                  :only ["quickfix"])))
+                            nil))
+                  (action (or (seq-find (lambda (a)
+                                          (eq (plist-get a :isPreferred) t))
+                                        actions)
+                              (car actions)))
+                  (edit (plist-get (flycheck-lsp--resolve-action server action)
+                                   :edit)))
+        (flycheck-lsp--workspace-edit-fix edit (plist-get action :title))))))
+
+(defun flycheck-lsp--fix-provider (server uri lsp)
+  "Return a lazy code-action fix provider for the LSP diagnostic, or nil.
+
+Non-nil only when `flycheck-lsp-code-actions' is on and SERVER advertises
+code actions.  The provider (see `flycheck-error-fix') closes over SERVER,
+the document URI and the raw diagnostic LSP, and requests its quickfix on
+demand via `flycheck-lsp--code-action-fix'."
+  (when (and flycheck-lsp-code-actions
+             (flycheck-lsp--capable server :codeActionProvider))
+    (lambda (_err) (flycheck-lsp--code-action-fix server uri lsp))))
+
+(defun flycheck-lsp--diagnostic->error (lsp buffer server uri)
   "Convert the raw LSP diagnostic plist LSP for BUFFER to a `flycheck-error'.
-Reuses the shared LSP mapping for the level, id and related locations."
+
+Reuses the shared LSP mapping for the level, id and related locations, and
+attaches a lazy quickfix from SERVER for the document URI (see
+`flycheck-lsp--fix-provider')."
   (with-current-buffer buffer
     (let* ((range (plist-get lsp :range))
            (start (plist-get range :start))
@@ -10760,6 +10911,7 @@ Reuses the shared LSP mapping for the level, id and related locations."
                  (plist-get end :line) (plist-get end :character))
        :id (flycheck-lsp--diagnostic-id lsp)
        :relations (flycheck-lsp--related-locations lsp)
+       :fix (flycheck-lsp--fix-provider server uri lsp)
        :checker 'lsp
        :buffer buffer
        :filename (buffer-file-name buffer)))))
@@ -10787,7 +10939,8 @@ fails to start still yields no diagnostics rather than an error."
             (flycheck-lsp--sync-document
              server doc uri (flycheck-lsp--language-id major-mode))
             (funcall callback 'finished
-                     (mapcar (lambda (d) (flycheck-lsp--diagnostic->error d buffer))
+                     (mapcar (lambda (d)
+                               (flycheck-lsp--diagnostic->error d buffer server uri))
                              (flycheck-lsp--doc-diags doc))))))
     (error (funcall callback 'errored (error-message-string err)))))
 
@@ -11039,58 +11192,6 @@ advertises code actions; see `flycheck-eglot--code-action-fix'."
                   beg)))
       (cons beg end))))
 
-(defun flycheck-eglot--text-edit (tedit)
-  "Convert the LSP TextEdit TEDIT to a `flycheck-fix-edit'.
-LSP positions are zero-based and end-exclusive; Flycheck's are one-based
-and end-exclusive, so only the line/column need incrementing."
-  (let ((start (plist-get (plist-get tedit :range) :start))
-        (end (plist-get (plist-get tedit :range) :end)))
-    (flycheck-fix-edit-new
-     :line (1+ (plist-get start :line))
-     :column (1+ (plist-get start :character))
-     :end-line (1+ (plist-get end :line))
-     :end-column (1+ (plist-get end :character))
-     :replacement (plist-get tedit :newText))))
-
-(defun flycheck-eglot--workspace-edit-fix (wedit description)
-  "Build a `flycheck-fix' from WEDIT, or nil.
-
-WEDIT is an LSP WorkspaceEdit.  A fix is built only when WEDIT edits a
-single file that is the current buffer, since a `flycheck-fix' applies to
-one buffer; a multi-file edit, or one with resource operations (create,
-rename, delete), is declined and left to Eglot's own commands.
-DESCRIPTION becomes the fix's description.  The tick is the buffer's
-current one: the action was just fetched against this buffer state, and
-the fix is applied right after."
-  (let* ((this (buffer-file-name))
-         (dchanges (append (plist-get wedit :documentChanges) nil))
-         (targets
-          (cond
-           ;; `documentChanges' with a resource operation (an entry without a
-           ;; `:textDocument') is not a plain text fix; decline it whole.
-           ((seq-some (lambda (tde) (null (plist-get tde :textDocument)))
-                      dchanges)
-            nil)
-           ;; `documentChanges' (preferred): array of TextDocumentEdit.
-           (dchanges
-            (mapcar (lambda (tde)
-                      (cons (eglot-uri-to-path
-                             (plist-get (plist-get tde :textDocument) :uri))
-                            (plist-get tde :edits)))
-                    dchanges))
-           ;; `changes' (legacy): a plist of uri -> edits.
-           (t
-            (cl-loop for (uri edits) on (plist-get wedit :changes) by #'cddr
-                     collect (cons (eglot-uri-to-path uri) edits))))))
-    (when (and this
-               (= (length targets) 1)
-               (flycheck-same-files-p (caar targets) this)
-               (cdar targets))
-      (flycheck-fix-new
-       :description description
-       :edits (mapcar #'flycheck-eglot--text-edit (append (cdar targets) nil))
-       :tick (buffer-chars-modified-tick)))))
-
 (defun flycheck-eglot--resolve-action (action)
   "Return ACTION with its edit filled in, resolving it if necessary.
 A server may omit the `edit' until the action is resolved via
@@ -11120,7 +11221,7 @@ talking to the server yields nil, so the fix just reports as unavailable."
                                 (car actions)))
                     (edit (plist-get (flycheck-eglot--resolve-action action)
                                      :edit)))
-          (flycheck-eglot--workspace-edit-fix
+          (flycheck-lsp--workspace-edit-fix
            edit (plist-get action :title)))))))
 
 (defun flycheck-eglot--report (diags &rest _)

--- a/flycheck.el
+++ b/flycheck.el
@@ -10509,6 +10509,9 @@ backend and a command checker both contribute.  Shared by the `lsp' and
 ;; a `:start' syncs the buffer to its server and reports the diagnostics
 ;; cached so far; the server's later `publishDiagnostics' push updates the
 ;; cache and re-triggers a check so the fresh diagnostics reach the buffer.
+;; The `initialize' handshake runs asynchronously, so starting a server
+;; never blocks Emacs; a check that arrives before it finishes reports
+;; nothing and is re-run when the handshake completes.
 ;;
 ;; One server process is shared per (project root, command); a buffer opens
 ;; its document on the matching server on the first check and closes it when
@@ -10516,6 +10519,7 @@ backend and a command checker both contribute.  Shared by the `lsp' and
 ;; document closes.
 
 (declare-function jsonrpc-request "jsonrpc" (connection method params &rest _))
+(declare-function jsonrpc-async-request "jsonrpc" (connection method params &rest _))
 (declare-function jsonrpc-notify "jsonrpc" (connection method params))
 (declare-function jsonrpc-shutdown "jsonrpc" (connection &optional cleanup))
 (declare-function jsonrpc-running-p "jsonrpc" (connection))
@@ -10590,10 +10594,11 @@ and a command checker can both contribute."
 (defcustom flycheck-lsp-initialize-timeout 5
   "Seconds to wait for a language server to answer `initialize'.
 
-The handshake is synchronous, so the first check of a buffer whose server
-is not running yet blocks Emacs for up to this long while the server
-starts.  A server that does not answer in time is treated as failed to
-start."
+The handshake runs asynchronously and does not block Emacs: the first
+check of a buffer whose server is still starting reports no diagnostics,
+and the buffer is rechecked once the handshake finishes.  A server that
+does not answer within this many seconds is torn down and retried on the
+next check."
   :type 'number
   :group 'flycheck
   :package-version '(flycheck . "38"))
@@ -10625,8 +10630,9 @@ VERSION is nil until the document has been opened."
 
 The `documents' table maps a document's canonical path (see
 `flycheck-lsp--doc-key') to a `flycheck-lsp--doc'.  `capabilities' is the
-server's advertised capability plist from its `initialize' reply."
-  connection root command stderr capabilities
+server's advertised capability plist from its `initialize' reply, filled
+in once `initialized' turns non-nil (the handshake runs asynchronously)."
+  connection root command stderr capabilities initialized
   (documents (make-hash-table :test 'equal)))
 
 (defvar flycheck-lsp--servers (make-hash-table :test 'equal)
@@ -10721,9 +10727,46 @@ fresh diagnostics are published (guarded against recursion)."
                     '(:codeActionLiteralSupport
                       (:codeActionKind (:valueSet ["quickfix"])))))))
 
+(defun flycheck-lsp--server-key (server)
+  "Return SERVER's key in `flycheck-lsp--servers'."
+  (cons (flycheck-lsp--server-root server)
+        (flycheck-lsp--server-command server)))
+
+(defun flycheck-lsp--on-initialized (server result)
+  "Finish SERVER's handshake with the `initialize' RESULT.
+
+Store the server's capabilities, send the `initialized' notification, and
+re-trigger a check in every buffer that opened a document while the
+handshake was still in flight, so their diagnostics finally come through.
+A no-op if the connection died in the meantime."
+  (when (flycheck-lsp--server-live-p server)
+    (setf (flycheck-lsp--server-capabilities server)
+          (plist-get result :capabilities)
+          (flycheck-lsp--server-initialized server) t)
+    (flycheck-lsp--notify server 'initialized (make-hash-table :test 'eq))
+    (maphash (lambda (_key doc)
+               (when-let* ((buffer (flycheck-lsp--doc-buffer doc))
+                           ((buffer-live-p buffer)))
+                 (with-current-buffer buffer
+                   (when flycheck-mode (flycheck-buffer-automatically)))))
+             (flycheck-lsp--server-documents server))))
+
+(defun flycheck-lsp--init-failed (server reason)
+  "Tear SERVER down after its handshake failed for REASON.
+Remove it from the registry so a later check starts a fresh one."
+  (message "Flycheck LSP: %s failed to initialize (%s)"
+           (car (flycheck-lsp--server-command server)) reason)
+  (flycheck-lsp--shutdown-server server)
+  (remhash (flycheck-lsp--server-key server) flycheck-lsp--servers))
+
 (defun flycheck-lsp--start-server (root command)
-  "Start and initialize an LSP server running COMMAND under ROOT.
-Return the `flycheck-lsp--server', or nil if it could not be started."
+  "Start an LSP server running COMMAND under ROOT and initialize it.
+
+The `initialize' handshake runs asynchronously, so this returns the
+`flycheck-lsp--server' before it is ready (its `initialized' slot is still
+nil).  When the reply arrives, `flycheck-lsp--on-initialized' finishes the
+handshake and re-checks the waiting buffers; a failure or timeout tears
+the server down.  Return nil if the process could not be spawned at all."
   (require 'jsonrpc)
   (add-hook 'kill-emacs-hook #'flycheck-lsp--shutdown-all)
   (let* ((default-directory root)
@@ -10743,14 +10786,15 @@ Return the `flycheck-lsp--server', or nil if it could not be started."
                        (flycheck-lsp--handle-notification server method params))
                      :request-dispatcher (lambda (&rest _) nil))))
           (setf (flycheck-lsp--server-connection server) conn)
-          ;; The handshake is synchronous, so this can block Emacs briefly on
-          ;; the first check; `flycheck-lsp-initialize-timeout' bounds the wait.
-          (let ((result (jsonrpc-request conn 'initialize
-                                         (flycheck-lsp--initialize-params root)
-                                         :timeout flycheck-lsp-initialize-timeout)))
-            (setf (flycheck-lsp--server-capabilities server)
-                  (plist-get result :capabilities)))
-          (jsonrpc-notify conn 'initialized (make-hash-table :test 'eq))
+          (jsonrpc-async-request
+           conn 'initialize (flycheck-lsp--initialize-params root)
+           :timeout flycheck-lsp-initialize-timeout
+           :success-fn (lambda (result)
+                         (flycheck-lsp--on-initialized server result))
+           :error-fn (lambda (err)
+                       (flycheck-lsp--init-failed
+                        server (or (plist-get err :message) err)))
+           :timeout-fn (lambda () (flycheck-lsp--init-failed server "timeout")))
           server)
       (error
        (ignore-errors (delete-process proc))
@@ -10923,7 +10967,12 @@ Ensure the buffer's server is running, sync the document to it, and report
 the diagnostics cached for the buffer so far.  The server's later push
 re-triggers the check to deliver fresh diagnostics.  The command, file and
 server are all guaranteed by the checker's predicate, but a server that
-fails to start still yields no diagnostics rather than an error."
+fails to start still yields no diagnostics rather than an error.
+
+While the server is still finishing its asynchronous `initialize'
+handshake, report nothing and leave the document registered: the
+handshake's completion re-triggers the check (see
+`flycheck-lsp--on-initialized')."
   (condition-case err
       (let* ((command (flycheck-lsp--command major-mode))
              (uri (flycheck-lsp--buffer-uri))
@@ -10936,12 +10985,14 @@ fails to start still yields no diagnostics rather than an error."
                  (doc (flycheck-lsp--document
                        server (expand-file-name buffer-file-name))))
             (setf (flycheck-lsp--doc-buffer doc) buffer)
-            (flycheck-lsp--sync-document
-             server doc uri (flycheck-lsp--language-id major-mode))
-            (funcall callback 'finished
-                     (mapcar (lambda (d)
-                               (flycheck-lsp--diagnostic->error d buffer server uri))
-                             (flycheck-lsp--doc-diags doc))))))
+            (if (not (flycheck-lsp--server-initialized server))
+                (funcall callback 'finished nil)
+              (flycheck-lsp--sync-document
+               server doc uri (flycheck-lsp--language-id major-mode))
+              (funcall callback 'finished
+                       (mapcar (lambda (d)
+                                 (flycheck-lsp--diagnostic->error d buffer server uri))
+                               (flycheck-lsp--doc-diags doc)))))))
     (error (funcall callback 'errored (error-message-string err)))))
 
 (defun flycheck-lsp--enabled-p ()

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -112,66 +112,6 @@
 
   (describe "code-action fixes"
 
-    (it "converts an LSP TextEdit to a fix edit, one-basing positions"
-      (let ((fe (flycheck-eglot--text-edit
-                 '(:range (:start (:line 0 :character 4)
-                           :end (:line 0 :character 9))
-                   :newText "hello"))))
-        (expect (flycheck-fix-edit-line fe) :to-equal 1)
-        (expect (flycheck-fix-edit-column fe) :to-equal 5)
-        (expect (flycheck-fix-edit-end-line fe) :to-equal 1)
-        (expect (flycheck-fix-edit-end-column fe) :to-equal 10)
-        (expect (flycheck-fix-edit-replacement fe) :to-equal "hello")))
-
-    (it "builds a fix from a single-file WorkspaceEdit"
-      (flycheck-buttercup-with-temp-buffer
-        (setq buffer-file-name "/proj/a.el")
-        (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity)
-                  ((symbol-function 'flycheck-same-files-p) #'equal))
-          (let ((fix (flycheck-eglot--workspace-edit-fix
-                      '(:documentChanges
-                        [(:textDocument (:uri "/proj/a.el")
-                          :edits [(:range (:start (:line 0 :character 0)
-                                           :end (:line 0 :character 3))
-                                   :newText "X")])])
-                      "Fix it")))
-            (expect (flycheck-fix-description fix) :to-equal "Fix it")
-            (expect (length (flycheck-fix-edits fix)) :to-equal 1)))))
-
-    (it "declines a multi-file WorkspaceEdit"
-      (flycheck-buttercup-with-temp-buffer
-        (setq buffer-file-name "/proj/a.el")
-        (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity)
-                  ((symbol-function 'flycheck-same-files-p) #'equal))
-          (expect (flycheck-eglot--workspace-edit-fix
-                   '(:documentChanges
-                     [(:textDocument (:uri "/proj/a.el")
-                       :edits [(:range (:start (:line 0 :character 0)
-                                        :end (:line 0 :character 1))
-                                :newText "X")])
-                      (:textDocument (:uri "/proj/b.el")
-                       :edits [(:range (:start (:line 0 :character 0)
-                                        :end (:line 0 :character 1))
-                                :newText "Y")])])
-                   "x")
-                  :to-be nil))))
-
-    (it "declines a WorkspaceEdit with a resource operation"
-      (flycheck-buttercup-with-temp-buffer
-        (setq buffer-file-name "/proj/a.el")
-        (cl-letf (((symbol-function 'eglot-uri-to-path) #'identity)
-                  ((symbol-function 'flycheck-same-files-p) #'equal))
-          ;; a file-creation op alongside a text edit is not a plain fix
-          (expect (flycheck-eglot--workspace-edit-fix
-                   '(:documentChanges
-                     [(:kind "create" :uri "/proj/new.el")
-                      (:textDocument (:uri "/proj/a.el")
-                       :edits [(:range (:start (:line 0 :character 0)
-                                        :end (:line 0 :character 1))
-                                :newText "X")])])
-                   "mix")
-                  :to-be nil))))
-
     (it "provides the code-action fix only when enabled and supported"
       (let ((flycheck-eglot-code-actions t))
         (cl-letf (((symbol-function 'eglot-server-capable) (lambda (&rest _) t)))

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -312,7 +312,52 @@
                 (reported 'unset))
             (flycheck-lsp--start 'lsp (lambda (status &optional data)
                                         (setq reported (cons status data))))
-            (expect reported :to-equal '(finished))))))
+            (expect reported :to-equal '(finished)))))
+      (it "reports nothing but registers the doc while the server initializes"
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local major-mode 'ruby-mode)
+          (let* ((buffer-file-name "/x/a.rb")
+                 (flycheck-lsp-servers '((ruby-mode "rubocop" "--lsp")))
+                 (server (flycheck-lsp--server-create)) ; initialized nil
+                 (reported 'unset))
+            (cl-letf (((symbol-function 'flycheck-lsp--ensure-server)
+                       (lambda (&rest _) server))
+                      ((symbol-function 'flycheck-lsp--sync-document)
+                       (lambda (&rest _) (error "must not sync before init"))))
+              (flycheck-lsp--start 'lsp (lambda (status &optional data)
+                                          (setq reported (cons status data)))))
+            (expect reported :to-equal '(finished))
+            ;; the document is registered so the init callback can recheck it
+            (expect (flycheck-lsp--doc-buffer
+                     (gethash (expand-file-name "/x/a.rb")
+                              (flycheck-lsp--server-documents server)))
+                    :to-be (current-buffer))))))
+
+    (describe "flycheck-lsp--on-initialized"
+      (it "stores caps, marks the server ready, and rechecks waiting buffers"
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local flycheck-mode t)
+          (spy-on 'flycheck-buffer-automatically)
+          (let* ((server (flycheck-lsp--server-create :connection 'conn))
+                 (doc (flycheck-lsp--document server "/x/a.rb")))
+            (setf (flycheck-lsp--doc-buffer doc) (current-buffer))
+            (cl-letf (((symbol-function 'jsonrpc-notify) #'ignore)
+                      ((symbol-function 'jsonrpc-running-p) (lambda (_) t)))
+              (flycheck-lsp--on-initialized server '(:capabilities (:x t))))
+            (expect (flycheck-lsp--server-initialized server) :to-be-truthy)
+            (expect (flycheck-lsp--server-capabilities server) :to-equal '(:x t))
+            (expect 'flycheck-buffer-automatically :to-have-been-called)))))
+
+    (describe "flycheck-lsp--init-failed"
+      (it "shuts the server down and drops it from the registry"
+        (let* ((server (flycheck-lsp--server-create
+                        :root "/p/" :command '("rubocop" "--lsp")))
+               (key (flycheck-lsp--server-key server))
+               (flycheck-lsp--servers (make-hash-table :test 'equal)))
+          (puthash key server flycheck-lsp--servers)
+          (cl-letf (((symbol-function 'flycheck-lsp--shutdown-server) #'ignore))
+            (flycheck-lsp--init-failed server "timeout"))
+          (expect (gethash key flycheck-lsp--servers) :to-be nil))))
 
     (describe "flycheck-lsp--capable"
       (it "walks the capability plist"

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -99,6 +99,64 @@
         (expect (flycheck-related-location-line (nth 1 locs))
                 :to-equal 10))))
 
+  (describe "workspace-edit fixes (shared)"
+    (it "converts an LSP TextEdit to a fix edit, one-basing positions"
+      (let ((fe (flycheck-lsp--text-edit
+                 '(:range (:start (:line 0 :character 4)
+                           :end (:line 0 :character 9))
+                   :newText "hello"))))
+        (expect (flycheck-fix-edit-line fe) :to-equal 1)
+        (expect (flycheck-fix-edit-column fe) :to-equal 5)
+        (expect (flycheck-fix-edit-end-line fe) :to-equal 1)
+        (expect (flycheck-fix-edit-end-column fe) :to-equal 10)
+        (expect (flycheck-fix-edit-replacement fe) :to-equal "hello")))
+
+    (it "builds a fix from a single-file WorkspaceEdit"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (cl-letf (((symbol-function 'flycheck-same-files-p) #'equal))
+          (let ((fix (flycheck-lsp--workspace-edit-fix
+                      '(:documentChanges
+                        [(:textDocument (:uri "/proj/a.el")
+                          :edits [(:range (:start (:line 0 :character 0)
+                                           :end (:line 0 :character 3))
+                                   :newText "X")])])
+                      "Fix it")))
+            (expect (flycheck-fix-description fix) :to-equal "Fix it")
+            (expect (length (flycheck-fix-edits fix)) :to-equal 1)))))
+
+    (it "declines a multi-file WorkspaceEdit"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (cl-letf (((symbol-function 'flycheck-same-files-p) #'equal))
+          (expect (flycheck-lsp--workspace-edit-fix
+                   '(:documentChanges
+                     [(:textDocument (:uri "/proj/a.el")
+                       :edits [(:range (:start (:line 0 :character 0)
+                                        :end (:line 0 :character 1))
+                                :newText "X")])
+                      (:textDocument (:uri "/proj/b.el")
+                       :edits [(:range (:start (:line 0 :character 0)
+                                        :end (:line 0 :character 1))
+                                :newText "Y")])])
+                   "x")
+                  :to-be nil))))
+
+    (it "declines a WorkspaceEdit with a resource operation"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (cl-letf (((symbol-function 'flycheck-same-files-p) #'equal))
+          ;; a file-creation op alongside a text edit is not a plain fix
+          (expect (flycheck-lsp--workspace-edit-fix
+                   '(:documentChanges
+                     [(:kind "create" :uri "/proj/new.el")
+                      (:textDocument (:uri "/proj/a.el")
+                       :edits [(:range (:start (:line 0 :character 0)
+                                        :end (:line 0 :character 1))
+                                :newText "X")])])
+                   "mix")
+                  :to-be nil)))))
+
   (describe "the native lsp checker"
 
     (describe "flycheck-lsp--language-id"
@@ -147,14 +205,17 @@
                       '(:severity 2 :message "oops" :code "C1"
                         :range (:start (:line 0 :character 1)
                                 :end (:line 0 :character 4)))
-                      (current-buffer))))
+                      (current-buffer)
+                      (flycheck-lsp--server-create) "file:///x")))
             (expect (flycheck-error-level err) :to-be 'warning)
             (expect (flycheck-error-message err) :to-equal "oops")
             (expect (substring-no-properties (flycheck-error-id err))
                     :to-equal "C1")
             (expect (flycheck-error-line err) :to-equal 1)
             (expect (flycheck-error-column err) :to-equal 2)
-            (expect (flycheck-error-checker err) :to-be 'lsp)))))
+            (expect (flycheck-error-checker err) :to-be 'lsp)
+            ;; a server with no code-action capability -> no fix
+            (expect (flycheck-error-fix err) :to-be nil)))))
 
     (describe "flycheck-lsp--enabled-p"
       (it "is non-nil only with the mode on, a file, and an installed server"
@@ -252,6 +313,96 @@
             (flycheck-lsp--start 'lsp (lambda (status &optional data)
                                         (setq reported (cons status data))))
             (expect reported :to-equal '(finished))))))
+
+    (describe "flycheck-lsp--capable"
+      (it "walks the capability plist"
+        (let ((server (flycheck-lsp--server-create
+                       :capabilities '(:codeActionProvider (:resolveProvider t)))))
+          (expect (flycheck-lsp--capable server :codeActionProvider)
+                  :to-equal '(:resolveProvider t))
+          (expect (flycheck-lsp--capable
+                   server :codeActionProvider :resolveProvider)
+                  :to-be t)))
+      (it "is nil past a boolean capability, and for a missing one"
+        (let ((server (flycheck-lsp--server-create
+                       :capabilities '(:codeActionProvider t))))
+          (expect (flycheck-lsp--capable
+                   server :codeActionProvider :resolveProvider)
+                  :to-be nil)
+          (expect (flycheck-lsp--capable server :hoverProvider) :to-be nil)))
+      (it "treats a JSON false capability as absent"
+        ;; jsonrpc decodes JSON `false' to `:json-false', which is truthy.
+        (let ((server (flycheck-lsp--server-create
+                       :capabilities '(:codeActionProvider :json-false))))
+          (expect (flycheck-lsp--capable server :codeActionProvider)
+                  :to-be nil))))
+
+    (describe "flycheck-lsp--fix-provider"
+      (it "is a function when enabled and the server is capable"
+        (let ((server (flycheck-lsp--server-create
+                       :capabilities '(:codeActionProvider t)))
+              (flycheck-lsp-code-actions t))
+          (expect (functionp
+                   (flycheck-lsp--fix-provider server "file:///a" '(:range nil)))
+                  :to-be-truthy)))
+      (it "is nil when the server has no code actions"
+        (let ((server (flycheck-lsp--server-create :capabilities nil))
+              (flycheck-lsp-code-actions t))
+          (expect (flycheck-lsp--fix-provider server "file:///a" nil) :to-be nil)))
+      (it "is nil when the feature is off"
+        (let ((server (flycheck-lsp--server-create
+                       :capabilities '(:codeActionProvider t)))
+              (flycheck-lsp-code-actions nil))
+          (expect (flycheck-lsp--fix-provider server "file:///a" nil) :to-be nil))))
+
+    (describe "flycheck-lsp--code-action-fix"
+      (it "requests, prefers the isPreferred action, and builds a fix"
+        (flycheck-buttercup-with-temp-buffer
+          (setq buffer-file-name "/proj/a.rb")
+          (let ((server (flycheck-lsp--server-create :connection 'conn))
+                (edit '(:documentChanges
+                        [(:textDocument (:uri "/proj/a.rb")
+                          :edits [(:range (:start (:line 0 :character 0)
+                                           :end (:line 0 :character 1))
+                                   :newText "Y")])])))
+            (cl-letf (((symbol-function 'jsonrpc-running-p) (lambda (_) t))
+                      ((symbol-function 'flycheck-lsp--sync-document) #'ignore)
+                      ((symbol-function 'flycheck-same-files-p) #'equal)
+                      ((symbol-function 'flycheck-lsp--request)
+                       (lambda (_s method _p)
+                         (when (eq method 'textDocument/codeAction)
+                           (vector (list :title "skip")
+                                   (list :title "do it" :isPreferred t
+                                         :edit edit))))))
+              (let ((fix (flycheck-lsp--code-action-fix
+                          server "file:///proj/a.rb" '(:range nil))))
+                (expect (flycheck-fix-description fix) :to-equal "do it")
+                (expect (length (flycheck-fix-edits fix)) :to-equal 1))))))
+      (it "resolves an action that has data but no edit"
+        (flycheck-buttercup-with-temp-buffer
+          (setq buffer-file-name "/proj/a.rb")
+          (let ((server (flycheck-lsp--server-create
+                         :connection 'conn
+                         :capabilities '(:codeActionProvider (:resolveProvider t))))
+                (edit '(:documentChanges
+                        [(:textDocument (:uri "/proj/a.rb")
+                          :edits [(:range (:start (:line 0 :character 0)
+                                           :end (:line 0 :character 1))
+                                   :newText "Z")])])))
+            (cl-letf (((symbol-function 'jsonrpc-running-p) (lambda (_) t))
+                      ((symbol-function 'flycheck-lsp--sync-document) #'ignore)
+                      ((symbol-function 'flycheck-same-files-p) #'equal)
+                      ((symbol-function 'flycheck-lsp--request)
+                       (lambda (_s method _p)
+                         (pcase method
+                           ('textDocument/codeAction
+                            (vector (list :title "lazy" :data "d")))
+                           ('codeAction/resolve
+                            (list :title "lazy" :data "d" :edit edit))))))
+              (let ((fix (flycheck-lsp--code-action-fix
+                          server "file:///proj/a.rb" '(:range nil))))
+                (expect (flycheck-fix-description fix) :to-equal "lazy")
+                (expect (length (flycheck-fix-edits fix)) :to-equal 1)))))))
 
     (describe "the lsp generic checker"
       (it "is a registered generic checker"


### PR DESCRIPTION
Two improvements to the native `lsp` checker.

**Code-action fixes.** When the server advertises code actions, each diagnostic now carries a lazy quickfix: applying it (`C-c ! f`, `C-c ! F`, or `x` in the error list) requests the server's `quickfix` for that diagnostic over the jsonrpc connection, resolves it if needed, and applies a single-file `WorkspaceEdit` - the same treatment the Eglot bridge already gives. The `WorkspaceEdit`-to-fix transforms are now shared between the two paths. The fix is only offered when the server advertises `codeActionProvider` (ruff, biome, harper do; rubocop, which autocorrects via formatting, does not), so servers without actions don't falsely mark everything fixable. `flycheck-lsp-code-actions` turns it off. Before requesting, the buffer is synced to the server so the edit is computed against current text.

**Async init.** The `initialize` handshake now runs via `jsonrpc-async-request` instead of blocking Emacs. A check that arrives before the handshake finishes reports nothing and is rechecked when it completes; a failure or timeout tears the server down and retries.

Went through the elisp-reviewer, which caught a stale-fix corruption path (fixed by syncing before the code-action request) and a `:json-false` truthiness bug in the capability check (jsonrpc decodes JSON `false` to a truthy symbol).