### PR TITLE
Roll out error explainers to more checkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### New Features
+
+- [#2230](https://github.com/flycheck/flycheck/pull/2230): Explain more checkers' diagnostics with `C-c ! e` (`flycheck-explain-error-at-point`): `dockerfile-hadolint`, `go-staticcheck`, `python-mypy`, `ruby-rubocop`/`ruby-standard`, and the `less`/`scss`/`sass` stylelint checkers. Checker authors can now define a URL-based explainer in one line with the new `flycheck-error-explainer-from-url` helper.
+
 ### Bugs fixed
 
 - [#2229](https://github.com/flycheck/flycheck/pull/2229): Keep `flycheck-annotate-mode`'s inline messages on the right line while editing - an edit that left point on its line (such as `open-line`) could strand an annotation on the wrong line until the next check.

--- a/doc/developer/developing.rst
+++ b/doc/developer/developing.rst
@@ -271,10 +271,8 @@ Here are two examples of more complex checkers:
                 :message (if supports-shell "yes" "no")
                 :face (if supports-shell 'success '(bold warning))))))
      :error-explainer
-     (lambda (err)
-       (let ((error-code (flycheck-error-id err))
-             (url "https://github.com/koalaman/shellcheck/wiki/%s"))
-         (and error-code `(url . ,(format url error-code))))))
+     (flycheck-error-explainer-from-url
+      "https://github.com/koalaman/shellcheck/wiki/%s"))
 
 The ``:command`` forms are longer, as the checkers pass more flags to ``protoc``
 and ``shellcheck``.  Note the use of ``eval``, ``option``, and ``option-flag``
@@ -315,7 +313,10 @@ feedback to users; its output gets included when users invoke
 
 Finally, the ``shellcheck`` checker includes an error explainer, which opens the
 relevant page on the ShellCheck wiki when users run
-`flycheck-explain-error-at-point`.
+`flycheck-explain-error-at-point`.  It is built with
+`flycheck-error-explainer-from-url`, a helper that turns a URL format string
+keyed by the error ID into an explainer; many tools document their diagnostics
+online this way, so their checkers can define an explainer in a single line.
 
 There are other useful properties, depending on your situation.  Most important
 is ``:enabled``, which is like ``:predicate`` but is run only once; it is used

--- a/flycheck.el
+++ b/flycheck.el
@@ -2354,6 +2354,9 @@ are mandatory.
        be found online at URL.
      - nil if there is no explanation for this error.
 
+     For the common case of a URL keyed by the error ID, build
+     FUNCTION with `flycheck-error-explainer-from-url'.
+
      If URL is provided by the checker, and cannot be composed
      from other elements in the `flycheck-error' object, consider
      passing the URL via text properties:
@@ -8369,6 +8372,26 @@ error at point has a related location."
           (t (error "Unsupported error explanation: %S" explanation)))
          (display-message-or-buffer standard-output nil 'not-this-window)))))
 
+(defun flycheck-error-explainer-from-url (url-format &optional transform)
+  "Return an `:error-explainer' that browses a URL for the error's ID.
+
+URL-FORMAT is a format string with a single %s, replaced by the error's
+`flycheck-error-id' -- first passed through TRANSFORM, a function of the ID
+returning the string to interpolate, when given.  The returned explainer
+yields a (url . STRING) cons, or nil for an error with no ID or whose
+TRANSFORM returns nil (so TRANSFORM can skip errors that have no online
+documentation).
+
+Many tools document their diagnostics online, keyed by the error ID, so
+their checkers can define an explainer in one line, e.g.
+
+    :error-explainer
+    (flycheck-error-explainer-from-url \"https://example.com/rules/%s\")"
+  (lambda (err)
+    (when-let* ((id (flycheck-error-id err))
+                (arg (if transform (funcall transform id) id)))
+      (cons 'url (format url-format arg)))))
+
 
 ;;; Syntax checkers using external commands
 (defun flycheck-command-argument-p (arg)
@@ -10383,7 +10406,13 @@ SYMBOL with `flycheck-def-executable-var'."
          ,@(when handle-suspicious
              `(:handle-suspicious #',handle-suspicious))
          ,@(when explainer
-             `(:error-explainer #',explainer))
+             ;; A symbol or a `lambda' form names the explainer directly; any
+             ;; other form is evaluated, so `:error-explainer' can be produced
+             ;; by a helper such as `flycheck-error-explainer-from-url'.
+             `(:error-explainer ,(if (or (symbolp explainer)
+                                         (eq (car-safe explainer) 'lambda))
+                                     `#',explainer
+                                   explainer)))
          :modes ',(plist-get properties :modes)
          ,@(when predicate
              `(:predicate #',predicate))
@@ -12306,10 +12335,7 @@ See URL `https://stylelint.io/'."
   :predicate flycheck-buffer-nonempty-p
   :modes (css-mode css-ts-mode)
   :error-explainer
-  (lambda (err)
-    (let ((error-code (flycheck-error-id err))
-          (url "https://stylelint.io/user-guide/rules/%s"))
-      (and error-code `(url . ,(format url error-code))))))
+  (flycheck-error-explainer-from-url "https://stylelint.io/user-guide/rules/%s"))
 
 (flycheck-def-option-var flycheck-cuda-language-standard nil cuda-nvcc
   "The CUDA language standard to use in nvcc."
@@ -12492,6 +12518,17 @@ Requires DMD 2.066 or newer.  See URL `https://dlang.org/'."
          (one-or-more " ") (message) line-end))
   :modes d-mode)
 
+(defun flycheck-dockerfile-hadolint-error-explainer (err)
+  "Browse the docs for a hadolint (DL...) or ShellCheck (SC...) error ERR.
+hadolint's own DL rules link to its wiki; the SC rules it forwards from
+ShellCheck link to ShellCheck's wiki."
+  (when-let* ((id (flycheck-error-id err)))
+    (cond
+     ((string-prefix-p "DL" id)
+      (cons 'url (format "https://github.com/hadolint/hadolint/wiki/%s" id)))
+     ((string-prefix-p "SC" id)
+      (cons 'url (format "https://github.com/koalaman/shellcheck/wiki/%s" id))))))
+
 (flycheck-define-checker dockerfile-hadolint
   "A Dockerfile syntax checker using hadolint.
 
@@ -12507,6 +12544,7 @@ See URL `https://github.com/hadolint/hadolint/'."
     (flycheck-sanitize-errors
      (flycheck-remove-error-file-names
       "/dev/stdin" (flycheck-remove-error-file-names "-" errors))))
+  :error-explainer flycheck-dockerfile-hadolint-error-explainer
   :modes (dockerfile-mode dockerfile-ts-mode))
 
 (defun flycheck-credo--working-directory (&rest _ignored)
@@ -13375,6 +13413,8 @@ limited features) if `flycheck-go-version' is set. See URL
             (option "-go" flycheck-go-version))
 
   :error-parser flycheck-parse-go-staticcheck
+  :error-explainer
+  (flycheck-error-explainer-from-url "https://staticcheck.dev/docs/checks#%s")
   :modes (go-mode go-ts-mode))
 
 (flycheck-define-checker groovy
@@ -13929,13 +13969,10 @@ See URL `https://eslint.org/'."
         :message (if have-config "found" "missing or incorrect")
         :face (if have-config 'success '(bold error))))))
   :error-explainer
