### PR TITLE
Detect eslint project roots from flat config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [#2233](https://github.com/flycheck/flycheck/pull/2233): Fix `flycheck-annotate-mode`'s `below` style trapping vertical motion on the annotated line - `next-line` needed an extra press to get past it and `evil-next-visual-line` could not move past it at all. The multi-line message now hangs off the following line instead of the annotated line's newline.
 - [#2235](https://github.com/flycheck/flycheck/pull/2235): Fix `flycheck-verify-setup` erroring with `Wrong type argument: number-or-marker-p, nil` when `eslint` is not installed ([#2232](https://github.com/flycheck/flycheck/issues/2232)); `flycheck-call-checker-process-for-output` no longer chokes on a missing executable either.
+- [#2236](https://github.com/flycheck/flycheck/pull/2236): Detect the project root of a `javascript-eslint` buffer from a flat config file (`eslint.config.js` and its `.mjs`/`.cjs`/`.ts` variants), not only the legacy `.eslintrc`/`.eslintignore` that ESLint 9 dropped.
 
 ## 38.3 (2026-07-29)
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13857,6 +13857,10 @@ See URL `https://github.com/htacg/tidy-html5'."
 The value of this variable is a list of strings, where each
 string is a directory with custom rules for ESLint.
 
+This passes the `--rulesdir' option, which ESLint 9 removed along
+with the legacy `.eslintrc' configuration; with flat config, load
+custom rules through a plugin in `eslint.config.js' instead.
+
 Refer to the ESLint manual at URL
 `https://eslint.org/docs/user-guide/command-line-interface#--rulesdir'
 for more information about the custom directories."
@@ -13957,10 +13961,15 @@ See URL `https://eslint.org' for more information about ESLint."
 
 This will be the directory that contains the `node_modules'
 directory.  If no such directory is found in the directory
-hierarchy, it looks first for `.eslintignore' and then for
-`.eslintrc' files to detect the project root."
-  (let* ((regex-config (concat "\\`\\.eslintrc"
-                               "\\(\\.\\(js\\|ya?ml\\|json\\)\\)?\\'")))
+hierarchy, it looks for `.eslintignore' and then for a
+configuration file to detect the project root.  Both the flat
+config files ESLint uses since version 9 (`eslint.config.js' and
+its `.mjs'/`.cjs'/`.ts' variants) and the legacy `.eslintrc'
+files are recognized."
+  (let* ((regex-config (concat "\\`\\(?:"
+                               "\\.eslintrc\\(?:\\.\\(?:js\\|ya?ml\\|json\\)\\)?"
+                               "\\|eslint\\.config\\.[cm]?[jt]s"
+                               "\\)\\'")))
     (when buffer-file-name
       (or (locate-dominating-file buffer-file-name "node_modules")
           (locate-dominating-file buffer-file-name ".eslintignore")

--- a/test/specs/languages/test-javascript.el
+++ b/test/specs/languages/test-javascript.el
@@ -107,6 +107,35 @@ Some more explanation here.")
       (spy-on 'flycheck-call-checker-process :and-return-value nil)
       (expect (flycheck-eslint-config-exists-p) :to-be nil)))
 
+  (describe "flycheck-eslint--find-working-directory"
+    (defun test-eslint/root-with (config-file)
+      "Return the detected root for a buffer under a dir holding CONFIG-FILE."
+      (let* ((root (make-temp-file "flycheck-eslint" 'dir))
+             (srcdir (expand-file-name "src/" root))
+             (src (expand-file-name "app.js" srcdir)))
+        (unwind-protect
+            (progn
+              (make-directory srcdir)
+              (write-region "" nil (expand-file-name config-file root))
+              (write-region "" nil src)
+              (with-temp-buffer
+                (setq buffer-file-name src)
+                (flycheck-eslint--find-working-directory nil)))
+          (delete-directory root 'recursive))))
+
+    (it "detects a project root from a flat config file"
+      (dolist (name '("eslint.config.js" "eslint.config.mjs"
+                      "eslint.config.cjs" "eslint.config.ts"))
+        (expect (test-eslint/root-with name) :not :to-be nil)))
+
+    (it "still detects a project root from a legacy .eslintrc"
+      (dolist (name '(".eslintrc" ".eslintrc.js" ".eslintrc.json"
+                      ".eslintrc.yml"))
+        (expect (test-eslint/root-with name) :not :to-be nil)))
+
+    (it "does not treat an unrelated dotfile as a config"
+      (expect (test-eslint/root-with ".prettierrc") :to-be nil)))
+
   (describe "Checker tests"
     (flycheck-buttercup-def-checker-test javascript-eslint javascript error
       (let ((inhibit-message t))


### PR DESCRIPTION
Deep-check of `javascript-eslint`. When `flycheck-eslint--find-working-directory` can't find a `node_modules` above the file, it falls back to locating the project root by config file - but it only looked for the legacy `.eslintrc`/`.eslintignore`. ESLint 9 made flat config (`eslint.config.js`, `.mjs`, `.cjs`, `.ts`) the default and dropped `.eslintignore`, so a flat-config project without an ancestor `node_modules` wouldn't get a working directory.

Match the flat config file names too, keeping the legacy ones for older setups. Also noted in `flycheck-eslint-rules-directories`'s docstring that `--rulesdir` went away with the legacy config in ESLint 9. Specs cover flat, legacy and negative cases.