### PR TITLE
Fix below-style annotations trapping vertical motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - [#2231](https://github.com/flycheck/flycheck/pull/2231): Make the `rust-clippy` checker configurable with `flycheck-rust-clippy-args` (extra `cargo clippy` arguments) and the `flycheck-rust-clippy-tests`, `flycheck-rust-clippy-all-targets` and `flycheck-rust-clippy-all-features` toggles; `flycheck-rust-features` now applies to `rust-clippy` as well (originally proposed in [#2087](https://github.com/flycheck/flycheck/pull/2087) and [#2125](https://github.com/flycheck/flycheck/pull/2125)).
 - [#2231](https://github.com/flycheck/flycheck/pull/2231): Add `flycheck-rust-edition` to set the edition (`--edition`) for the `rust` checker when checking single-file crates outside a Cargo project.
 
+### Bugs fixed
+
+- [#2233](https://github.com/flycheck/flycheck/pull/2233): Fix `flycheck-annotate-mode`'s `below` style trapping vertical motion on the annotated line - `next-line` needed an extra press to get past it and `evil-next-visual-line` could not move past it at all. The multi-line message now hangs off the following line instead of the annotated line's newline.
+
 ## 38.3 (2026-07-29)
 
 ### New Features

--- a/flycheck.el
+++ b/flycheck.el
@@ -7766,13 +7766,15 @@ carries a machine-applicable fix."
 (defun flycheck-annotate--make-overlay (anchor string)
   "Create a tracked inline overlay showing STRING at end-of-line ANCHOR.
 
-The overlay spans ANCHOR's trailing newline and shows STRING as a
-`before-string', so the annotation renders right after the code.  A
-`cursor' text property on STRING keeps the cursor pinned to ANCHOR -- the
-end of the code -- rather than to the end of the annotation, so `C-e' and
-typing behave as if the annotation were not there.  This is the same
-technique Flymake uses for its end-of-line diagnostics.  Return the
-overlay."
+STRING must be a single display line -- the `eol' and `sideline' styles
+use this; the multi-line `below' style has its own placement, see
+`flycheck-annotate--make-below-overlay'.  The overlay spans ANCHOR's
+trailing newline and shows STRING as a `before-string', so the annotation
+renders right after the code.  A `cursor' text property on STRING keeps the
+cursor pinned to ANCHOR -- the end of the code -- rather than to the end of
+the annotation, so `C-e' and typing behave as if the annotation were not
+there.  This is the same technique Flymake uses for its end-of-line
+diagnostics.  Return the overlay."
   (let* ((end (min (point-max) (1+ anchor)))
          (ov (make-overlay anchor end nil t nil)))
     (overlay-put ov 'priority 100)
@@ -7783,9 +7785,8 @@ overlay."
     ;; The cursor is drawn on the first character of the before-string.  Anchor
     ;; it to a dedicated plain space so `C-e' and typing park at the end of the
     ;; code rather than inside the annotation.  A plain space is required: the
-    ;; `cursor' property is ignored on a newline (which the `below' style's
-    ;; string starts with) and lands at the far end of the `sideline' style's
-    ;; `:align-to' stretch, both leaving the cursor stranded.
+    ;; `cursor' property lands at the far end of the `sideline' style's
+    ;; `:align-to' stretch, leaving the cursor stranded.
     (overlay-put ov 'before-string
                  (if (> (length string) 0)
                      (concat (propertize " " 'cursor t) string)
@@ -7871,6 +7872,29 @@ clamped to the line so a checker column past the end still lands on it."
       (forward-char offset)
       (current-column))))
 
+(defun flycheck-annotate--make-below-overlay (anchor block)
+  "Create a tracked overlay rendering BLOCK on its own lines below ANCHOR.
+
+BLOCK is the annotation text without surrounding newlines.  It is hung off
+the beginning of the following line as a `before-string' ending in a
+newline, so its extra screen rows belong to that line's buffer position
+rather than to ANCHOR's line.  That keeps visual-line motion working:
+`next-line' (with `line-move-visual') and `evil-next-visual-line' move
+point onto the next line of code instead of stalling on -- or, under Evil,
+getting stuck before -- the annotation.  On the last line of the buffer,
+where there is no following line, the block is hung off ANCHOR with a
+leading newline and a `cursor'-anchored space instead.  Return the overlay."
+  (if (< anchor (point-max))
+      (let ((ov (make-overlay (1+ anchor) (1+ anchor) nil t nil)))
+        (overlay-put ov 'priority 100)
+        (overlay-put ov 'before-string (concat block "\n"))
+        (flycheck-annotate--track ov))
+    (let ((ov (make-overlay anchor anchor nil t nil)))
+      (overlay-put ov 'priority 100)
+      (overlay-put ov 'before-string
+                   (concat (propertize " " 'cursor t) "\n" block))
+      (flycheck-annotate--track ov))))
+
 (defun flycheck-annotate-below-style (errors anchor _focused)
   "Render ERRORS on their own lines below the line ending at ANCHOR.
 
@@ -7904,9 +7928,9 @@ gutter.  FOCUSED is ignored."
                               (propertize (flycheck-related-location-format loc)
                                           'face 'shadow)))
                     (flycheck-error-relations err) "")))
-        (push (concat "\n" pad conn msg rels) lines)))
-    (flycheck-annotate--make-overlay anchor
-                                   (apply #'concat (nreverse lines)))))
+        (push (concat pad conn msg rels) lines)))
+    (flycheck-annotate--make-below-overlay
+     anchor (string-join (nreverse lines) "\n"))))
 
 (defun flycheck-annotate--clear ()
   "Delete all inline overlays in the current buffer."

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -48,10 +48,15 @@ so it doubles as a predicate for the message overlays."
     (if (get-text-property 0 'cursor s) (substring s 1) s)))
 
 (defun test-annotate/anchors ()
-  "Return an alist mapping each message overlay's line to its text."
+  "Return an alist mapping each message overlay's code line to its text.
+A `below'-style block is hung off the start of the line after the code it
+annotates (so it doesn't disturb visual-line motion); such a block ends in
+a newline, so key it back under the code line."
   (mapcar (lambda (ov)
-            (cons (line-number-at-pos (overlay-start ov))
-                  (substring-no-properties (test-annotate/text ov))))
+            (let* ((text (test-annotate/text ov))
+                   (below (string-suffix-p "\n" text)))
+              (cons (- (line-number-at-pos (overlay-start ov)) (if below 1 0))
+                    (substring-no-properties text))))
           (seq-filter #'test-annotate/text flycheck-annotate--overlays)))
 
 (defun test-annotate/tints ()
@@ -129,10 +134,13 @@ so it doubles as a predicate for the message overlays."
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
                (s (substring-no-properties (test-annotate/text ov))))
-          (expect (string-prefix-p "\n" s) :to-be t)
+          ;; the block hangs off the next line, so it ends (not begins) with a
+          ;; newline, keeping visual-line motion off the annotated line
+          (expect (string-suffix-p "\n" s) :to-be t)
+          (expect (string-prefix-p "\n" s) :to-be nil)
           (expect s :to-match "one")
           (expect s :to-match "two")
-          ;; leading newline plus one line per error
+          ;; one line per error, then the trailing newline
           (expect (length (split-string s "\n")) :to-equal 3))))
 
     (it "aligns the connector to the error's display column past a tab"
@@ -146,8 +154,8 @@ so it doubles as a predicate for the message overlays."
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
                (s (test-annotate/text ov)))
-          ;; the pad after the newline aligns to display column 8, not 1
-          (expect (get-text-property 1 'display s)
+          ;; the leading pad aligns to display column 8, not 1
+          (expect (get-text-property 0 'display s)
                   :to-equal '(space :align-to 8)))))
 
     (it "adds no pad for an error in the first column"
@@ -159,8 +167,8 @@ so it doubles as a predicate for the message overlays."
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
                (s (test-annotate/text ov)))
-          ;; char 1 is the connector itself, no stretch space
-          (expect (get-text-property 1 'display s) :to-be nil))))
+          ;; char 0 is the connector itself, no stretch space
+          (expect (get-text-property 0 'display s) :to-be nil))))
 
     (it "trails an error's related locations on their own lines"
       (flycheck-buttercup-with-temp-buffer
@@ -176,8 +184,41 @@ so it doubles as a predicate for the message overlays."
                (s (substring-no-properties (test-annotate/text ov))))
           (expect s :to-match "redefined")
           (expect s :to-match "↳ first here (5:2)")
-          ;; leading newline, the message line, then the related-location line
-          (expect (length (split-string s "\n")) :to-equal 3)))))
+          ;; the message line, the related-location line, then the trailing newline
+          (expect (length (split-string s "\n")) :to-equal 3))))
+
+    (it "hangs the block off the start of the next line"
+      ;; Regression guard: anchoring the multi-line block on the following
+      ;; line's buffer position (rather than the annotated line's newline)
+      ;; keeps `next-line' and `evil-next-visual-line' from stalling on -- or,
+      ;; under Evil, getting stuck before -- the annotation.
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abcdef\nghijkl\n")
+        (let* ((eol (save-excursion (goto-char (point-min)) (line-end-position)))
+               (errs (list (flycheck-error-new-at 1 1 'error "boom"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate-below-style errs eol t)))
+          (expect (line-number-at-pos (overlay-start ov)) :to-equal 2)
+          (expect (overlay-start ov)
+                  :to-equal (save-excursion (goto-char (point-min))
+                                            (line-beginning-position 2))))))
+
+    (it "falls back to a leading newline on the buffer's last line"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abcdef")             ; no trailing newline: line 1 is the last
+        (let* ((eol (line-end-position))
+               (errs (list (flycheck-error-new-at 1 1 'error "boom"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil)
+               (ov (flycheck-annotate-below-style errs eol t))
+               (raw (overlay-get ov 'before-string)))
+          ;; no following line to hang off: keep it on this line, with a
+          ;; leading newline and the cursor-anchoring space
+          (expect (overlay-start ov) :to-equal (point-max))
+          (expect (get-text-property 0 'cursor raw) :to-be t)
+          (expect (string-prefix-p " \n" (substring-no-properties raw))
+                  :to-be t)))))
 
   (describe "flycheck-annotate-sideline-style"
     (it "right-aligns the compact message with an align-to spacer"
@@ -298,10 +339,10 @@ so it doubles as a predicate for the message overlays."
           (forward-line 1)              ; line 2
           (flycheck-annotate-mode 1)
           (let ((anchors (test-annotate/anchors)))
-            ;; line 2 is focused -> below (annotation begins with a newline)
-            (expect (string-prefix-p "\n" (cdr (assq 2 anchors))) :to-be t)
-            ;; line 4 is unfocused -> eol
-            (expect (string-prefix-p "\n" (cdr (assq 4 anchors))) :to-be nil)))))
+            ;; line 2 is focused -> below (a multi-line block ending in a newline)
+            (expect (string-suffix-p "\n" (cdr (assq 2 anchors))) :to-be t)
+            ;; line 4 is unfocused -> eol (a single line)
+            (expect (string-suffix-p "\n" (cdr (assq 4 anchors))) :to-be nil)))))
 
     (it "swaps the styles as point moves between lines"
       (flycheck-buttercup-with-temp-buffer
@@ -312,8 +353,8 @@ so it doubles as a predicate for the message overlays."
           (forward-line 3)              ; line 4
           (flycheck-annotate-mode 1)
           (let ((anchors (test-annotate/anchors)))
-            (expect (string-prefix-p "\n" (cdr (assq 4 anchors))) :to-be t)
-            (expect (string-prefix-p "\n" (cdr (assq 2 anchors))) :to-be nil))))))
+            (expect (string-suffix-p "\n" (cdr (assq 4 anchors))) :to-be t)
+            (expect (string-suffix-p "\n" (cdr (assq 2 anchors))) :to-be nil))))))
 
   (describe "per-tier level filtering"
     (it "can restrict other lines to a stricter level set than point"
@@ -363,18 +404,20 @@ so it doubles as a predicate for the message overlays."
           (flycheck-clear)
           (expect flycheck-annotate--overlays :to-be nil))))
 
