### PR TITLE
Fix changes-form code actions; trim LSP defaults to verified linters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,20 @@
 ``master`` (unreleased)
 =======================
 
+- [#2217]: A code-action fix returned as a legacy ``changes`` WorkspaceEdit
+  (which Ruff and other servers use) now applies correctly; the URI keys jsonrpc
+  decodes to keywords were mishandled, so the fix silently did nothing.  Affects
+  both the ``lsp`` checker and the Eglot bridge.
 - The native ``lsp`` checker now offers a server's ``quickfix`` code actions as
   Flycheck fixes (``C-c ! f``, ``C-c ! F``, ``[fix]`` in the error list) when
   the server advertises them, and its ``initialize`` handshake runs
   asynchronously so starting a server no longer briefly blocks Emacs.
   Customize ``flycheck-lsp-code-actions`` to turn the fixes off.
-- [#2214]: ``flycheck-lsp-servers`` gains built-in entries for Taplo (TOML),
-  TFLint (Terraform), Buf (Protobuf) and Harper (Markdown prose), alongside the
-  existing RuboCop, Ruff and Biome.  Each is only used when its program is
-  installed.
+- [#2214]: ``flycheck-lsp-servers`` gains a built-in entry for Harper (Markdown
+  prose), alongside the existing RuboCop, Ruff and Biome.  These lint out of the
+  box; linters that need project configuration first (TFLint, Buf, Taplo) are
+  documented as opt-in entries rather than defaults.  Each entry is only used
+  when its program is installed.
 - [#2213]: Flycheck can now talk to a diagnostics language server directly,
   without Eglot.  Enable ``global-flycheck-lsp-mode`` and configure a server
   per major mode in ``flycheck-lsp-servers`` (``rubocop --lsp`` out of the

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -251,10 +251,10 @@ Turn it on everywhere with:
    (global-flycheck-lsp-mode 1)
 
 Out of the box this covers RuboCop (Ruby), Ruff (Python), Biome (JavaScript,
-TypeScript, JSON, CSS), Taplo (TOML), TFLint (Terraform), Buf (Protobuf) and
-Harper (Markdown prose).  A server is only used when its program is installed,
-so enabling the mode globally does nothing in a buffer whose language server
-you don't have.
+TypeScript, JSON, CSS) and Harper (Markdown prose) - each lints with sensible
+defaults, no project configuration needed.  A server is only used when its
+program is installed, so enabling the mode globally does nothing in a buffer
+whose language server you don't have.
 
 .. minor-mode:: flycheck-lsp-mode
 
@@ -321,21 +321,24 @@ Configuring servers
    Ruby                            RuboCop   ``rubocop --lsp``
    Python                          Ruff      ``ruff server``
    JavaScript/TypeScript/JSON/CSS  Biome     ``biome lsp-proxy``
-   TOML                            Taplo     ``taplo lsp stdio``
-   Terraform                       TFLint    ``tflint --langserver``
-   Protobuf                        Buf       ``buf lsp serve``
    Markdown (prose)                Harper    ``harper-ls --stdio``
    ==============================  ========  ========================
+
+   These lint out of the box.  Other linters ship an LSP server too but need
+   project configuration before they report anything - TFLint wants a
+   ``.tflint.hcl`` and plugins, Buf wants a module, Taplo wants a workspace
+   config it fetches over ``workspace/configuration`` (which the ``lsp`` checker
+   does not answer) - so they are left out of the defaults.  Add them once your
+   project is set up::
+
+      (add-to-list 'flycheck-lsp-servers '(terraform-mode "tflint" "--langserver"))
+      (add-to-list 'flycheck-lsp-servers '(protobuf-mode "buf" "lsp" "serve"))
 
    A major mode maps to a single server.  To use a different one, replace the
    entry - e.g. Standard instead of RuboCop, or Oxlint instead of Biome::
 
       (setf (alist-get 'ruby-mode flycheck-lsp-servers) '("standardrb" "--lsp"))
       (setf (alist-get 'js-ts-mode flycheck-lsp-servers) '("oxlint" "--lsp"))
-
-   To cover a mode that has no default, add an entry - e.g. Psalm for PHP::
-
-      (add-to-list 'flycheck-lsp-servers '(php-mode "psalm-language-server"))
 
    To drop a default, remove it::
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -10464,10 +10464,16 @@ fix is applied right after."
                              (plist-get (plist-get tde :textDocument) :uri))
                             (plist-get tde :edits)))
                     dchanges))
-           ;; `changes' (legacy): a plist of uri -> edits.
+           ;; `changes' (legacy): a JSON object of uri -> edits, which jsonrpc
+           ;; decodes to a plist whose keys are keywords (`:file:///...'), so
+           ;; strip the leading colon before resolving each URI.
            (t
             (cl-loop for (uri edits) on (plist-get wedit :changes) by #'cddr
-                     collect (cons (flycheck-lsp--uri-to-path uri) edits))))))
+                     collect (cons (flycheck-lsp--uri-to-path
+                                    (if (keywordp uri)
+                                        (substring (symbol-name uri) 1)
+                                      uri))
+                                   edits))))))
     (when (and this
                (= (length targets) 1)
                (flycheck-same-files-p (caar targets) this)
@@ -10539,11 +10545,6 @@ backend and a command checker both contribute.  Shared by the `lsp' and
     (jsonc-mode "biome" "lsp-proxy")
     (css-mode "biome" "lsp-proxy")
     (css-ts-mode "biome" "lsp-proxy")
-    (toml-mode "taplo" "lsp" "stdio")
-    (toml-ts-mode "taplo" "lsp" "stdio")
-    (conf-toml-mode "taplo" "lsp" "stdio")
-    (terraform-mode "tflint" "--langserver")
-    (protobuf-mode "buf" "lsp" "serve")
     (markdown-mode "harper-ls" "--stdio")
     (gfm-mode "harper-ls" "--stdio"))
   "Alist mapping a major mode to a diagnostics LSP server command.
