### PR TITLE
Fix the cursor landing inside inline annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+- [#2227](https://github.com/flycheck/flycheck/pull/2227): Fix `flycheck-annotate-mode` drawing the cursor past the inline annotation, so the line at point read as if the cursor were inside the message (most visibly with the multi-line `below` style) and editing the line was awkward.
+
 ## 38.0 (2026-07-29)
 
 ### New Features

--- a/flycheck.el
+++ b/flycheck.el
@@ -7752,17 +7752,33 @@ carries a machine-applicable fix."
   (push overlay flycheck-annotate--overlays)
   overlay)
 
-(defun flycheck-annotate--make-overlay (anchor &rest props)
-  "Create a tracked inline overlay at ANCHOR with PROPS.
+(defun flycheck-annotate--make-overlay (anchor string)
+  "Create a tracked inline overlay showing STRING at end-of-line ANCHOR.
 
-ANCHOR is a buffer position; the overlay is empty and carries the
-`flycheck-annotate' property so it can be found and deleted.  PROPS is a
-plist of additional overlay properties, e.g. `after-string'.  Return the
+The overlay spans ANCHOR's trailing newline and shows STRING as a
+`before-string', so the annotation renders right after the code.  A
+`cursor' text property on STRING keeps the cursor pinned to ANCHOR -- the
+end of the code -- rather than to the end of the annotation, so `C-e' and
+typing behave as if the annotation were not there.  This is the same
+technique Flymake uses for its end-of-line diagnostics.  Return the
 overlay."
-  (let ((ov (make-overlay anchor anchor nil t)))
+  (let* ((end (min (point-max) (1+ anchor)))
+         (ov (make-overlay anchor end nil t nil)))
     (overlay-put ov 'priority 100)
-    (while props
-      (overlay-put ov (pop props) (pop props)))
+    ;; Evaporate once the spanned newline is gone, but not when the overlay is
+    ;; empty from the start (end of buffer, no trailing newline to span) -- an
+    ;; empty evaporating overlay would delete itself and drop the annotation.
+    (overlay-put ov 'evaporate (/= anchor end))
+    ;; The cursor is drawn on the first character of the before-string.  Anchor
+    ;; it to a dedicated plain space so `C-e' and typing park at the end of the
+    ;; code rather than inside the annotation.  A plain space is required: the
+    ;; `cursor' property is ignored on a newline (which the `below' style's
+    ;; string starts with) and lands at the far end of the `sideline' style's
+    ;; `:align-to' stretch, both leaving the cursor stranded.
+    (overlay-put ov 'before-string
+                 (if (> (length string) 0)
+                     (concat (propertize " " 'cursor t) string)
+                   string))
     (flycheck-annotate--track ov)))
 
 (defun flycheck-annotate--background-face (level)
@@ -7817,7 +7833,7 @@ first) with a count of the rest, propertized with its level face."
 Only the most severe error's message is shown, with a count of the rest.
 FOCUSED is ignored."
   (flycheck-annotate--make-overlay
-   anchor 'after-string (concat "  " (flycheck-annotate--compact-text errors))))
+   anchor (concat "  " (flycheck-annotate--compact-text errors))))
 
 (defun flycheck-annotate-sideline-style (errors anchor _focused)
   "Render ERRORS flushed to the window's right edge past line ANCHOR.
@@ -7829,7 +7845,7 @@ instead.  FOCUSED is ignored."
   (let* ((text (flycheck-annotate--compact-text errors))
          (width (string-width text))
          (spacer (propertize " " 'display `(space :align-to (- right ,width)))))
-    (flycheck-annotate--make-overlay anchor 'after-string (concat spacer text))))
+    (flycheck-annotate--make-overlay anchor (concat spacer text))))
 
 (defun flycheck-annotate--display-column (err bol eol)
   "Return the display column of ERR's start on the line from BOL to EOL.
@@ -7878,7 +7894,7 @@ gutter.  FOCUSED is ignored."
                                           'face 'shadow)))
                     (flycheck-error-relations err) "")))
         (push (concat "\n" pad conn msg rels) lines)))
