### PR TITLE
Don't crash flycheck-verify-setup when eslint is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugs fixed
 
 - [#2233](https://github.com/flycheck/flycheck/pull/2233): Fix `flycheck-annotate-mode`'s `below` style trapping vertical motion on the annotated line - `next-line` needed an extra press to get past it and `evil-next-visual-line` could not move past it at all. The multi-line message now hangs off the following line instead of the annotated line's newline.
+- [#2235](https://github.com/flycheck/flycheck/pull/2235): Fix `flycheck-verify-setup` erroring with `Wrong type argument: number-or-marker-p, nil` when `eslint` is not installed ([#2232](https://github.com/flycheck/flycheck/issues/2232)); `flycheck-call-checker-process-for-output` no longer chokes on a missing executable either.
 
 ## 38.3 (2026-07-29)
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -8744,7 +8744,10 @@ the error checking automatically."
         (let ((exit-code (apply #'flycheck-call-checker-process
                                 checker infile temp error args))
               (output (with-current-buffer temp (buffer-string))))
-          (if (zerop exit-code) output
+          ;; EXIT-CODE is nil when CHECKER cannot be found (and ERROR is nil, so
+          ;; no error was raised) and a string for a signalled process; treat
+          ;; both as failure rather than passing them to `zerop'.
+          (if (eql 0 exit-code) output
             (when error
               (error "Process %s failed with %S (%s)"
                      checker exit-code output))))
@@ -13863,7 +13866,9 @@ for more information about the custom directories."
 
 (defun flycheck-eslint-config-exists-p ()
   "Whether there is a valid eslint config for the current buffer."
-  (zerop (flycheck-call-checker-process
+  ;; `flycheck-call-checker-process' returns nil when eslint cannot be found, so
+  ;; test for a zero exit status rather than passing a possible nil to `zerop'.
+  (eql 0 (flycheck-call-checker-process
           'javascript-eslint nil nil nil
           "--print-config" (flycheck-buffer-file-local-name "index.js"))))
 

--- a/test/specs/languages/test-javascript.el
+++ b/test/specs/languages/test-javascript.el
@@ -92,6 +92,21 @@ Some more explanation here.")
                'javascript-eslint 1 "[{\"unexpected\": \"format\"}]")
               :to-be 'suspicious)))
 
+  (describe "flycheck-eslint-config-exists-p"
+    (it "is non-nil when eslint exits zero"
+      (spy-on 'flycheck-call-checker-process :and-return-value 0)
+      (expect (flycheck-eslint-config-exists-p) :to-be-truthy))
+
+    (it "is nil when eslint exits non-zero"
+      (spy-on 'flycheck-call-checker-process :and-return-value 1)
+      (expect (flycheck-eslint-config-exists-p) :to-be nil))
+
+    (it "is nil, not an error, when eslint cannot be found"
+      ;; Regression for #2232: `flycheck-call-checker-process' returns nil when
+      ;; the executable is missing, and that nil must not reach `zerop'.
+      (spy-on 'flycheck-call-checker-process :and-return-value nil)
+      (expect (flycheck-eslint-config-exists-p) :to-be nil)))
+
   (describe "Checker tests"
     (flycheck-buttercup-def-checker-test javascript-eslint javascript error
       (let ((inhibit-message t))

--- a/test/specs/test-checker-api.el
+++ b/test/specs/test-checker-api.el
@@ -89,6 +89,20 @@
                              (flycheck-checker-executable ',checker)))
                     :to-equal "some-nice-executable"))))))
 
+  (describe "flycheck-call-checker-process"
+    (it "returns nil when the executable cannot be found"
+      (spy-on 'flycheck-find-checker-executable :and-return-value nil)
+      (expect (flycheck-call-checker-process 'emacs-lisp nil nil nil)
+              :to-be nil)))
+
+  (describe "flycheck-call-checker-process-for-output"
+    (it "returns nil, not an error, when the executable cannot be found"
+      ;; Regression: a nil exit status must not reach `zerop' (see #2232 for the
+      ;; sibling `flycheck-eslint-config-exists-p').
+      (spy-on 'flycheck-find-checker-executable :and-return-value nil)
+      (expect (flycheck-call-checker-process-for-output 'emacs-lisp nil nil)
+              :to-be nil)))
+
   (describe "flycheck-checker-get"
     (it "modes"
       (dolist (checker flycheck-checkers)


### PR DESCRIPTION
Fixes #2232. On a machine without eslint, `M-x flycheck-verify-setup` died with `Wrong type argument: number-or-marker-p, nil`.

`flycheck-eslint-config-exists-p` passed the result of `flycheck-call-checker-process` straight to `zerop`, but that function returns nil when the executable can't be found (as its own docstring notes). Testing for a zero exit status instead fixes it. The reporter diagnosed this exactly - thanks.

I fixed the same latent nil-to-`zerop` bug in `flycheck-call-checker-process-for-output`, whose nil path is reachable through `flycheck-python-run-snippet` when python isn't on PATH. Added regression specs for all three.