-    (it "anchors the cursor to the end of the code across every style"
-      ;; Every message overlay spans the trailing newline and renders its text
-      ;; as a `before-string' whose first character is a plain space carrying a
-      ;; `cursor' property.  That keeps C-e and typing parked at the end of the
-      ;; code instead of the end of the annotation.  A plain space is essential:
-      ;; the `cursor' property is ignored on a newline (the `below' string) and
-      ;; lands at the far end of the `sideline' `:align-to' stretch.
+    (it "anchors the cursor to the end of the code for the single-line styles"
+      ;; The single-line `eol' and `sideline' overlays span the trailing newline
+      ;; and render their text as a `before-string' whose first character is a
+      ;; plain space carrying a `cursor' property.  That keeps C-e and typing
+      ;; parked at the end of the code instead of the end of the annotation.  A
+      ;; plain space is essential: the `cursor' property lands at the far end of
+      ;; the `sideline' `:align-to' stretch.  The multi-line `below' style keeps
+      ;; the cursor on the code line by hanging its block off the next line
+      ;; instead (see its own specs), so it is excluded here.
       (flycheck-buttercup-with-temp-buffer
         (save-window-excursion
           (set-window-buffer (selected-window) (current-buffer))
           (test-annotate/setup)
-          (dolist (style '(eol below sideline))
+          (dolist (style '(eol sideline))
             (let ((flycheck-annotate-current-line-style style)
                   (flycheck-annotate-other-lines-style style))
               (flycheck-annotate-mode 1)


### PR DESCRIPTION
A user reported that `flycheck-annotate-mode`'s `below` style breaks navigation: `next-line` needs an extra press to get past the annotated line, and `evil-next-visual-line` can't move past it at all.

The cause is that the multi-line message hung off the annotated line's own newline, so its extra screen rows counted as part of that line for visual-line motion. Evil made it worse - it pulls point back off the newline the annotation sits on, so every downward press just re-landed on the same line.

Anchoring the block on the start of the *following* line fixes both cases: its rows now belong to that line's buffer position, so `next-line` and `evil-next-visual-line` land there cleanly. The rendering is unchanged. I verified the behavior in a scripted GUI Emacs (plain and Evil) and the eol/sideline styles were already fine.