### PR TITLE
Rename the native LSP checker to flycheck-lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+- [#2228](https://github.com/flycheck/flycheck/pull/2228): Rename the native LSP checker from `lsp` to `flycheck-lsp`, so it no longer clobbers the `lsp` checker `lsp-mode` registers for its own Flycheck integration - which had left lsp-mode users with an empty error list and no highlighting ([#2226](https://github.com/flycheck/flycheck/issues/2226)).
+
 ## 38.1 (2026-07-29)
 
 ### Bugs fixed

--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -311,7 +311,7 @@ checkers that currently provide fixes are ``javascript-eslint``,
 clippy``'s machine-applicable suggestions), and any checker whose SARIF output
 includes fixes (e.g. ``dockerfile-hadolint``).  LSP servers that offer
 ``quickfix`` code actions provide fixes too, through ``flycheck-eglot-mode`` or
-the native ``lsp`` checker (see :doc:`syntax-checks`).
+the native ``flycheck-lsp`` checker (see :doc:`syntax-checks`).
 
 
 Kill errors

--- a/doc/user/flycheck-versus-flymake.rst
+++ b/doc/user/flycheck-versus-flymake.rst
@@ -98,7 +98,7 @@ detail.
      - yes; grouping, filtering, project-wide
      - yes; project-wide (28+)
    * - `Native LSP diagnostics`_
-     - yes (built-in ``lsp`` checker)
+     - yes (built-in ``flycheck-lsp`` checker)
      - no (needs Eglot)
    * - `Supported by Eglot`_
      - yes (``flycheck-eglot-mode``)

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -240,7 +240,7 @@ LSP diagnostics without Eglot
 A growing number of linters ship their own LSP server - RuboCop
 (``rubocop --lsp``), Ruff (``ruff server``), Biome (``biome lsp-proxy``) and
 more.  ``flycheck-lsp-mode`` talks to one of these directly, over Emacs'
-built-in ``jsonrpc`` library, and reports its diagnostics through the ``lsp``
+built-in ``jsonrpc`` library, and reports its diagnostics through the ``flycheck-lsp``
 checker - no Eglot, and no full LSP client, involved.
 
 This is the setup the native LSP support is built for, and it is worth
@@ -266,7 +266,7 @@ whose language server you don't have.
 .. minor-mode:: flycheck-lsp-mode
 
    Start the LSP server configured for the buffer's major mode, send it the
-   buffer's text, and report the diagnostics it pushes back through the ``lsp``
+   buffer's text, and report the diagnostics it pushes back through the ``flycheck-lsp``
    checker.  Does nothing in a buffer whose major mode has no configured,
    installed server.
 
@@ -334,7 +334,7 @@ Configuring servers
    These lint out of the box.  Other linters ship an LSP server too but need
    project configuration before they report anything - TFLint wants a
    ``.tflint.hcl`` and plugins, Buf wants a module, Taplo wants a workspace
-   config it fetches over ``workspace/configuration`` (which the ``lsp`` checker
+   config it fetches over ``workspace/configuration`` (which the ``flycheck-lsp`` checker
    does not answer) - so they are left out of the defaults.  Add them once your
    project is set up::
 
@@ -363,7 +363,7 @@ Configuring servers
 .. defcustom:: flycheck-lsp-exclusive
 
    When non-nil (the default), a buffer reports only the language server's
-   diagnostics.  Set to nil to have ``lsp`` chain to the first command checker
+   diagnostics.  Set to nil to have ``flycheck-lsp`` chain to the first command checker
    that supports the buffer's major mode, so the server and a command checker
    both contribute.
 
@@ -390,7 +390,7 @@ Configuring servers
    server that does not answer in time is torn down and retried later.
    Defaults to 5.
 
-Diagnostics from the ``lsp`` checker carry the same detail as Eglot's - error
+Diagnostics from the ``flycheck-lsp`` checker carry the same detail as Eglot's - error
 level, id, an explanation URL from ``codeDescription``, and the secondary
 locations of ``relatedInformation`` (visit them with ``C-c ! j``).  When the
 server offers code actions, they are available as fixes as well (see
@@ -399,7 +399,7 @@ server offers code actions, they are available as fixes as well (see
 Full language servers
 ---------------------
 
-The ``lsp`` checker consumes only diagnostics, so nothing stops you pointing it
+The ``flycheck-lsp`` checker consumes only diagnostics, so nothing stops you pointing it
 at a *full* language server - clojure-lsp, ruby-lsp, gopls and the like - and
 letting Flycheck surface its diagnostics::
 
@@ -420,6 +420,6 @@ errors.  If you want those features too, run the server through Eglot and use
 lighter than a language server.
 
 Two caveats if you do point it at a full server: some report diagnostics only
-through LSP *pull* requests rather than pushing them, which the ``lsp`` checker
+through LSP *pull* requests rather than pushing them, which the ``flycheck-lsp`` checker
 does not yet support (it will report nothing), and some need extra
 ``initializationOptions`` or workspace configuration to lint the way you expect.

--- a/flycheck.el
+++ b/flycheck.el
@@ -246,7 +246,7 @@
     ;; Only ever selected when `flycheck-eglot-mode' is on (see its predicate).
     eglot-check
     ;; Only ever selected when `flycheck-lsp-mode' is on (see its predicate).
-    lsp)
+    flycheck-lsp)
   "Syntax checkers available for automatic selection.
 
 A list of Flycheck syntax checkers to choose from when syntax
@@ -10385,7 +10385,7 @@ SYMBOL with `flycheck-def-executable-var'."
 ;;
 ;; Shared machinery for turning a Language Server Protocol diagnostic into a
 ;; `flycheck-error'.  Both the Eglot bridge (`eglot-check', below) and the
-;; native `lsp' checker use it, so the two produce identical errors -- the
+;; native `flycheck-lsp' checker use it, so the two produce identical errors -- the
 ;; same level, id, related locations and codeDescription -- regardless of how
 ;; the diagnostic reached Flycheck.  These helpers operate on the raw LSP
 ;; diagnostic object (a plist), not on any client's data structures.
@@ -10519,7 +10519,7 @@ fix is applied right after."
 
 With EXCLUSIVE non-nil, CHECKER is the buffer's sole checker; otherwise it
 chains to the first other checker that supports the mode, so an LSP
-backend and a command checker both contribute.  Shared by the `lsp' and
+backend and a command checker both contribute.  Shared by the `flycheck-lsp' and
 `eglot-check' bridges."
   (unless (flycheck-checker-supports-major-mode-p checker major-mode)
     (flycheck-add-mode checker major-mode))
@@ -10535,7 +10535,7 @@ backend and a command checker both contribute.  Shared by the `lsp' and
 
 ;;; Native LSP diagnostics client
 ;;
-;; The `lsp' checker talks to a diagnostics language server directly, over
+;; The `flycheck-lsp' checker talks to a diagnostics language server directly, over
 ;; the built-in `jsonrpc' library -- no Eglot required.  It is meant for the
 ;; single-purpose LSP linters (`rubocop --lsp', `ruff server', ...), letting
 ;; Flycheck use them like any other checker without handing the buffer to a
