### PR TITLE
Offer LSP fixes shipped inline in a diagnostic's data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``master`` (unreleased)
 =======================
 
+- [#2218]: The ``lsp`` checker (and the Eglot bridge) now offer RuboCop's and
+  standardrb's autocorrects as fixes.  These servers ship each diagnostic's
+  quickfix inline in the diagnostic's data rather than answering a
+  ``textDocument/codeAction`` request, so Flycheck reads it from there -- and
+  since the fix is already in the payload, it costs nothing.
+
 - [#2217]: A code-action fix returned as a legacy ``changes`` WorkspaceEdit
   (which Ruff and other servers use) now applies correctly; the URI keys jsonrpc
   decodes to keywords were mishandled, so the fix silently did nothing.  Affects

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -364,11 +364,14 @@ Configuring servers
    When non-nil (the default), offer the server's ``quickfix`` code actions as
    Flycheck fixes: ``C-c ! f`` applies the fix of the error at point, ``C-c !
    F`` applies all, and the error list marks fixable errors with ``[fix]``.
-   The action is fetched from the server only when you apply a fix, so every
-   diagnostic is shown as potentially fixable even if the server has nothing
-   for it.  Set to nil to turn this off.  Only servers that advertise code
-   actions offer fixes - Ruff, Biome and Harper do; RuboCop, which autocorrects
-   through formatting rather than per-diagnostic actions, does not.
+   Set to nil to turn this off.
+
+   Flycheck gets these actions two ways.  Some servers (RuboCop, standardrb)
+   ship each diagnostic's autocorrect inline, in the diagnostic's data;
+   Flycheck uses it directly, for free.  Others (Ruff, Biome, Oxlint) answer a
+   ``textDocument/codeAction`` request, which Flycheck sends only when you
+   apply a fix - so with those, a diagnostic is shown as potentially fixable
+   even when the server turns out to have nothing for it.
 
 .. defcustom:: flycheck-lsp-initialize-timeout
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -10930,16 +10930,36 @@ as unavailable."
                                    :edit)))
         (flycheck-lsp--workspace-edit-fix edit (plist-get action :title))))))
 