@@ -10553,12 +10554,12 @@ enables `flycheck-lsp-mode' has PROGRAM started with the ARGs as an LSP
 server, is fed the buffer's text, and reports the diagnostics the server
 pushes back through the `lsp' checker.
 
-The default entries cover single-purpose linters that ship a native LSP
-mode: RuboCop (Ruby), Ruff (Python), Biome (JavaScript, TypeScript, JSON,
-CSS), Taplo (TOML), TFLint (Terraform), Buf (Protobuf) and Harper
-(Markdown prose).  An entry is only used when its PROGRAM is on
-`exec-path' (see `executable-find'), so listing a server you have not
-installed is harmless.
+The default entries are linters that ship a native LSP server and lint out
+of the box, with no project configuration: RuboCop (Ruby), Ruff (Python),
+Biome (JavaScript, TypeScript, JSON, CSS) and Harper (Markdown prose).  An
+entry is only used when its PROGRAM is on `exec-path' (see
+`executable-find'), so listing a server you have not installed is
+harmless.
 
 A major mode maps to a single server.  To use a different one, replace
 the entry -- e.g. Standard instead of RuboCop for Ruby, or Oxlint instead
@@ -10567,9 +10568,13 @@ of Biome for JavaScript:
     (setf (alist-get \\='ruby-mode flycheck-lsp-servers)
           \\='(\"standardrb\" \"--lsp\"))
 
-To cover a mode that has no default, add an entry:
+To cover a mode that has no default, add an entry.  Some linters ship an
+LSP server but need project configuration to report anything (a TFLint
+config and plugins, a Buf module), so they are left out of the defaults;
+add them once your project is set up:
 
-    (add-to-list \\='flycheck-lsp-servers \\='(php-mode \"psalm-language-server\"))
+    (add-to-list \\='flycheck-lsp-servers
+                 \\='(terraform-mode \"tflint\" \"--langserver\"))
 
 The server needs to speak LSP over stdio and publish diagnostics.  For a
 full language server (hover, completion, rename) you usually want Eglot

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -125,6 +125,25 @@
             (expect (flycheck-fix-description fix) :to-equal "Fix it")
             (expect (length (flycheck-fix-edits fix)) :to-equal 1)))))
 
+    (it "builds a fix from a legacy `changes' WorkspaceEdit"
+      ;; jsonrpc decodes the changes object's URI keys to keywords
+      ;; (`:file:///...'); the fix must strip the leading colon.  Ruff and
+      ;; other servers use this form, so this path must work.
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (cl-letf (((symbol-function 'flycheck-same-files-p) #'equal))
+          (let ((fix (flycheck-lsp--workspace-edit-fix
+                      '(:changes
+                        (:file:///proj/a.el
+                         [(:range (:start (:line 0 :character 0)
+                                   :end (:line 1 :character 0))
+                           :newText "")]))
+                      "Remove import")))
+            (expect (flycheck-fix-description fix) :to-equal "Remove import")
+            (expect (length (flycheck-fix-edits fix)) :to-equal 1)
+            (expect (flycheck-fix-edit-replacement (car (flycheck-fix-edits fix)))
+                    :to-equal "")))))
+
     (it "declines a multi-file WorkspaceEdit"
       (flycheck-buttercup-with-temp-buffer
         (setq buffer-file-name "/proj/a.el")
@@ -179,8 +198,7 @@
           (expect (cdr entry) :to-be-truthy)
           (expect (seq-every-p #'stringp (cdr entry)) :to-be-truthy)))
       (it "covers the shipped languages"
-        (dolist (mode '(ruby-mode python-mode js-ts-mode toml-mode
-                        terraform-mode protobuf-mode markdown-mode))
+        (dolist (mode '(ruby-mode python-mode js-ts-mode css-mode markdown-mode))
           (expect (flycheck-lsp--command mode) :to-be-truthy))))
 
     (describe "flycheck-lsp--position-to-point"


### PR DESCRIPTION
While live-testing the native LSP checker against real servers (ruff, biome, oxlint, harper, taplo, tflint, buf), two things came up.

**A real fix bug.** A code action whose edit is a legacy `changes` WorkspaceEdit (Ruff and others use this form) never applied: jsonrpc decodes the changes object's URI keys to keywords (`:file:///…`), and the code passed that keyword straight to the URI decoder, which errored and — swallowed by `ignore-errors` — silently produced no fix. Now it strips the leading colon. Shared helper, so the Eglot bridge gets the fix too.

**Trimming the defaults to what actually works.** I verified ruff, biome, oxlint and harper end to end — diagnostics, and quickfix fixes where the server advertises them. But Taplo, TFLint and Buf (added in #2214) ship an LSP server yet report nothing out of the box: Taplo excludes files until it gets workspace configuration over a request the checker doesn't answer, TFLint needs a `.tflint.hcl` and plugins, Buf needs a module. So the defaults are now the four that lint with zero project config (RuboCop, Ruff, Biome, Harper), and TFLint/Buf/Taplo are documented opt-in entries instead. All still `executable-find`-gated.