### PR TITLE
Add an inline-messages menu toggle; drop an inaccurate annotate note

### DIFF
--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -390,18 +390,6 @@ competing for attention.
      (``flycheck-annotate-suppress-echo``), and user-registrable styles
      (``flycheck-annotate-style-functions``).
 
-.. note::
-
-   Two rough edges in the ``below`` layout:
-
-   * Under ``display-line-numbers-mode`` the annotation's own lines are not
-     blanked in the line-number gutter.
-   * The virtual lines and the whole-line tint are not coordinated with
-     ``hl-line-mode``.
-
-   Neither affects correctness; if either bothers you, use the ``eol`` layout
-   for those lines (``flycheck-annotate-current-line-style``).
-
 Mode line
 =========
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -1471,6 +1471,8 @@ Only has effect when variable `global-flycheck-mode' is non-nil."
      ["Go to next error" flycheck-next-error flycheck-mode]
      ["Go to previous error" flycheck-previous-error flycheck-mode]
      ["Show all errors" flycheck-list-errors flycheck-mode]
+     ["Show messages inline" flycheck-annotate-mode
+      :style toggle :selected (bound-and-true-p flycheck-annotate-mode)]
      "---"
      ["Copy messages at point" flycheck-copy-errors-as-kill
       (flycheck-overlays-at (point))]


### PR DESCRIPTION
Two small polish items from the arc audit.

- Add a "Show messages inline" toggle to the Flycheck menu for `flycheck-annotate-mode` — the feature a user most wants to switch on, but which was menu-invisible.
- Remove the `below`-layout "known limitations" note I added earlier: I verified against a real GUI frame that under `display-line-numbers-mode` the annotation lines' gutter is blanked and the messages still align past it (even with a wider gutter), and that `hl-line-mode` coexists cleanly. The note described problems that don't actually occur, so it was misleading.