@@ -10584,7 +10584,7 @@ backend and a command checker both contribute.  Shared by the `lsp' and
 Each entry is (MAJOR-MODE PROGRAM ARG...): a buffer in MAJOR-MODE that
 enables `flycheck-lsp-mode' has PROGRAM started with the ARGs as an LSP
 server, is fed the buffer's text, and reports the diagnostics the server
-pushes back through the `lsp' checker.
+pushes back through the `flycheck-lsp' checker.
 
 The default entries are linters that ship a native LSP server and lint out
 of the box, with no project configuration: RuboCop (Ruby), Ruff (Python),
@@ -10617,15 +10617,15 @@ and `flycheck-eglot-mode' instead."
   :package-version '(flycheck . "38"))
 
 (defcustom flycheck-lsp-exclusive t
-  "Whether the `lsp' checker is the only checker or chains to others.
+  "Whether the `flycheck-lsp' checker is the only checker or chains to others.
 
 When non-nil (the default), a buffer using `flycheck-lsp-mode' reports
-only the language server's diagnostics.  When nil, `lsp' chains to the
+only the language server's diagnostics.  When nil, `flycheck-lsp' chains to the
 first other checker that supports the buffer's major mode, so the server
 and a command checker can both contribute.
 
 Note that this takes effect globally when a buffer enables the mode: it is
-stored in `lsp's chain, not per buffer."
+stored in `flycheck-lsp's chain, not per buffer."
   :type 'boolean
   :safe #'booleanp
   :group 'flycheck
