### PR TITLE
Rebuild inline annotations after in-place edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+- [#2229](https://github.com/flycheck/flycheck/pull/2229): Keep `flycheck-annotate-mode`'s inline messages on the right line while editing - an edit that left point on its line (such as `open-line`) could strand an annotation on the wrong line until the next check.
+
 ## 38.2 (2026-07-29)
 
 ### Bugs fixed

--- a/flycheck.el
+++ b/flycheck.el
@@ -7729,6 +7729,14 @@ start of the buffer on every command.")
 (defvar-local flycheck-annotate--last-window-start nil
   "Window start the inline overlays were last built for.")
 
+(defvar-local flycheck-annotate--last-tick nil
+  "Buffer-modification tick the inline overlays were last built for.
+
+Tracked so `flycheck-annotate--post-command' also rebuilds after an edit
+that left point on its line -- e.g. `open-line', which inserts a newline
+but keeps point put -- and would otherwise strand an annotation on the
+wrong line until the next check.")
+
 (defun flycheck-annotate--level-face (level)
   "Return the inline face for error LEVEL."
   (pcase level
@@ -7964,7 +7972,8 @@ Records the line and window start the overlays were built for, so
 `flycheck-annotate--post-command' can skip rebuilds that would not change
 anything."
   (setq flycheck-annotate--last-line-start (line-beginning-position)
-        flycheck-annotate--last-window-start (window-start))
+        flycheck-annotate--last-window-start (window-start)
+        flycheck-annotate--last-tick (buffer-chars-modified-tick))
   (flycheck-annotate--clear)
   (when (and (bound-and-true-p flycheck-annotate-mode) flycheck-mode)
     (pcase-let ((`(,beg . ,end) (flycheck-annotate--region))
@@ -7993,12 +8002,18 @@ anything."
               (funcall render errors anchor focused))))))))
 
 (defun flycheck-annotate--post-command ()
-  "Rebuild the inline overlays if point or the window has moved.
+  "Rebuild the inline overlays if point, the window or the buffer changed.
 
-Only rebuilds when point changed line or the window scrolled, since the
-annotations are otherwise unaffected by point motion within a line."
+Skips the rebuild only when nothing that affects the annotations happened:
+point stayed on its line, the window did not scroll, and the buffer was not
+edited.  The buffer-change check catches edits that leave point on its line
+\(such as `open-line'), which the line and window checks alone would miss,
+and keeps a `below'-style connector aligned as the code under it changes.
+The check runs once per command, so a bulk edit rebuilds once rather than
+once per change."
   (unless (and (eql (line-beginning-position) flycheck-annotate--last-line-start)
-               (eql (window-start) flycheck-annotate--last-window-start))
+               (eql (window-start) flycheck-annotate--last-window-start)
+               (eql (buffer-chars-modified-tick) flycheck-annotate--last-tick))
     (flycheck-annotate--refresh)))
 
 (defun flycheck-annotate--suppresses-echo-p ()

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -434,7 +434,37 @@ so it doubles as a predicate for the message overlays."
             (insert "X")
             (expect (buffer-substring-no-properties
                      (point-min) (line-end-position))
-                    :to-equal "codeX"))))))
+                    :to-equal "codeX")))))
+
+    (it "rebuilds after an edit that leaves point on its line"
+      ;; An edit such as `open-line' changes the buffer without moving point
+      ;; off its line or scrolling the window, so the line/window check alone
+      ;; would not rebuild.  The buffer-change (tick) check must catch it.
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (insert "abcdef\n")
+          (setq-local flycheck-mode t)
+          (let ((e (flycheck-error-new-at 1 1 'error "boom"
+                                          :buffer (current-buffer)
+                                          :checker 'emacs-lisp)))
+            (setq flycheck-current-errors (list e))
+            (mapc #'flycheck-add-overlay flycheck-current-errors))
+          (goto-char (point-min))
+          (let ((flycheck-annotate-current-line-style 'eol)
+                (flycheck-annotate-other-lines-style 'eol))
+            (flycheck-annotate-mode 1)
+            (let ((line0 flycheck-annotate--last-line-start)
+                  (win0 flycheck-annotate--last-window-start))
+              ;; edit later on the same line, leaving point put
+              (save-excursion (goto-char (+ (point-min) 3)) (insert "X"))
+              ;; the line/window check would skip: neither has changed
+              (expect (line-beginning-position) :to-equal line0)
+              (expect (window-start) :to-equal win0)
+              ;; but the buffer changed, so post-command must rebuild
+              (flycheck-annotate--post-command)
+              (expect flycheck-annotate--last-tick
+                      :to-equal (buffer-chars-modified-tick))))))))
 
   (describe "the background tint"
     (it "adds no tint when disabled"


### PR DESCRIPTION
Follow-up hardening for `flycheck-annotate-mode`.

The overlays were rebuilt only when point changed line or the window scrolled. An edit that leaves point on its line - `open-line`, `split-line`, deleting a trailing newline - would strand an annotation on the wrong line until the next check, and same-line typing left `below`-style connectors misaligned.

Track `buffer-chars-modified-tick` in the post-command hook so any edit triggers a rebuild. This runs once per command, so a bulk edit rebuilds once rather than once per change. New spec covers it.