-  (lambda (err)
-    (let ((error-code (flycheck-error-id err))
-          (url "https://eslint.org/docs/rules/%s"))
-      (and error-code
-           ;; skip non-builtin rules
-           (not (seq-contains-p error-code ?/))
-           `(url . ,(format url error-code))))))
+  (flycheck-error-explainer-from-url
+   "https://eslint.org/docs/rules/%s"
+   ;; skip non-builtin (plugin) rules, which eslint.org does not document
+   (lambda (id) (unless (seq-contains-p id ?/) id))))
 
 (flycheck-define-checker javascript-oxlint
   "A JavaScript and TypeScript linter using oxlint.
@@ -14073,6 +14110,8 @@ See URL `https://stylelint.io/'."
   :verify (lambda (_) (flycheck--stylelint-verify 'less-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
+  :error-explainer
+  (flycheck-error-explainer-from-url "https://stylelint.io/user-guide/rules/%s")
   :modes (less-css-mode))
 
 (flycheck-define-checker llvm-llc
@@ -14266,10 +14305,8 @@ See URL `https://metacpan.org/pod/Perl::Critic'."
   :next-checkers (perl-perlimports)
 
   :error-explainer
-  (lambda (err)
-    (let ((error-code (flycheck-error-id err))
-          (url "https://metacpan.org/pod/Perl::Critic::Policy::%s"))
-      (and error-code `(url . ,(format url error-code))))))
+  (flycheck-error-explainer-from-url
+   "https://metacpan.org/pod/Perl::Critic::Policy::%s"))
 
 (defun flycheck-perl-perlimports-parse-errors (output checker buffer)
   "Parse perlimports json output errors from OUTPUT.
@@ -15144,6 +15181,9 @@ See URL `https://mypy-lang.org/'."
           (setf (flycheck-error-id err) (match-string 2 msg)))))
     errors)
   :working-directory flycheck-python-find-project-root
+  :error-explainer
+  (flycheck-error-explainer-from-url
+   "https://mypy.readthedocs.io/en/stable/error_code_list.html#code-%s")
   :modes (python-mode python-ts-mode)
   ;; Ensure the file is saved, to work around
   ;; https://github.com/python/mypy/issues/4746.
@@ -15343,11 +15383,12 @@ See URL `https://github.com/rpm-software-management/rpmlint'."
   (flycheck-sanitize-errors
    (flycheck-remove-error-file-names "(string)" errors)))
 