@@ -10644,7 +10644,7 @@ next check."
   :package-version '(flycheck . "38"))
 
 (defcustom flycheck-lsp-code-actions t
-  "Whether the `lsp' checker offers LSP quick-fix code actions as fixes.
+  "Whether the `flycheck-lsp' checker offers LSP quick-fix code actions as fixes.
 
 When non-nil (the default) and the server advertises code actions, each
 diagnostic carries a lazy fix (see `flycheck-error-resolve-fix') that
@@ -10698,7 +10698,7 @@ A server installed mid-session is not noticed until the cache is rebuilt
 
 Uses `flycheck-executable-find', so it honours the user's setting and TRAMP.
 The result is cached buffer-locally, keyed on MODE: `executable-find' scans
-`exec-path' (and probes the remote host over TRAMP), and the `lsp' checker's
+`exec-path' (and probes the remote host over TRAMP), and the `flycheck-lsp' checker's
 predicate calls this on every check."
   (if (eq (car flycheck-lsp--command-cache) mode)
       (cdr flycheck-lsp--command-cache)
@@ -11035,12 +11035,12 @@ attaches a lazy quickfix from SERVER for the document URI (see
        :id (flycheck-lsp--diagnostic-id lsp)
        :relations (flycheck-lsp--related-locations lsp)
        :fix (flycheck-lsp--fix-provider server uri lsp)
-       :checker 'lsp
+       :checker 'flycheck-lsp
        :buffer buffer
        :filename (buffer-file-name buffer)))))
 
 (defun flycheck-lsp--start (_checker callback)
-  "Start the `lsp' syntax check, reporting through CALLBACK.
+  "Start the `flycheck-lsp' syntax check, reporting through CALLBACK.
 
 Ensure the buffer's server is running, sync the document to it, and report
 the diagnostics cached for the buffer so far.  The server's later push
@@ -11075,18 +11075,18 @@ handshake's completion re-triggers the check (see
     (error (funcall callback 'errored (error-message-string err)))))
 
 (defun flycheck-lsp--enabled-p ()
-  "Return non-nil when the `lsp' checker may run in the current buffer.
+  "Return non-nil when the `flycheck-lsp' checker may run in the current buffer.
 
 That is, `flycheck-lsp-mode' is on, the buffer visits a file, and its
 major mode has a server in `flycheck-lsp-servers' whose program is
-installed.  Used as the checker's predicate so `lsp' is never selected
+installed.  Used as the checker's predicate so `flycheck-lsp' is never selected
 unless the mode opted in and the server is actually available."
   (and (bound-and-true-p flycheck-lsp-mode)
        buffer-file-name
        (flycheck-lsp--available-command major-mode)
        t))
 
-(flycheck-define-generic-checker 'lsp
+(flycheck-define-generic-checker 'flycheck-lsp
   "Report the diagnostics of a Language Server Protocol server.
 
 Talks to the server configured for the buffer's major mode in
@@ -11137,8 +11137,8 @@ Added to `kill-emacs-hook' the first time a server starts."
   "Set up the current buffer to report its LSP server's diagnostics.
 A no-op unless the mode's server is configured and installed."
   (when (flycheck-lsp--available-command major-mode)
-    (flycheck-lsp--register-checker 'lsp flycheck-lsp-exclusive)
-    (setq flycheck-checker 'lsp)
+    (flycheck-lsp--register-checker 'flycheck-lsp flycheck-lsp-exclusive)
+    (setq flycheck-checker 'flycheck-lsp)
     ;; Give the recheck guard a real buffer-local binding, so the `let' that
     ;; sets it around a push-triggered check isolates to this buffer instead
     ;; of leaking a global value to others (see `flycheck-lsp--suppress-recheck').
@@ -11149,7 +11149,7 @@ A no-op unless the mode's server is configured and installed."
 (defun flycheck-lsp--disable ()
   "Undo `flycheck-lsp--enable' in the current buffer."
   (flycheck-lsp--close-buffer)
-  (when (eq flycheck-checker 'lsp)
+  (when (eq flycheck-checker 'flycheck-lsp)
     (setq flycheck-checker nil))
   (when flycheck-mode
     (flycheck-buffer-deferred)))
@@ -11160,8 +11160,8 @@ A no-op unless the mode's server is configured and installed."
 
 When enabled, and the buffer's major mode has a server configured in
 `flycheck-lsp-servers', Flycheck starts that server and shows the
-diagnostics it reports (via the `lsp' checker), talking LSP directly
-without Eglot.  With `flycheck-lsp-exclusive' nil, `lsp' chains to the
+diagnostics it reports (via the `flycheck-lsp' checker), talking LSP directly
+without Eglot.  With `flycheck-lsp-exclusive' nil, `flycheck-lsp' chains to the
 command checkers so both contribute.
 
 Enable it for every configured buffer with `global-flycheck-lsp-mode'.

--- a/test/specs/test-documentation.el
+++ b/test/specs/test-documentation.el
@@ -66,11 +66,11 @@
                                                 languages)))
 
         (it "documents all syntax checkers"
-          ;; `eglot-check' and `lsp' are not per-language command checkers;
-          ;; they are documented in the LSP sections of the manual, not
-          ;; languages.rst.
+          ;; `eglot-check' and `flycheck-lsp' are not per-language command
+          ;; checkers; they are documented in the LSP sections of the manual,
+          ;; not languages.rst.
           (expect (seq-difference
-                   (seq-difference flycheck-checkers '(eglot-check lsp))
+                   (seq-difference flycheck-checkers '(eglot-check flycheck-lsp))
                    checkers)
                   :to-equal nil))
 

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -245,7 +245,7 @@
                     :to-equal "C1")
             (expect (flycheck-error-line err) :to-equal 1)
             (expect (flycheck-error-column err) :to-equal 2)
-            (expect (flycheck-error-checker err) :to-be 'lsp)
+            (expect (flycheck-error-checker err) :to-be 'flycheck-lsp)
             ;; a server with no code-action capability -> no fix
             (expect (flycheck-error-fix err) :to-be nil)))))
 
@@ -342,7 +342,7 @@
           (let ((flycheck-lsp-servers nil)
                 (buffer-file-name "/x/a.rb")
                 (reported 'unset))
-            (flycheck-lsp--start 'lsp (lambda (status &optional data)
+            (flycheck-lsp--start 'flycheck-lsp (lambda (status &optional data)
                                         (setq reported (cons status data))))
             (expect reported :to-equal '(finished)))))
       (it "reports nothing but registers the doc while the server initializes"
@@ -356,7 +356,7 @@
                        (lambda (&rest _) server))
                       ((symbol-function 'flycheck-lsp--sync-document)
                        (lambda (&rest _) (error "must not sync before init"))))
-              (flycheck-lsp--start 'lsp (lambda (status &optional data)
+              (flycheck-lsp--start 'flycheck-lsp (lambda (status &optional data)
                                           (setq reported (cons status data)))))
             (expect reported :to-equal '(finished))
             ;; the document is registered so the init callback can recheck it
@@ -526,9 +526,15 @@
                 (expect (flycheck-fix-description fix) :to-equal "lazy")
                 (expect (length (flycheck-fix-edits fix)) :to-equal 1)))))))
 
-    (describe "the lsp generic checker"
+    (describe "the flycheck-lsp generic checker"
       (it "is a registered generic checker"
-        (expect (flycheck-valid-checker-p 'lsp) :to-be-truthy)
-        (expect (flycheck-checker-get 'lsp 'start) :to-be #'flycheck-lsp--start)))))
+        (expect (flycheck-valid-checker-p 'flycheck-lsp) :to-be-truthy)
+        (expect (flycheck-checker-get 'flycheck-lsp 'start) :to-be #'flycheck-lsp--start))
+
+      (it "does not define an `lsp' checker, so it never clobbers lsp-mode's"
+        ;; lsp-mode has owned the `lsp' checker name for years; a colliding
+        ;; definition broke its integration (issue #2226), so the native
+        ;; checker is named `flycheck-lsp' instead.
+        (expect (flycheck-valid-checker-p 'lsp) :to-be nil)))))
 
 ;;; test-lsp.el ends here


### PR DESCRIPTION
Flycheck 38 registered its native LSP-diagnostics checker as `lsp` - the same name `lsp-mode` has used for its own Flycheck integration for years. Loading Flycheck 38 redefined that checker, so lsp-mode users lost all diagnostics: an empty error list and no underlining (#2226).

Rename the native checker to `flycheck-lsp`, matching `flycheck-lsp-mode` and `flycheck-lsp-servers`, so it can't collide with lsp-mode's `lsp`. Docs and specs updated, with a new spec asserting Flycheck defines no `lsp` checker.

Fixes #2226.