-(defun flycheck-lsp--fix-provider (server uri lsp)
-  "Return a lazy code-action fix provider for the LSP diagnostic, or nil.
+(defun flycheck-lsp--inline-fix (lsp)
+  "Build a fix from a quickfix CodeAction embedded in the diagnostic LSP, or nil.
 
-Non-nil only when `flycheck-lsp-code-actions' is on and SERVER advertises
-code actions.  The provider (see `flycheck-error-fix') closes over SERVER,
-the document URI and the raw diagnostic LSP, and requests its quickfix on
-demand via `flycheck-lsp--code-action-fix'."
-  (when (and flycheck-lsp-code-actions
-             (flycheck-lsp--capable server :codeActionProvider))
-    (lambda (_err) (flycheck-lsp--code-action-fix server uri lsp))))
+RuboCop and standardrb do not answer `textDocument/codeAction'; they ship
+their autocorrect actions inline in each diagnostic's `data' slot, as a
+`code_actions' array.  Pick the `isPreferred' one that carries an edit
+\(the autocorrect, not the \"disable for this line\" action) and convert
+its WorkspaceEdit into a `flycheck-fix'.  Returns the fix eagerly -- it is
+already in the payload, so no request is needed."
+  (when-let* ((actions (append (plist-get (plist-get lsp :data) :code_actions)
+                               nil))
+              (action (seq-find (lambda (a)
+                                  (and (eq (plist-get a :isPreferred) t)
+                                       (plist-get a :edit)))
+                                actions))
+              (edit (plist-get action :edit)))
+    (flycheck-lsp--workspace-edit-fix edit (plist-get action :title))))
+
+(defun flycheck-lsp--fix-provider (server uri lsp)
+  "Return a code-action fix, or a lazy provider, for the diagnostic LSP, or nil.
+
+With `flycheck-lsp-code-actions' on, prefer a quickfix action the server
+embedded in the diagnostic's `data' (see `flycheck-lsp--inline-fix'),
+building the fix eagerly.  Otherwise, when SERVER advertises code actions,
+return a lazy provider (see `flycheck-error-fix') that requests the
+quickfix from SERVER on demand via `flycheck-lsp--code-action-fix'."
+  (when flycheck-lsp-code-actions
+    (or (flycheck-lsp--inline-fix lsp)
+        (and (flycheck-lsp--capable server :codeActionProvider)
+             (lambda (_err) (flycheck-lsp--code-action-fix server uri lsp))))))
 
 (defun flycheck-lsp--diagnostic->error (lsp buffer server uri)
   "Convert the raw LSP diagnostic plist LSP for BUFFER to a `flycheck-error'.
@@ -11218,7 +11238,10 @@ as a fallback."
      :end-pos (flymake-diagnostic-end diag)
      :id (and lsp (flycheck-lsp--diagnostic-id lsp))
      :relations (and lsp (flycheck-lsp--related-locations lsp))
-     :fix (flycheck-eglot--fix-provider)
+     ;; Prefer a quickfix the server embedded in the diagnostic's data
+     ;; (rubocop, standardrb); fall back to Eglot's on-demand code actions.
+     :fix (or (and flycheck-eglot-code-actions lsp (flycheck-lsp--inline-fix lsp))
+              (flycheck-eglot--fix-provider))
      :checker 'eglot-check
      :buffer (current-buffer)
      :filename (buffer-file-name))))

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -416,7 +416,52 @@
         (let ((server (flycheck-lsp--server-create
                        :capabilities '(:codeActionProvider t)))
               (flycheck-lsp-code-actions nil))
-          (expect (flycheck-lsp--fix-provider server "file:///a" nil) :to-be nil))))
+          (expect (flycheck-lsp--fix-provider server "file:///a" nil) :to-be nil)))
+      (it "returns an inline fix eagerly, not a lazy provider"
+        (flycheck-buttercup-with-temp-buffer
+          (setq buffer-file-name "/proj/a.rb")
+          (cl-letf (((symbol-function 'flycheck-same-files-p) #'equal))
+            (let* ((server (flycheck-lsp--server-create))  ; no codeActionProvider
+                   (flycheck-lsp-code-actions t)
+                   (lsp '(:data (:correctable t :code_actions
+                                 [(:title "Autocorrect" :kind "quickfix" :isPreferred t
+                                   :edit (:documentChanges
+                                          [(:textDocument (:uri "/proj/a.rb")
+                                            :edits [(:range (:start (:line 0 :character 0)
+                                                     :end (:line 0 :character 1))
+                                                     :newText "")])]))])))
+                   (fix (flycheck-lsp--fix-provider server "file:///proj/a.rb" lsp)))
+              (expect (flycheck-fix-p fix) :to-be-truthy)
+              (expect (flycheck-fix-description fix) :to-equal "Autocorrect"))))))
+
+    (describe "flycheck-lsp--inline-fix"
+      (it "builds a fix from the isPreferred inline code action"
+        (flycheck-buttercup-with-temp-buffer
+          (setq buffer-file-name "/proj/a.rb")
+          (cl-letf (((symbol-function 'flycheck-same-files-p) #'equal))
+            (let ((fix (flycheck-lsp--inline-fix
+                        '(:data (:correctable t :code_actions
+                                 [(:title "Autocorrect X" :kind "quickfix" :isPreferred t
+                                   :edit (:documentChanges
+                                          [(:textDocument (:uri "/proj/a.rb")
+                                            :edits [(:range (:start (:line 0 :character 0)
+                                                     :end (:line 0 :character 1))
+                                                     :newText "")])]))
+                                  (:title "Disable X" :kind "quickfix"
+                                   :edit (:documentChanges
+                                          [(:textDocument (:uri "/proj/a.rb")
+                                            :edits [(:range (:start (:line 0 :character 0)
+                                                     :end (:line 0 :character 0))
+                                                     :newText "# disable\n")])]))])))))
+              (expect (flycheck-fix-description fix) :to-equal "Autocorrect X")))))
+      (it "is nil when no inline action is preferred (only disable)"
+        (expect (flycheck-lsp--inline-fix
+                 '(:data (:correctable :json-false :code_actions
+                          [(:title "Disable X" :kind "quickfix"
+                            :edit (:documentChanges []))])))
+                :to-be nil))
+      (it "is nil when the diagnostic carries no inline actions"
+        (expect (flycheck-lsp--inline-fix '(:code "X")) :to-be nil)))
 
     (describe "flycheck-lsp--code-action-fix"
       (it "requests, prefers the isPreferred action, and builds a fix"


### PR DESCRIPTION
RuboCop and standardrb compute autocorrects but don't answer `textDocument/codeAction`. Instead they attach each offense's quickfix to the diagnostic itself, in a `code_actions` array under the diagnostic's `data`. A standard LSP client that only requests code actions never sees them, so RuboCop's fixes were invisible in Flycheck even though they were right there in the payload.

This reads the inline action when present and builds the fix from it directly - eagerly, since it's already in the payload, with no request round-trip. Wired into both the native `lsp` checker and the Eglot bridge, so RuboCop's and standardrb's autocorrects now show up as Flycheck fixes (`C-c ! f`, `[fix]`) whichever integration you use.

Verified live against `rubocop --lsp`.