### PR TITLE
Add global-flycheck-annotate-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#2204](https://github.com/flycheck/flycheck/pull/2204): Add a `sideline` annotation style that flushes the compact message to the window's right edge, in the manner of `lsp-ui-sideline`.
 - [#2205](https://github.com/flycheck/flycheck/pull/2205): Align `below`-style connectors to the error's real display column, so they line up under tab-indented code and past a line-number gutter.
 - [#2206](https://github.com/flycheck/flycheck/pull/2206): Filter inline annotations per tier via `flycheck-annotate-current-line-levels` and `flycheck-annotate-other-lines-levels`, so the focused line and the rest can show different levels.
+- [#2225](https://github.com/flycheck/flycheck/pull/2225): Add `global-flycheck-annotate-mode` to turn inline diagnostics on in every buffer Flycheck checks.
 - [#2193](https://github.com/flycheck/flycheck/pull/2193): Add a quick-fix API. `C-c ! f` (`flycheck-fix-error-at-point`) and `x` in the error list apply a checker's machine-applicable fix, attached to a `flycheck-error` via the new `:fix` slot. Wired into `javascript-eslint`, the Rust checkers and SARIF-based checkers, whose fixes were previously parsed and discarded.
 - [#2195](https://github.com/flycheck/flycheck/pull/2195): `python-ruff` and `sh-shellcheck` now carry the fixes their tools suggest (shellcheck 0.7 or newer required).
 - [#2207](https://github.com/flycheck/flycheck/pull/2207): `C-c ! F` (`flycheck-fix-all-errors`) applies every fix in the buffer at once as a single undoable change; `X` does the same from the error list.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ few more things:
   :ensure t
   :hook ((after-init . global-flycheck-mode)
          ;; Show diagnostics inline, next to the code (Error Lens style)
-         (flycheck-mode . flycheck-annotate-mode))
+         (after-init . global-flycheck-annotate-mode))
   :config
   ;; Report Eglot's LSP diagnostics through Flycheck
   (global-flycheck-eglot-mode 1))

--- a/doc/user/error-reports.rst
+++ b/doc/user/error-reports.rst
@@ -250,16 +250,22 @@ Inline error messages
 Beyond the fringe or margin indicators, Flycheck can render the error messages
 themselves right next to the code they refer to, in the spirit of VS Code's
 Error Lens and the inline diagnostics of Neovim, Helix and Zed.  Enable
-``flycheck-annotate-mode`` to turn this on:
+``flycheck-annotate-mode`` to turn this on in the current buffer, or
+``global-flycheck-annotate-mode`` to turn it on everywhere Flycheck checks:
 
 .. code-block:: elisp
 
-   (add-hook 'flycheck-mode-hook #'flycheck-annotate-mode)
+   (add-hook 'after-init-hook #'global-flycheck-annotate-mode)
 
 .. minor-mode:: flycheck-annotate-mode
 
    Toggle the inline display of Flycheck error messages in the current buffer.
    The annotations appear only while ``flycheck-mode`` is on.
+
+.. minor-mode:: global-flycheck-annotate-mode
+
+   Toggle ``flycheck-annotate-mode`` in every buffer Flycheck may check, the
+   same set of buffers ``global-flycheck-mode`` enables.
 
 Flycheck picks the display style per line: the line at point uses
 ``flycheck-annotate-current-line-style`` and every other line uses

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -30,7 +30,7 @@ Flycheck surface your language server's diagnostics too:
    (add-hook 'after-init-hook #'global-flycheck-mode)
 
    ;; Show diagnostics inline, next to the code (in the spirit of Error Lens)
-   (add-hook 'flycheck-mode-hook #'flycheck-annotate-mode)
+   (add-hook 'after-init-hook #'global-flycheck-annotate-mode)
 
    ;; Report Eglot's LSP diagnostics through Flycheck
    (global-flycheck-eglot-mode 1)

--- a/flycheck.el
+++ b/flycheck.el
@@ -8037,6 +8037,15 @@ annotated on the next command."
                  #'flycheck-annotate--refresh t)
     (flycheck-annotate--clear))))
 
+;;;###autoload
+(define-globalized-minor-mode global-flycheck-annotate-mode
+  flycheck-annotate-mode
+  (lambda ()
+    ;; Enable inline annotations in exactly the buffers `global-flycheck-mode'
+    ;; checks; the mode stays inert until a check runs there anyway.
+    (when (flycheck-may-enable-mode) (flycheck-annotate-mode 1)))
+  :group 'flycheck)
+
 
 ;;; Working with errors
 (defun flycheck-copy-errors-as-kill (pos &optional formatter)

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -412,4 +412,28 @@ Line 2 gets an error and a warning; line 4 gets a warning."
               (expect (overlay-start ov) :to-equal (line-beginning-position))
               (expect (overlay-end ov) :to-equal (1+ (line-end-position))))))))))
 
+(describe "global-flycheck-annotate-mode"
+  (after-each
+    ;; The globalized mode toggles the minor mode across all buffers and
+    ;; installs a global hook, so make sure it never leaks between specs.
+    (global-flycheck-annotate-mode -1))
+
+  (it "enables flycheck-annotate-mode in buffers Flycheck may check"
+    (let ((buffer (get-buffer-create "test-annotate-global-eligible")))
+      (unwind-protect
+          (with-current-buffer buffer
+            (text-mode)
+            (global-flycheck-annotate-mode 1)
+            (expect flycheck-annotate-mode :to-be-truthy))
+        (kill-buffer buffer))))
+
+  (it "leaves buffers Flycheck skips alone"
+    (let ((buffer (get-buffer-create "test-annotate-global-special")))
+      (unwind-protect
+          (with-current-buffer buffer
+            (special-mode)
+            (global-flycheck-annotate-mode 1)
+            (expect flycheck-annotate-mode :to-be nil))
+        (kill-buffer buffer)))))
+
 ;;; test-annotate.el ends here


### PR DESCRIPTION
Enabling inline diagnostics everywhere meant hooking `flycheck-annotate-mode` onto `flycheck-mode-hook` by hand. This adds a globalized variant so one call turns it on in the same buffers `global-flycheck-mode` checks (gated on `flycheck-may-enable-mode`), and updates the README, quickstart and manual to use it.