### PR TITLE
Warn about the built-in/third-party flycheck-eglot name clash

### DIFF
--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -226,6 +226,13 @@ server has nothing for it.
 This obsoletes the third-party ``flycheck-eglot`` package; drop it from your
 configuration if you used it.
 
+.. warning::
+
+   The built-in mode uses the same names -- ``flycheck-eglot-mode`` and
+   ``global-flycheck-eglot-mode`` -- as the old package.  If both are
+   installed they define the same commands, so **uninstall the third-party
+   ``flycheck-eglot`` package** before relying on the built-in one.
+
 
 LSP diagnostics without Eglot
 =============================


### PR DESCRIPTION
The built-in `flycheck-eglot-mode` reuses the mode names of the obsoleted third-party `flycheck-eglot` package, so having both installed defines the same commands twice. Adds a warning to the manual and a note to the changelog so upgraders uninstall the old package. Docs only.