### PR TITLE
Make the Rust checkers more configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Packages installed for development
 /.cask/
 /.eask/
+/.eldev/
 
 # linters
 /.elsa/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## master (unreleased)
 
+### New Features
+
+- [#2231](https://github.com/flycheck/flycheck/pull/2231): Make the `rust-clippy` checker configurable with `flycheck-rust-clippy-args` (extra `cargo clippy` arguments) and the `flycheck-rust-clippy-tests`, `flycheck-rust-clippy-all-targets` and `flycheck-rust-clippy-all-features` toggles; `flycheck-rust-features` now applies to `rust-clippy` as well (originally proposed in [#2087](https://github.com/flycheck/flycheck/pull/2087) and [#2125](https://github.com/flycheck/flycheck/pull/2125)).
+- [#2231](https://github.com/flycheck/flycheck/pull/2231): Add `flycheck-rust-edition` to set the edition (`--edition`) for the `rust` checker when checking single-file crates outside a Cargo project.
+
 ## 38.3 (2026-07-29)
 
 ### New Features

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1269,8 +1269,6 @@ to view the docstring of the syntax checker.  Likewise, you may use
       compiler is invoked through ``cargo check`` to take Cargo dependencies
       into account.
 
-      `rust-clippy` has no configurable options.
-
       .. note::
 
          `rust-cargo` requires Rust 1.17 or newer.
@@ -1331,7 +1329,8 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          The value of this variable is a list of strings denoting features
          that will be activated to build the target to check. Features will
-         be passed to ``cargo check --features=FEATURES``.
+         be passed to ``cargo check --features=FEATURES`` and, for
+         `rust-clippy`, to ``cargo clippy --features=FEATURES``.
 
          Empty by default.
 
@@ -1341,6 +1340,39 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          A list of additional library directories. Relative paths are relative
          to the buffer being checked.
+
+      .. defcustom:: flycheck-rust-edition
+
+         The Rust edition for the `rust` checker, passed to ``rustc`` as
+         ``--edition``, as a string such as ``"2021"`` or ``"2024"``.
+
+         When nil (the default), ``rustc`` falls back to edition 2015, which
+         rejects code written for a newer edition.  Set this to check a
+         single-file crate that is not part of a Cargo project.
+
+         `rust-cargo` takes the edition from ``Cargo.toml`` and ignores this
+         option.
+
+      .. defcustom:: flycheck-rust-clippy-args
+
+         A list of additional arguments passed to the ``cargo clippy``
+         subcommand.  To pass options on to Clippy's own lints, separate them
+         with ``--``, e.g. ``("--" "-W" "clippy::pedantic")``.
+
+      .. defcustom:: flycheck-rust-clippy-tests
+
+         Whether to lint test code with Clippy, by passing ``--tests`` to
+         ``cargo clippy``.  Off by default.
+
+      .. defcustom:: flycheck-rust-clippy-all-targets
+
+         Whether to lint all targets with Clippy, by passing ``--all-targets``
+         to ``cargo clippy``.  Off by default.
+
+      .. defcustom:: flycheck-rust-clippy-all-features
+
+         Whether to lint with all Cargo features enabled in Clippy, by passing
+         ``--all-features`` to ``cargo clippy``.  Off by default.
 
 .. supported-language:: SaltStack
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -15906,12 +15906,13 @@ ignored."
   :package-version '(flycheck . "28"))
 (make-variable-buffer-local 'flycheck-rust-binary-name)
 
-(flycheck-def-option-var flycheck-rust-features nil rust-cargo
+(flycheck-def-option-var flycheck-rust-features nil (rust-cargo rust-clippy)
   "List of features to activate during build or check.
 
 The value of this variable is a list of strings denoting features
 that will be activated to build the target to check. Features will
-be passed to `cargo check --features=FEATURES'."
+be passed to `cargo check --features=FEATURES' and, for the
+`rust-clippy' checker, to `cargo clippy --features=FEATURES'."
   :type '(repeat :tag "Features to activate"
                  (string :tag "Feature"))
   :safe #'flycheck-string-list-p
@@ -15927,6 +15928,51 @@ Relative paths are relative to the file being checked."
   :type '(repeat (directory :tag "Library directory"))
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.18"))
+
+(flycheck-def-option-var flycheck-rust-edition nil rust
+  "The Rust edition for the `rust' checker.
+
+Passed to `rustc' as `--edition'.  When nil, `rustc' uses its own
+default, edition 2015, which rejects code written for a newer edition.
+Set this to a string such as \"2021\" or \"2024\" to check single-file
+code that is not part of a Cargo project.  The `rust-cargo' checker takes
+the edition from `Cargo.toml' and ignores this variable."
+  :type '(choice (const :tag "rustc default (2015)" nil)
+                 (const "2015") (const "2018")
+                 (const "2021") (const "2024")
+                 (string :tag "Other edition"))
+  :safe #'string-or-null-p
+  :package-version '(flycheck . "38.4"))
+(make-variable-buffer-local 'flycheck-rust-edition)
+
+(flycheck-def-args-var flycheck-rust-clippy-args (rust-clippy)
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-rust-clippy-tests nil rust-clippy
+  "Whether to lint test code with Clippy.
+
+When non-nil, `cargo clippy' is passed `--tests', so code marked with
+`#[cfg(test)]' or `#[test]' is linted as well."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-rust-clippy-all-targets nil rust-clippy
+  "Whether to lint all targets with Clippy.
+
+When non-nil, `cargo clippy' is passed `--all-targets', linting tests,
+benches and examples on top of the default targets."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-rust-clippy-all-features nil rust-clippy
+  "Whether to lint with all Cargo features enabled in Clippy.
+
+When non-nil, `cargo clippy' is passed `--all-features'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38.4"))
 
 (defun flycheck--fontify-as-markdown ()
   "Place current buffer in `markdown-view-mode' and fontify it."
@@ -16088,6 +16134,7 @@ This syntax checker needs Rust 1.18 or newer.  See URL
 `https://www.rust-lang.org'."
   :command ("rustc"
             (option "--crate-type" flycheck-rust-crate-type)
+            (option "--edition" flycheck-rust-edition)
             "--emit=metadata"
             "--out-dir" (eval (file-local-name (flycheck-temp-dir-system))) ; avoid creating binaries
             "--error-format=json"
@@ -16106,7 +16153,14 @@ This syntax checker needs Rust 1.18 or newer.  See URL
   "A Rust syntax checker using clippy.
 
 See URL `https://github.com/rust-lang-nursery/rust-clippy'."
-  :command ("cargo" "clippy" "--message-format=json")
+  :command ("cargo" "clippy"
+            (option "--features=" flycheck-rust-features concat
+                    flycheck-option-comma-separated-list)
+            (option-flag "--tests" flycheck-rust-clippy-tests)
+            (option-flag "--all-targets" flycheck-rust-clippy-all-targets)
+            (option-flag "--all-features" flycheck-rust-clippy-all-features)
+            "--message-format=json"
+            (eval flycheck-rust-clippy-args))
   :error-parser flycheck-parse-cargo-rustc
   :error-filter flycheck-rust-error-filter
   :error-explainer flycheck-rust-error-explainer

--- a/test/specs/languages/test-rust.el
+++ b/test/specs/languages/test-rust.el
@@ -315,6 +315,52 @@
            :end-line 2 :end-column 16)
        '(2 5 info "remove `return`: `true`"
            :checker rust-clippy :id "clippy::needless_return" :group 1
-           :end-line 2 :end-column 16)))))
+           :end-line 2 :end-column 16))))
+
+  (describe "the `rust' checker command"
+    ;; Pin the crate root so argument substitution never touches the
+    ;; buffer's file name.
+    (it "omits --edition when `flycheck-rust-edition' is nil"
+      (let ((flycheck-rust-edition nil)
+            (flycheck-rust-crate-root "root.rs"))
+        (expect (flycheck-checker-substituted-arguments 'rust)
+                :not :to-contain "--edition")))
+
+    (it "passes --edition when `flycheck-rust-edition' is set"
+      (let ((flycheck-rust-edition "2021")
+            (flycheck-rust-crate-root "root.rs"))
+        (let ((args (flycheck-checker-substituted-arguments 'rust)))
+          (expect args :to-contain "--edition")
+          (expect args :to-contain "2021")))))
+
+  (describe "the `rust-clippy' checker command"
+    (it "passes only --message-format by default"
+      (let ((flycheck-rust-features nil)
+            (flycheck-rust-clippy-tests nil)
+            (flycheck-rust-clippy-all-targets nil)
+            (flycheck-rust-clippy-all-features nil)
+            (flycheck-rust-clippy-args nil))
+        (expect (flycheck-checker-substituted-arguments 'rust-clippy)
+                :to-equal '("clippy" "--message-format=json"))))
+
+    (it "passes --features from `flycheck-rust-features'"
+      (let ((flycheck-rust-features '("foo" "bar")))
+        (expect (flycheck-checker-substituted-arguments 'rust-clippy)
+                :to-contain "--features=foo,bar")))
+
+    (it "passes the clippy option flags when enabled"
+      (let ((flycheck-rust-clippy-tests t)
+            (flycheck-rust-clippy-all-targets t)
+            (flycheck-rust-clippy-all-features t))
+        (let ((args (flycheck-checker-substituted-arguments 'rust-clippy)))
+          (expect args :to-contain "--tests")
+          (expect args :to-contain "--all-targets")
+          (expect args :to-contain "--all-features"))))
+
+    (it "appends `flycheck-rust-clippy-args' after --message-format"
+      (let ((flycheck-rust-clippy-args '("--" "-W" "clippy::pedantic")))
+        (expect (flycheck-checker-substituted-arguments 'rust-clippy)
+                :to-equal '("clippy" "--message-format=json"
+                            "--" "-W" "clippy::pedantic"))))))
 
 ;;; test-rust.el ends here


### PR DESCRIPTION
Two long-standing gaps in the Rust support, closed together.

`rust-clippy` had no options at all, so there was no way to lint tests or examples, enable features, or pass Clippy its own lint flags. It now takes `flycheck-rust-clippy-args` plus `flycheck-rust-clippy-tests`, `flycheck-rust-clippy-all-targets` and `flycheck-rust-clippy-all-features`, and `flycheck-rust-features` finally applies to it too. This supersedes #2087 (thanks @craigbro) and #2125 (thanks @berquist), whose ideas it folds in.

The single-file `rust` checker gains `flycheck-rust-edition`, so `rustc` no longer defaults to edition 2015 and rejects code written for a newer one when you're outside a Cargo project.