-(defun flycheck-markdownlint-error-explainer (err)
-  "Error explainer for markdownlint checkers."
-  (let ((error-code (substring (flycheck-error-id err) 0 5))
-        (url "https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#%s"))
-    (and error-code `(url . ,(format url error-code)))))
+(defalias 'flycheck-markdownlint-error-explainer
+  (flycheck-error-explainer-from-url
+   "https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#%s"
+   ;; the ID is "MDNNN/rule-name"; the doc anchor is just the "MDNNN" code
+   (lambda (id) (substring id 0 5)))
+  "Browse the markdownlint rule documentation for the error at point.")
 
 (flycheck-define-checker markdown-markdownlint-cli
   "Markdown checker using markdownlint-cli.
@@ -15631,6 +15672,20 @@ report style issues as well."
   :type 'boolean
   :package-version '(flycheck . "0.16"))
 
+(defun flycheck-ruby-rubocop-error-explainer (err)
+  "Browse the RuboCop documentation for the cop of error ERR.
+The error ID is a DEPARTMENT/CopName cop name.  Only RuboCop's own built-in
+departments are documented at docs.rubocop.org, so cops from extensions
+\(RuboCop RSpec, Rails, ...) yield no explanation rather than a broken link."
+  (when-let* ((id (flycheck-error-id err))
+              ((string-match "\\`\\([A-Z][a-zA-Z]*\\)/" id))
+              (dept (downcase (match-string 1 id)))
+              ((member dept '("bundler" "gemspec" "layout" "lint" "metrics"
+                              "migration" "naming" "security" "style")))
+              (anchor (downcase (replace-regexp-in-string "/" "" id))))
+    (cons 'url (format "https://docs.rubocop.org/rubocop/cops_%s.html#%s"
+                       dept anchor))))
+
 (defconst flycheck-ruby-rubocop-error-patterns
   '((info line-start (file-name) ":" line ":" column ": C: "
           (optional (id (one-or-more (not (any ":")))) ": ") (message) line-end)
