### PR TITLE
Make the python-ruff checker configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#2231](https://github.com/flycheck/flycheck/pull/2231): Make the `rust-clippy` checker configurable with `flycheck-rust-clippy-args` (extra `cargo clippy` arguments) and the `flycheck-rust-clippy-tests`, `flycheck-rust-clippy-all-targets` and `flycheck-rust-clippy-all-features` toggles; `flycheck-rust-features` now applies to `rust-clippy` as well (originally proposed in [#2087](https://github.com/flycheck/flycheck/pull/2087) and [#2125](https://github.com/flycheck/flycheck/pull/2125)).
 - [#2231](https://github.com/flycheck/flycheck/pull/2231): Add `flycheck-rust-edition` to set the edition (`--edition`) for the `rust` checker when checking single-file crates outside a Cargo project.
+- [#2234](https://github.com/flycheck/flycheck/pull/2234): Make the `python-ruff` checker configurable without a config file: `flycheck-python-ruff-select`, `flycheck-python-ruff-extend-select` and `flycheck-python-ruff-ignore` for rule tuning, `flycheck-python-ruff-target-version`, `flycheck-python-ruff-preview`, and `flycheck-python-ruff-args` for arbitrary `ruff check` arguments.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1072,6 +1072,35 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. syntax-checker-config-file:: flycheck-python-ruff-config
 
+      .. defcustom:: flycheck-python-ruff-args
+
+         A list of additional arguments passed to ``ruff check``.
+
+      .. defcustom:: flycheck-python-ruff-select
+
+         A list of rule codes to enable, via ``--select``.  Each item is a rule
+         code or prefix such as ``E``, ``F401`` or ``I``, or the special value
+         ``ALL``.  Replaces the selection Ruff would take from its
+         configuration.
+
+      .. defcustom:: flycheck-python-ruff-extend-select
+
+         A list of rule codes to enable on top of Ruff's configuration, via
+         ``--extend-select``.
+
+      .. defcustom:: flycheck-python-ruff-ignore
+
+         A list of rule codes to disable, via ``--ignore``.
+
+      .. defcustom:: flycheck-python-ruff-target-version
+
+         The minimum Python version to assume, via ``--target-version``, as a
+         string such as ``py312``.
+
+      .. defcustom:: flycheck-python-ruff-preview
+
+         Whether to enable Ruff's preview rules and fixes, via ``--preview``.
+
    .. syntax-checker:: python-pyright
 
       Type check Python with `pyright <https://github.com/microsoft/pyright>`_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -14935,6 +14935,58 @@ Requires Flake8 3.0 or newer. See URL
 (flycheck-def-config-file-var flycheck-python-ruff-config python-ruff
                               '("pyproject.toml" "ruff.toml" ".ruff.toml"))
 
+(flycheck-def-args-var flycheck-python-ruff-args python-ruff
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-python-ruff-select nil python-ruff
+  "A list of rule codes to enable in Ruff, via `--select'.
+
+Each element is a rule code or prefix, such as \"E\", \"F401\" or \"I\", or
+the special value \"ALL\".  Passed to `ruff check' as a comma-separated
+`--select' argument, replacing the selection Ruff would otherwise take from
+its configuration.  When nil, Ruff's configured or default selection is
+used."
+  :type '(repeat (string :tag "Rule code"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-python-ruff-extend-select nil python-ruff
+  "A list of rule codes to enable in Ruff on top of its configuration.
+
+Like `flycheck-python-ruff-select', but passed via `--extend-select', so it
+adds to the rules selected in `pyproject.toml' or `ruff.toml' rather than
+replacing them."
+  :type '(repeat (string :tag "Rule code"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-python-ruff-ignore nil python-ruff
+  "A list of rule codes to disable in Ruff, via `--ignore'.
+
+Each element is a rule code or prefix, such as \"E501\" or \"D\"."
+  :type '(repeat (string :tag "Rule code"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-python-ruff-target-version nil python-ruff
+  "The minimum Python version Ruff should assume, via `--target-version'.
+
+A string such as \"py38\" or \"py312\", or nil to let Ruff infer the version
+from the project's configuration."
+  :type '(choice (const :tag "Inferred" nil)
+                 (const "py37") (const "py38") (const "py39")
+                 (const "py310") (const "py311") (const "py312")
+                 (const "py313") (const "py314")
+                 (string :tag "Version tag"))
+  :safe #'string-or-null-p
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-python-ruff-preview nil python-ruff
+  "Whether to enable Ruff's preview rules and fixes, via `--preview'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38.4"))
+
 (defun flycheck--explain-error-via-checker (checker &rest args)
   "Return an explainer function that calls CHECKER with ARGS.
 The checker output is fontified as Markdown."
@@ -15007,8 +15059,18 @@ See URL `https://docs.astral.sh/ruff/'."
   :command ("ruff"
             "check"
             (config-file "--config" flycheck-python-ruff-config)
+            (option "--select=" flycheck-python-ruff-select concat
+                    flycheck-option-comma-separated-list)
+            (option "--extend-select=" flycheck-python-ruff-extend-select concat
+                    flycheck-option-comma-separated-list)
+            (option "--ignore=" flycheck-python-ruff-ignore concat
+                    flycheck-option-comma-separated-list)
+            (option "--target-version=" flycheck-python-ruff-target-version concat)
+            (option-flag "--preview" flycheck-python-ruff-preview)
+            (eval flycheck-python-ruff-args)
             ;; JSON carries the machine-applicable fixes ruff computes (see
-            ;; `flycheck-parse-ruff'); "--output-format" needs ruff >= 0.2.
+            ;; `flycheck-parse-ruff'); "--output-format" needs ruff >= 0.2.  Keep
+            ;; it last so it wins over any --output-format in the args above.
             "--output-format=json"
             (eval (when buffer-file-name
                     (list "--stdin-filename" (flycheck-buffer-file-local-name))))

--- a/test/specs/languages/test-python.el
+++ b/test/specs/languages/test-python.el
@@ -120,6 +120,46 @@
                          'python-ruff (current-buffer)))))
           (expect (flycheck-error-fix err) :to-be nil)))))
 
+  (describe "the python-ruff checker command"
+    ;; Bind the config-file var to nil so argument substitution never locates a
+    ;; pyproject.toml/ruff.toml and adds a stray --config.
+    (it "passes only check, JSON output and stdin by default"
+      (let ((flycheck-python-ruff-config nil)
+            (flycheck-python-ruff-select nil)
+            (flycheck-python-ruff-extend-select nil)
+            (flycheck-python-ruff-ignore nil)
+            (flycheck-python-ruff-target-version nil)
+            (flycheck-python-ruff-preview nil)
+            (flycheck-python-ruff-args nil))
+        (expect (flycheck-checker-substituted-arguments 'python-ruff)
+                :to-equal '("check" "--output-format=json" "-"))))
+
+    (it "passes --select, --extend-select and --ignore as comma lists"
+      (let ((flycheck-python-ruff-config nil)
+            (flycheck-python-ruff-select '("E" "F" "I"))
+            (flycheck-python-ruff-extend-select '("B"))
+            (flycheck-python-ruff-ignore '("E501" "D")))
+        (let ((args (flycheck-checker-substituted-arguments 'python-ruff)))
+          (expect args :to-contain "--select=E,F,I")
+          (expect args :to-contain "--extend-select=B")
+          (expect args :to-contain "--ignore=E501,D"))))
+
+    (it "passes --target-version and --preview"
+      (let ((flycheck-python-ruff-config nil)
+            (flycheck-python-ruff-target-version "py312")
+            (flycheck-python-ruff-preview t))
+        (let ((args (flycheck-checker-substituted-arguments 'python-ruff)))
+          (expect args :to-contain "--target-version=py312")
+          (expect args :to-contain "--preview"))))
+
+    (it "keeps --output-format=json last so it wins over user args"
+      (let ((flycheck-python-ruff-config nil)
+            (flycheck-python-ruff-args '("--output-format=text")))
+        (let* ((args (flycheck-checker-substituted-arguments 'python-ruff))
+               (formats (seq-filter (lambda (a) (string-prefix-p "--output-format" a))
+                                    args)))
+          (expect (car (last formats)) :to-equal "--output-format=json")))))
+
   (flycheck-buttercup-def-checker-test python-pylint python nil
     (let ((flycheck-disabled-checkers '(python-flake8 python-mypy))
           (flycheck-python-pylint-executable "python3"))


### PR DESCRIPTION
Ruff was the odd one out among the Python checkers: you could only steer it through a `pyproject.toml`/`ruff.toml`, with no way to tune rules, target version or preview lints from Emacs, and no escape hatch for arbitrary arguments.

Adds `flycheck-python-ruff-select`, `-extend-select` and `-ignore` for rule tuning, `-target-version`, `-preview`, and `-args` for anything else. They go ahead of `--output-format=json` on the command line, which stays last so it always wins over a stray `--output-format` in `-args`. Verified the flags against ruff 0.16, with command-construction specs and doc entries.