-    (flycheck-annotate--make-overlay anchor 'after-string
+    (flycheck-annotate--make-overlay anchor
                                    (apply #'concat (nreverse lines)))))
 
 (defun flycheck-annotate--clear ()

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -40,13 +40,19 @@ Line 2 gets an error and a warning; line 4 gets a warning."
     (setq flycheck-current-errors (list e2 e2b e4))
     (mapc #'flycheck-add-overlay flycheck-current-errors)))
 
+(defun test-annotate/text (ov)
+  "Return OV's annotation string, minus the leading cursor-anchor space.
+Return nil for overlays that carry no annotation, such as tint overlays,
+so it doubles as a predicate for the message overlays."
+  (when-let* ((s (overlay-get ov 'before-string)))
+    (if (get-text-property 0 'cursor s) (substring s 1) s)))
+
 (defun test-annotate/anchors ()
   "Return an alist mapping each message overlay's line to its text."
   (mapcar (lambda (ov)
             (cons (line-number-at-pos (overlay-start ov))
-                  (substring-no-properties (overlay-get ov 'after-string))))
-          (seq-filter (lambda (ov) (overlay-get ov 'after-string))
-                      flycheck-annotate--overlays)))
+                  (substring-no-properties (test-annotate/text ov))))
+          (seq-filter #'test-annotate/text flycheck-annotate--overlays)))
 
 (defun test-annotate/tints ()
   "Return an alist mapping each tinted line to its background face."
@@ -106,7 +112,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
                                                   :checker 'emacs-lisp)))
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-eol-style errs (line-end-position) nil))
-               (s (substring-no-properties (overlay-get ov 'after-string))))
+               (s (substring-no-properties (test-annotate/text ov))))
           (expect s :to-match "big")
           (expect s :to-match (regexp-quote "(+1)"))
           (expect (string-prefix-p "\n" s) :to-be nil)))))
@@ -122,7 +128,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
                                                   :checker 'emacs-lisp)))
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
-               (s (substring-no-properties (overlay-get ov 'after-string))))
+               (s (substring-no-properties (test-annotate/text ov))))
           (expect (string-prefix-p "\n" s) :to-be t)
           (expect s :to-match "one")
           (expect s :to-match "two")
@@ -139,7 +145,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
                                                   :checker 'emacs-lisp)))
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
-               (s (overlay-get ov 'after-string)))
+               (s (test-annotate/text ov)))
           ;; the pad after the newline aligns to display column 8, not 1
           (expect (get-text-property 1 'display s)
                   :to-equal '(space :align-to 8)))))
@@ -152,7 +158,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
                                                   :checker 'emacs-lisp)))
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
-               (s (overlay-get ov 'after-string)))
+               (s (test-annotate/text ov)))
           ;; char 1 is the connector itself, no stretch space
           (expect (get-text-property 1 'display s) :to-be nil))))
 
@@ -167,7 +173,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
                                    :line 5 :column 2 :message "first here")))))
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
-               (s (substring-no-properties (overlay-get ov 'after-string))))
+               (s (substring-no-properties (test-annotate/text ov))))
           (expect s :to-match "redefined")
           (expect s :to-match "↳ first here (5:2)")
           ;; leading newline, the message line, then the related-location line
@@ -183,7 +189,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
                                                   :checker 'emacs-lisp)))
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-sideline-style errs (line-end-position) nil))
-               (s (overlay-get ov 'after-string)))
+               (s (test-annotate/text ov)))
           ;; most severe message plus a count, no leading newline
           (expect (substring-no-properties s) :to-match "big")
           (expect (substring-no-properties s) :to-match (regexp-quote "(+1)"))
@@ -207,9 +213,9 @@ Line 2 gets an error and a warning; line 4 gets a warning."
           (let ((flycheck-annotate-current-line-style 'sideline)
                 (flycheck-annotate-other-lines-style nil))
             (flycheck-annotate-mode 1)
-            (let* ((ov (seq-find (lambda (o) (overlay-get o 'after-string))
+            (let* ((ov (seq-find (lambda (o) (test-annotate/text o))
                                  flycheck-annotate--overlays))
-                   (s (overlay-get ov 'after-string)))
+                   (s (test-annotate/text ov)))
               (expect (car (get-text-property 0 'display s)) :to-be 'space)))))))
 
   (describe "the fix marker"
@@ -242,7 +248,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
       (flycheck-buttercup-with-temp-buffer
         (insert "abc\n")
         (let* ((flycheck-annotate--overlays nil)
-               (ov (flycheck-annotate--make-overlay (point-min) 'after-string "x")))
+               (ov (flycheck-annotate--make-overlay (point-min) "x")))
           (expect (overlay-get ov 'flycheck-annotate) :to-be t)
           (expect (memq ov flycheck-annotate--overlays) :not :to-be nil)))))
 
@@ -292,7 +298,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
           (forward-line 1)              ; line 2
           (flycheck-annotate-mode 1)
           (let ((anchors (test-annotate/anchors)))
-            ;; line 2 is focused -> below (after-string begins with a newline)
+            ;; line 2 is focused -> below (annotation begins with a newline)
             (expect (string-prefix-p "\n" (cdr (assq 2 anchors))) :to-be t)
             ;; line 4 is unfocused -> eol
             (expect (string-prefix-p "\n" (cdr (assq 4 anchors))) :to-be nil)))))
@@ -355,7 +361,80 @@ Line 2 gets an error and a warning; line 4 gets a warning."
           (flycheck-annotate-mode 1)
           (expect flycheck-annotate--overlays :not :to-be nil)
           (flycheck-clear)
-          (expect flycheck-annotate--overlays :to-be nil)))))
+          (expect flycheck-annotate--overlays :to-be nil))))
+
+    (it "anchors the cursor to the end of the code across every style"
+      ;; Every message overlay spans the trailing newline and renders its text
+      ;; as a `before-string' whose first character is a plain space carrying a
+      ;; `cursor' property.  That keeps C-e and typing parked at the end of the
+      ;; code instead of the end of the annotation.  A plain space is essential:
+      ;; the `cursor' property is ignored on a newline (the `below' string) and
+      ;; lands at the far end of the `sideline' `:align-to' stretch.
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)
+          (dolist (style '(eol below sideline))
+            (let ((flycheck-annotate-current-line-style style)
+                  (flycheck-annotate-other-lines-style style))
+              (flycheck-annotate-mode 1)
+              (let ((msg-ovs (seq-filter #'test-annotate/text
+                                         flycheck-annotate--overlays)))
+                (expect msg-ovs :not :to-be nil)
+                (dolist (ov msg-ovs)
+                  (let ((s (overlay-get ov 'before-string)))
+                    ;; spans exactly the trailing newline
+                    (expect (overlay-end ov) :to-equal (1+ (overlay-start ov)))
+                    ;; plain-space cursor anchor: cursor prop, a real space,
+                    ;; and no `display' spec that would move the cursor away
+                    (expect (get-text-property 0 'cursor s) :to-be t)
+                    (expect (aref s 0) :to-equal ?\s)
+                    (expect (get-text-property 0 'display s) :to-be nil))))
+              (flycheck-annotate-mode -1))))))
+
+    (it "keeps a last-line annotation with no trailing newline"
+      ;; At end of buffer there is no newline to span, so the overlay is empty;
+      ;; it must not evaporate, or the annotation would disappear.
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (insert "code")               ; deliberately no trailing newline
+          (setq-local flycheck-mode t)
+          (let ((e (flycheck-error-new-at 1 1 'error "boom"
+                                          :buffer (current-buffer)
+                                          :checker 'emacs-lisp)))
+            (setq flycheck-current-errors (list e))
+            (mapc #'flycheck-add-overlay flycheck-current-errors))
+          (goto-char (point-max))
+          (let ((flycheck-annotate-current-line-style 'below)
+                (flycheck-annotate-other-lines-style 'below))
+            (flycheck-annotate-mode 1)
+            (let ((ov (seq-find #'test-annotate/text flycheck-annotate--overlays)))
+              (expect ov :not :to-be nil)
+              (expect (overlay-start ov) :to-equal (point-max))
+              (expect (overlay-get ov 'evaporate) :to-be nil))))))
+
+    (it "leaves the code editable at the end of the line"
+      ;; Typing at end of line inserts into the code, not into the annotation.
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (insert "code\n")
+          (setq-local flycheck-mode t)
+          (let ((e (flycheck-error-new-at 1 1 'error "boom"
+                                          :buffer (current-buffer)
+                                          :checker 'emacs-lisp)))
+            (setq flycheck-current-errors (list e))
+            (mapc #'flycheck-add-overlay flycheck-current-errors))
+          (goto-char (point-min))
+          (let ((flycheck-annotate-current-line-style 'below)
+                (flycheck-annotate-other-lines-style 'below))
+            (flycheck-annotate-mode 1)
+            (end-of-line)
+            (insert "X")
+            (expect (buffer-substring-no-properties
+                     (point-min) (line-end-position))
+                    :to-equal "codeX"))))))
 
   (describe "the background tint"
     (it "adds no tint when disabled"


### PR DESCRIPTION
`flycheck-annotate-mode` rendered each style's message in the `after-string` of an empty end-of-line overlay. With point at end of line (e.g. after `C-e`), the cursor was drawn past the whole annotation, so it looked like it was inside the message and editing the line was confusing - worst with the multi-line `below` style, which also scrolled the window right and hid the code.

Adopt Flymake's end-of-line-diagnostics technique: put the message in the `before-string` of an overlay spanning the trailing newline, and anchor the cursor to a dedicated leading space carrying a `cursor` text property. A plain space is required - the `cursor` property is ignored on a newline (the `below` string) and lands at the far end of the `sideline` `:align-to` stretch. The end-of-buffer case (empty overlay, no newline to span) is guarded so it doesn't evaporate.

Verified visually across all styles plus typing and the last-line case, and covered by new specs (cross-style cursor anchor, end-of-buffer, editable-at-eol).