@@ -15665,6 +15720,7 @@ See URL `https://rubocop.org/'."
   :working-directory #'flycheck-ruby--find-project-root
   :error-patterns flycheck-ruby-rubocop-error-patterns
   :error-filter #'flycheck-ruby--filter-rubocop-errors
+  :error-explainer #'flycheck-ruby-rubocop-error-explainer
   :modes '(enh-ruby-mode ruby-mode ruby-ts-mode)
   :next-checkers '((warning . ruby-reek)
                    (warning . ruby-chef-cookstyle)))
@@ -15727,6 +15783,7 @@ See URL `https://github.com/testdouble/standard' for more information."
   :working-directory #'flycheck-ruby--find-project-root
   :error-patterns flycheck-ruby-rubocop-error-patterns
   :error-filter #'flycheck-ruby--filter-rubocop-errors
+  :error-explainer #'flycheck-ruby-rubocop-error-explainer
   :modes '(enh-ruby-mode ruby-mode ruby-ts-mode)
   :next-checkers '((warning . ruby-reek)
                    (warning . ruby-chef-cookstyle)))
@@ -16266,6 +16323,8 @@ See URL `https://stylelint.io/'."
   :verify (lambda (_) (flycheck--stylelint-verify 'scss-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
+  :error-explainer
+  (flycheck-error-explainer-from-url "https://stylelint.io/user-guide/rules/%s")
   :modes (scss-mode))
 
 (flycheck-define-checker sass-stylelint
@@ -16280,6 +16339,8 @@ See URL `https://stylelint.io/'."
   :verify (lambda (_) (flycheck--stylelint-verify 'sass-stylelint))
   :error-parser flycheck-parse-stylelint
   :predicate flycheck-buffer-nonempty-p
+  :error-explainer
+  (flycheck-error-explainer-from-url "https://stylelint.io/user-guide/rules/%s")
   :modes (sass-mode))
 
 (flycheck-def-args-var flycheck-sh-bash-args (sh-bash)
@@ -16477,10 +16538,7 @@ See URL `https://github.com/koalaman/shellcheck/'."
                 :message (if supports-shell "yes" "no")
                 :face (if supports-shell 'success '(bold warning))))))
   :error-explainer
-  (lambda (err)
-    (let ((error-code (flycheck-error-id err))
-          (url "https://github.com/koalaman/shellcheck/wiki/%s"))
-      (and error-code `(url . ,(format url error-code))))))
+  (flycheck-error-explainer-from-url "https://github.com/koalaman/shellcheck/wiki/%s"))
 
 (flycheck-define-checker slim
   "A Slim syntax checker using the Slim compiler.

--- a/test/specs/test-error-explainers.el
+++ b/test/specs/test-error-explainers.el
@@ -1,0 +1,101 @@
+;;; test-error-explainers.el --- Flycheck Specs: Error explainers -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for `:error-explainer' functionality: the `flycheck-error-explainer-from-url'
+;; helper and the checker explainers built on it.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+
+(defun test-explainer/explain (checker id)
+  "Return the explanation CHECKER's `:error-explainer' gives an error with ID."
+  (when-let* ((fn (flycheck-checker-get checker 'error-explainer)))
+    (funcall fn (flycheck-error-new-at 1 1 'error "msg" :id id :checker checker))))
+
+(describe "Error explainers"
+
+  (describe "flycheck-error-explainer-from-url"
+    (it "formats the error id into the url"
+      (let ((ex (flycheck-error-explainer-from-url "https://x/%s")))
+        (expect (funcall ex (flycheck-error-new-at 1 1 'error "m" :id "foo"))
+                :to-equal '(url . "https://x/foo"))))
+
+    (it "returns nil for an error without an id"
+      (let ((ex (flycheck-error-explainer-from-url "https://x/%s")))
+        (expect (funcall ex (flycheck-error-new-at 1 1 'error "m")) :to-be nil)))
+
+    (it "applies the transform to the id"
+      (let ((ex (flycheck-error-explainer-from-url "https://x/%s" #'upcase)))
+        (expect (funcall ex (flycheck-error-new-at 1 1 'error "m" :id "foo"))
+                :to-equal '(url . "https://x/FOO"))))
+
+    (it "skips the error when the transform returns nil"
+      (let ((ex (flycheck-error-explainer-from-url "https://x/%s"
+                                                   (lambda (_id) nil))))
+        (expect (funcall ex (flycheck-error-new-at 1 1 'error "m" :id "foo"))
+                :to-be nil))))
+
+  (describe "the plain url explainers"
+    (it "links stylelint rules for every stylelint variant"
+      (dolist (c '(css-stylelint less-stylelint scss-stylelint sass-stylelint))
+        (expect (test-explainer/explain c "indentation")
+                :to-equal
+                '(url . "https://stylelint.io/user-guide/rules/indentation"))))
+
+    (it "links shellcheck, staticcheck and mypy diagnostics"
+      (expect (test-explainer/explain 'sh-shellcheck "SC2086")
+              :to-equal '(url . "https://github.com/koalaman/shellcheck/wiki/SC2086"))
+      (expect (test-explainer/explain 'go-staticcheck "SA1000")
+              :to-equal '(url . "https://staticcheck.dev/docs/checks#SA1000"))
+      (expect (test-explainer/explain 'python-mypy "name-defined")
+              :to-equal
+              '(url . "https://mypy.readthedocs.io/en/stable/error_code_list.html#code-name-defined")))
+
+    (it "links core eslint rules but skips plugin rules"
+      (expect (test-explainer/explain 'javascript-eslint "no-eval")
+              :to-equal '(url . "https://eslint.org/docs/rules/no-eval"))
+      (expect (test-explainer/explain 'javascript-eslint "react/jsx-key")
+              :to-be nil)))
+
+  (describe "flycheck-dockerfile-hadolint-error-explainer"
+    (it "routes DL rules to the hadolint wiki"
+      (expect (test-explainer/explain 'dockerfile-hadolint "DL3006")
+              :to-equal '(url . "https://github.com/hadolint/hadolint/wiki/DL3006")))
+
+    (it "routes forwarded SC rules to the shellcheck wiki"
+      (expect (test-explainer/explain 'dockerfile-hadolint "SC2086")
+              :to-equal '(url . "https://github.com/koalaman/shellcheck/wiki/SC2086")))
+
+    (it "returns nil for an unrecognised id"
+      (expect (test-explainer/explain 'dockerfile-hadolint "XY1") :to-be nil)))
+
+  (describe "flycheck-ruby-rubocop-error-explainer"
+    (it "links a core cop to its department page and anchor"
+      (expect (test-explainer/explain 'ruby-rubocop "Style/StringLiterals")
+              :to-equal
+              '(url . "https://docs.rubocop.org/rubocop/cops_style.html#stylestringliterals")))
+
+    (it "skips cops from extensions, so it never yields a broken link"
+      (expect (test-explainer/explain 'ruby-rubocop "RSpec/ExampleLength")
+              :to-be nil))))
+
+;;; test-error-explainers.el ends here


### PR DESCRIPTION
Adds `flycheck-error-explainer-from-url`, a helper that turns a URL format string (keyed by the error ID, with an optional transform that can also skip errors with no docs) into an `:error-explainer`, plus a small backward-compatible tweak to `flycheck-define-checker` so the helper can be used inline.

Rolls explainers out to more checkers via `C-c ! e`:
- the `less`/`scss`/`sass` stylelint variants (`css-stylelint` already had one)
- `dockerfile-hadolint` (DL rules -> hadolint wiki, forwarded SC rules -> ShellCheck wiki)
- `go-staticcheck`, `python-mypy`
- `ruby-rubocop`/`ruby-standard` (built-in departments only, so extension cops never produce a broken link)

Existing url-lambda explainers (stylelint, eslint, perlcritic, shellcheck, markdownlint) are refactored onto the helper. New spec file covers the helper and the custom explainers.