### PR TITLE
Expose more ruby-rubocop options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2231](https://github.com/flycheck/flycheck/pull/2231): Make the `rust-clippy` checker configurable with `flycheck-rust-clippy-args` (extra `cargo clippy` arguments) and the `flycheck-rust-clippy-tests`, `flycheck-rust-clippy-all-targets` and `flycheck-rust-clippy-all-features` toggles; `flycheck-rust-features` now applies to `rust-clippy` as well (originally proposed in [#2087](https://github.com/flycheck/flycheck/pull/2087) and [#2125](https://github.com/flycheck/flycheck/pull/2125)).
 - [#2231](https://github.com/flycheck/flycheck/pull/2231): Add `flycheck-rust-edition` to set the edition (`--edition`) for the `rust` checker when checking single-file crates outside a Cargo project.
 - [#2234](https://github.com/flycheck/flycheck/pull/2234): Make the `python-ruff` checker configurable without a config file: `flycheck-python-ruff-select`, `flycheck-python-ruff-extend-select` and `flycheck-python-ruff-ignore` for rule tuning, `flycheck-python-ruff-target-version`, `flycheck-python-ruff-preview`, and `flycheck-python-ruff-args` for arbitrary `ruff check` arguments.
+- [#2237](https://github.com/flycheck/flycheck/pull/2237): Expose more `ruby-rubocop` options: `flycheck-rubocop-server` to keep a warm server process alive (`--server`), `flycheck-rubocop-only` and `flycheck-rubocop-except` to focus or suppress cops, and `flycheck-rubocop-args` for arbitrary arguments.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1231,6 +1231,23 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Whether to suppress warnings about style issues, via the ``--lint``
          option.
 
+      .. defcustom:: flycheck-rubocop-server
+
+         Whether to run RuboCop in server mode, via ``--server``, keeping a warm
+         server process alive between runs to cut startup latency.
+
+      .. defcustom:: flycheck-rubocop-only
+
+         A list of cops or departments to run exclusively, via ``--only``.
+
+      .. defcustom:: flycheck-rubocop-except
+
+         A list of cops or departments to disable, via ``--except``.
+
+      .. defcustom:: flycheck-rubocop-args
+
+         A list of additional arguments passed to ``rubocop``.
+
       .. syntax-checker-config-file:: flycheck-rubocoprc
 
    .. syntax-checker:: ruby-standard

--- a/flycheck.el
+++ b/flycheck.el
@@ -15772,6 +15772,37 @@ report style issues as well."
   :type 'boolean
   :package-version '(flycheck . "0.16"))
 
+(flycheck-def-args-var flycheck-rubocop-args ruby-rubocop
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-rubocop-server nil ruby-rubocop
+  "Whether to run RuboCop in server mode, via `--server'.
+
+When non-nil, RuboCop keeps a warm server process alive between runs,
+which greatly cuts its startup time on repeated checks.  See URL
+`https://docs.rubocop.org/rubocop/usage/server.html'."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-rubocop-only nil ruby-rubocop
+  "A list of cops to run exclusively in RuboCop, via `--only'.
+
+Each element is a cop or department name, such as
+\"Style/StringLiterals\" or \"Lint\"."
+  :type '(repeat (string :tag "Cop or department"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-rubocop-except nil ruby-rubocop
+  "A list of cops to disable in RuboCop, via `--except'.
+
+Each element is a cop or department name, such as
+\"Style/StringLiterals\" or \"Metrics\"."
+  :type '(repeat (string :tag "Cop or department"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "38.4"))
+
 (defun flycheck-ruby-rubocop-error-explainer (err)
   "Browse the RuboCop documentation for the cop of error ERR.
 The error ID is a DEPARTMENT/CopName cop name.  Only RuboCop's own built-in
@@ -15811,6 +15842,12 @@ See URL `https://rubocop.org/'."
              "--format" "emacs"
              (config-file "--config" flycheck-rubocoprc)
              (option-flag "--lint" flycheck-rubocop-lint-only)
+             (option-flag "--server" flycheck-rubocop-server)
+             (option "--only" flycheck-rubocop-only nil
+                     flycheck-option-comma-separated-list)
+             (option "--except" flycheck-rubocop-except nil
+                     flycheck-option-comma-separated-list)
+             (eval flycheck-rubocop-args)
              ;; RuboCop takes the original file name as argument when reading
              ;; from standard input, but it chokes when that name is the empty
              ;; string, so fall back to "stdin" in order to handle buffers with

--- a/test/specs/languages/test-ruby.el
+++ b/test/specs/languages/test-ruby.el
@@ -68,6 +68,43 @@
                                         :buffer 'buffer
                                         :filename "app/controllers/application_controller.rb"))))))
 
+  (describe "the ruby-rubocop checker command"
+    ;; Bind the config-file var to nil so argument substitution never locates a
+    ;; .rubocop.yml and adds a stray --config.
+    (it "adds no extra flags by default"
+      (let ((flycheck-rubocoprc nil)
+            (flycheck-rubocop-lint-only nil)
+            (flycheck-rubocop-server nil)
+            (flycheck-rubocop-only nil)
+            (flycheck-rubocop-except nil)
+            (flycheck-rubocop-args nil))
+        (let ((args (flycheck-checker-substituted-arguments 'ruby-rubocop)))
+          (expect args :not :to-contain "--server")
+          (expect args :not :to-contain "--only")
+          (expect args :not :to-contain "--except"))))
+
+    (it "passes --server when enabled"
+      (let ((flycheck-rubocoprc nil)
+            (flycheck-rubocop-server t))
+        (expect (flycheck-checker-substituted-arguments 'ruby-rubocop)
+                :to-contain "--server")))
+
+    (it "passes --only and --except as comma-separated cop lists"
+      (let ((flycheck-rubocoprc nil)
+            (flycheck-rubocop-only '("Style/StringLiterals" "Lint"))
+            (flycheck-rubocop-except '("Metrics")))
+        (let ((args (flycheck-checker-substituted-arguments 'ruby-rubocop)))
+          (expect args :to-contain "--only")
+          (expect args :to-contain "Style/StringLiterals,Lint")
+          (expect args :to-contain "--except")
+          (expect args :to-contain "Metrics"))))
+
+    (it "appends flycheck-rubocop-args"
+      (let ((flycheck-rubocoprc nil)
+            (flycheck-rubocop-args '("--display-time")))
+        (expect (flycheck-checker-substituted-arguments 'ruby-rubocop)
+                :to-contain "--display-time"))))
+
   (describe "Checker tests"
     (flycheck-buttercup-def-checker-test ruby-rubocop ruby syntax-error
       (flycheck-buttercup-should-syntax-check


### PR DESCRIPTION
Deep-check of `ruby-rubocop`. It only exposed `--config` and `--lint`, so common needs meant patching the command.

Adds `flycheck-rubocop-server` (RuboCop's server mode, the biggest startup-latency win when checking on save), `flycheck-rubocop-only`/`flycheck-rubocop-except` to focus or suppress cops from Emacs, and a `flycheck-rubocop-args` escape hatch. Verified the flags against rubocop 1.88.2 (server mode's startup message goes to stderr, so stdout parsing stays clean); command-construction specs and docs included.