### PR TITLE
LSP/Eglot audit: fix preferred-action bug, tighten consistency and perf

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -11322,7 +11322,11 @@ talking to the server yields nil, so the fix just reports as unavailable."
       ;; not abort the fix command (or a `flycheck-fix-all-errors' batch).
       (ignore-errors
         (when-let* ((actions (eglot-code-actions beg end "quickfix" nil))
-                    (action (or (seq-find (lambda (a) (plist-get a :isPreferred))
+                    ;; `eq' to t, not bare truthiness: jsonrpc decodes JSON
+                    ;; `false' to `:json-false', which is truthy in Elisp, so a
+                    ;; server sending `isPreferred: false' must not be picked.
+                    (action (or (seq-find (lambda (a)
+                                            (eq (plist-get a :isPreferred) t))
                                           actions)
                                 (car actions)))
                     (edit (plist-get (flycheck-eglot--resolve-action action)

--- a/flycheck.el
+++ b/flycheck.el
@@ -10521,8 +10521,9 @@ backend and a command checker both contribute.  Shared by the `lsp' and
 ;;
 ;; One server process is shared per (project root, command); a buffer opens
 ;; its document on the matching server on the first check and closes it when
-;; the buffer or the mode goes away, shutting the server down once its last
-;; document closes.
+;; the buffer or the mode goes away.  The server itself is kept for the rest
+;; of the session and shut down only when Emacs exits, so reopening or
+;; checking another of its files does not pay to restart it.
 
 (declare-function jsonrpc-request "jsonrpc" (connection method params &rest _))
 (declare-function jsonrpc-async-request "jsonrpc" (connection method params &rest _))
@@ -10590,7 +10591,10 @@ and `flycheck-eglot-mode' instead."
 When non-nil (the default), a buffer using `flycheck-lsp-mode' reports
 only the language server's diagnostics.  When nil, `lsp' chains to the
 first other checker that supports the buffer's major mode, so the server
-and a command checker can both contribute."
+and a command checker can both contribute.
+
+Note that this takes effect globally when a buffer enables the mode: it is
+stored in `lsp's chain, not per buffer."
   :type 'boolean
   :safe #'booleanp
   :group 'flycheck
@@ -10643,19 +10647,35 @@ in once `initialized' turns non-nil (the handshake runs asynchronously)."
 (defvar flycheck-lsp--servers (make-hash-table :test 'equal)
   "Live `flycheck-lsp--server's, keyed by (ROOT . COMMAND).")
 
-(defvar flycheck-lsp--suppress-recheck nil
+(defvar-local flycheck-lsp--suppress-recheck nil
   "When non-nil, a diagnostics push does not re-trigger a check.
-Bound while a push-triggered check runs, so it cannot recurse.")
+Bound while a push-triggered check runs, so it cannot recurse.  Buffer-local
+so a synchronous round-trip during one buffer's check cannot suppress a
+push that arrives for another buffer.")
 
 (defun flycheck-lsp--command (mode)
   "Return the LSP server command configured for major MODE, or nil."
   (alist-get mode flycheck-lsp-servers))
 
+(defvar-local flycheck-lsp--command-cache nil
+  "Cached (MODE . RESULT) of `flycheck-lsp--available-command' for this buffer.
+A server installed mid-session is not noticed until the cache is rebuilt
+\(on a major-mode change, which clears buffer-local variables).")
+
 (defun flycheck-lsp--available-command (mode)
   "Return the server command for MODE if its program is installed, else nil.
-Uses `flycheck-executable-find', so it honours the user's setting and TRAMP."
-  (when-let* ((command (flycheck-lsp--command mode)))
-    (and (funcall flycheck-executable-find (car command)) command)))
+
+Uses `flycheck-executable-find', so it honours the user's setting and TRAMP.
+The result is cached buffer-locally, keyed on MODE: `executable-find' scans
+`exec-path' (and probes the remote host over TRAMP), and the `lsp' checker's
+predicate calls this on every check."
+  (if (eq (car flycheck-lsp--command-cache) mode)
+      (cdr flycheck-lsp--command-cache)
+    (let ((result (when-let* ((command (flycheck-lsp--command mode)))
+                    (and (funcall flycheck-executable-find (car command))
+                         command))))
+      (setq-local flycheck-lsp--command-cache (cons mode result))
+      result)))
 
 (defun flycheck-lsp--language-id (mode)
   "Return a best-effort LSP languageId string for major MODE."
@@ -10873,12 +10893,15 @@ whole-buffer copy is taken only when a message is actually sent."
 
 LSP counts a character offset in UTF-16 code units, so a character
 outside the Basic Multilingual Plane counts as two; step over the line
-accordingly to land on the right buffer position."
+accordingly to land on the right buffer position.
+
+Seek the line through `flycheck-goto-line', whose cache turns the many
+in-order lookups of a check (two per diagnostic) into a single forward
+pass instead of rescanning from `point-min' each time."
   (save-excursion
     (save-restriction
       (widen)
-      (goto-char (point-min))
-      (forward-line line)
+      (flycheck-goto-line (1+ line))
       (let ((remaining character)
             (eol (line-end-position)))
         (while (and (> remaining 0) (< (point) eol))
@@ -11008,7 +11031,7 @@ handshake's completion re-triggers the check (see
             (funcall callback 'finished nil)
           (let* ((buffer (current-buffer))
                  (doc (flycheck-lsp--document
-                       server (expand-file-name buffer-file-name))))
+                       server (flycheck-lsp--doc-key uri))))
             (setf (flycheck-lsp--doc-buffer doc) buffer)
             (if (not (flycheck-lsp--server-initialized server))
                 (funcall callback 'finished nil)
@@ -11060,7 +11083,7 @@ of the session and torn down only when Emacs exits (see
 `flycheck-lsp--shutdown-all') -- so reopening or checking another of its
 files does not pay to restart it."
   (when-let* ((uri (flycheck-lsp--buffer-uri))
-              (key (expand-file-name buffer-file-name)))
+              (key (flycheck-lsp--doc-key uri)))
     (maphash
      (lambda (_server-key server)
        (when (gethash key (flycheck-lsp--server-documents server))
@@ -11085,6 +11108,10 @@ A no-op unless the mode's server is configured and installed."
   (when (flycheck-lsp--available-command major-mode)
     (flycheck-lsp--register-checker 'lsp flycheck-lsp-exclusive)
     (setq flycheck-checker 'lsp)
+    ;; Give the recheck guard a real buffer-local binding, so the `let' that
+    ;; sets it around a push-triggered check isolates to this buffer instead
+    ;; of leaking a global value to others (see `flycheck-lsp--suppress-recheck').
+    (setq-local flycheck-lsp--suppress-recheck nil)
     (unless flycheck-mode (flycheck-mode 1))
     (flycheck-buffer-deferred)))
 

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -144,6 +144,34 @@
             (expect (flycheck-fix-p fix) :to-be t)
             (expect (flycheck-fix-description fix) :to-equal "Quick fix")))))
 
+    (it "does not treat isPreferred `:json-false' as preferred"
+      ;; jsonrpc decodes JSON `false' to `:json-false', which is truthy; the
+      ;; first action here carries it and must not be mistaken for preferred.
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/proj/a.el")
+        (insert "line one\n")
+        (cl-letf (((symbol-function 'eglot-managed-p) (lambda () t))
+                  ((symbol-function 'eglot-uri-to-path) #'identity)
+                  ((symbol-function 'flycheck-same-files-p) #'equal)
+                  ((symbol-function 'eglot-code-actions)
+                   (lambda (&rest _)
+                     (list '(:title "Not preferred" :isPreferred :json-false
+                             :edit (:documentChanges
+                                    [(:textDocument (:uri "/proj/a.el")
+                                      :edits [(:range (:start (:line 0 :character 0)
+                                                       :end (:line 0 :character 1))
+                                               :newText "X")])]))
+                           '(:title "The real one" :isPreferred t
+                             :edit (:documentChanges
+                                    [(:textDocument (:uri "/proj/a.el")
+                                      :edits [(:range (:start (:line 0 :character 0)
+                                                       :end (:line 0 :character 4))
+                                               :newText "LINE")])]))))))
+          (let ((fix (flycheck-eglot--code-action-fix
+                      (flycheck-error-new-at 1 1 'error "x"
+                                             :buffer (current-buffer)))))
+            (expect (flycheck-fix-description fix) :to-equal "The real one")))))
+
     (it "returns no fix when the server offers no actions"
       (flycheck-buttercup-with-temp-buffer
         (insert "x\n")

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -210,6 +210,48 @@
         (expect (flycheck-error-list-visit-related-location)
                 :to-throw 'user-error))))
 
+  (describe "Applying fixes"
+    (it "applies the fix of the error at point"
+      (let* ((fix (flycheck-fix-new :description "Fix it" :edits nil :tick 0))
+             (err (flycheck-error-new-at 1 1 'error "x" :checker 'emacs-lisp
+                                         :fix fix))
+             applied)
+        (with-temp-buffer
+          (insert (propertize "row" 'tabulated-list-id err))
+          (goto-char (point-min))
+          (cl-letf (((symbol-function 'flycheck--error-fix-buffer)
+                     (lambda (_e) (current-buffer)))
+                    ((symbol-function 'flycheck-apply-fix)
+                     (lambda (f _b) (setq applied f)))
+                    ((symbol-function 'flycheck-error-list-refresh) #'ignore))
+            (flycheck-error-list-apply-fix)))
+        (expect applied :to-be fix)))
+
+    (it "signals a user-error when the error at point has no fix"
+      (with-temp-buffer
+        (insert (propertize "row" 'tabulated-list-id
+                            (flycheck-error-new-at 1 1 'error "x"
+                                                   :checker 'emacs-lisp)))
+        (goto-char (point-min))
+        (expect (flycheck-error-list-apply-fix) :to-throw 'user-error)))
+
+    (it "fixes all errors in the source buffer"
+      (let ((src (generate-new-buffer " src")) called)
+        (unwind-protect
+            (with-temp-buffer
+              (setq-local flycheck-error-list-source-buffer src)
+              (cl-letf (((symbol-function 'flycheck-fix-all-errors)
+                         (lambda () (interactive) (setq called t)))
+                        ((symbol-function 'flycheck-error-list-refresh) #'ignore))
+                (flycheck-error-list-fix-all))
+              (expect called :to-be t))
+          (kill-buffer src))))
+
+    (it "signals a user-error when there is no live source buffer"
+      (with-temp-buffer
+        (setq-local flycheck-error-list-source-buffer nil)
+        (expect (flycheck-error-list-fix-all) :to-throw 'user-error))))
+
   (describe "Grouping by file"
     (let ((errors (list (flycheck-error-new-at 3 1 'error "in b"
                                                :filename "/p/b.el" :checker 'x)

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -191,6 +191,20 @@
                   :to-equal '("rubocop" "--lsp"))
           (expect (flycheck-lsp--command 'python-mode) :to-be nil))))
 
+    (describe "flycheck-lsp--available-command"
+      (it "caches its result per mode instead of re-probing the executable"
+        (flycheck-buttercup-with-temp-buffer
+          (setq-local major-mode 'ruby-mode)
+          (let ((flycheck-lsp-servers '((ruby-mode "rubocop" "--lsp")))
+                (flycheck-executable-find (lambda (_p) "/usr/bin/rubocop")))
+            ;; first call caches the positive result
+            (expect (flycheck-lsp--available-command 'ruby-mode)
+                    :to-equal '("rubocop" "--lsp"))
+            ;; even once the program looks absent, the cached command stands
+            (setq flycheck-executable-find (lambda (_p) nil))
+            (expect (flycheck-lsp--available-command 'ruby-mode)
+                    :to-equal '("rubocop" "--lsp"))))))
+
     (describe "the default flycheck-lsp-servers"
       (it "maps every mode to a non-empty command of strings"
         (dolist (entry flycheck-lsp-servers)


### PR DESCRIPTION
Follow-ups from a careful audit of the LSP/diagnostics arc, all on unreleased code.

- **Bug:** Eglot's `flycheck-eglot--code-action-fix` picked the preferred quickfix with bare truthiness on `:isPreferred`, but jsonrpc decodes JSON `false` to the *truthy* `:json-false`. A server marking some actions `isPreferred: false` (rust-analyzer, tsserver) got the wrong action applied. Now tests `eq` to t, matching the native `lsp` paths.
- **Perf:** the native `lsp` checker seeked lines by rescanning from `point-min` per diagnostic (O(diagnostics × lines)); now it reuses `flycheck-goto-line`'s cache. And `executable-find` ran in the checker predicate on every check — now cached per mode (matters over TRAMP).
- **Consistency/robustness:** `flycheck-lsp--suppress-recheck` is buffer-local now (was a global that could drop another buffer's push); open documents key on `flycheck-lsp--doc-key` everywhere (Windows URI respelling); the `flycheck-lsp-exclusive` docstring gains the global-chain caveat its Eglot twin has; a stale lifecycle comment is corrected.
- **Tests:** added coverage for the availability cache, the error-list `x`/`X` fix commands (were untested), and the Eglot `:json-false` regression.