### PR TITLE
Make the diagnostics arc more discoverable

### DIFF
--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -390,6 +390,18 @@ competing for attention.
      (``flycheck-annotate-suppress-echo``), and user-registrable styles
      (``flycheck-annotate-style-functions``).
 
+.. note::
+
+   Two rough edges in the ``below`` layout:
+
+   * Under ``display-line-numbers-mode`` the annotation's own lines are not
+     blanked in the line-number gutter.
+   * The virtual lines and the whole-line tint are not coordinated with
+     ``hl-line-mode``.
+
+   Neither affects correctness; if either bothers you, use the ``eol`` layout
+   for those lines (``flycheck-annotate-current-line-style``).
+
 Mode line
 =========
 

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -78,3 +78,22 @@ The same menu also pops up when you click on the mode line lighter:
 .. figure:: /images/flycheck-mode-line-menu.png
 
    The mode line menu of Flycheck
+
+What else Flycheck can do
+=========================
+
+The basics above are only the start.  A few highlights worth knowing about:
+
+- **Inline error messages.**  Flycheck can show each message right next to the
+  code it refers to, in the spirit of VS Code's Error Lens - turn on
+  ``flycheck-annotate-mode`` (see :doc:`error-reports`).
+- **Fixes.**  Some checkers report a machine-applicable fix; apply the one at
+  point with :kbd:`C-c ! f`, or every fix in the buffer with :kbd:`C-c ! F`
+  (see :doc:`error-interaction`).
+- **Related locations.**  When an error points at other places (an earlier
+  definition, a borrow), jump to them with :kbd:`C-c ! j` (see
+  :doc:`error-interaction`).
+- **Language servers.**  Flycheck can report a language server's diagnostics -
+  either through Eglot (``flycheck-eglot-mode``) or by talking to a diagnostics
+  linter directly, with no full LSP client (``flycheck-lsp-mode``).  See
+  :doc:`syntax-checks`.

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -333,6 +333,7 @@ Configuring servers
 
       (add-to-list 'flycheck-lsp-servers '(terraform-mode "tflint" "--langserver"))
       (add-to-list 'flycheck-lsp-servers '(protobuf-mode "buf" "lsp" "serve"))
+      (add-to-list 'flycheck-lsp-servers '(toml-mode "taplo" "lsp" "stdio"))
 
    A major mode maps to a single server.  To use a different one, replace the
    entry - e.g. Standard instead of RuboCop, or Oxlint instead of Biome::

--- a/flycheck.el
+++ b/flycheck.el
@@ -1572,7 +1572,11 @@ Key bindings:
   \\[flycheck-list-errors]     List all errors
 
   \\[flycheck-copy-errors-as-kill]   Copy error messages at point
-  \\[flycheck-display-error-at-point]     Explain error at point
+  \\[flycheck-display-error-at-point]     Show error at point
+  \\[flycheck-explain-error-at-point]     Explain error at point
+  \\[flycheck-visit-related-location]     Visit a related location
+  \\[flycheck-fix-error-at-point]     Apply fix at point
+  \\[flycheck-fix-all-errors]     Apply all fixes in buffer
 ")))
         (help-mode)
         (read-only-mode 0)


### PR DESCRIPTION
Docs/discoverability follow-ups from the arc audit.

- `flycheck-quick-help` was stale: it mislabelled `h` as "Explain error at point" (that's `e`) and omitted every newer command. It now shows show/explain at point, visit-related-location, and the two fix commands.
- The quickstart never mentioned the marquee features, so a newcomer who stopped there would never learn they exist. Added a short "What else Flycheck can do" with pointers to inline messages, fixes, related locations, and LSP support.
- Added the missing Taplo example to the opt-in LSP servers list.
- Documented two known `below`-layout rough edges (`display-line-numbers` gutter, `hl-line`).