### PR TITLE
Add a flycheck-python-mypy-args escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2231](https://github.com/flycheck/flycheck/pull/2231): Add `flycheck-rust-edition` to set the edition (`--edition`) for the `rust` checker when checking single-file crates outside a Cargo project.
 - [#2234](https://github.com/flycheck/flycheck/pull/2234): Make the `python-ruff` checker configurable without a config file: `flycheck-python-ruff-select`, `flycheck-python-ruff-extend-select` and `flycheck-python-ruff-ignore` for rule tuning, `flycheck-python-ruff-target-version`, `flycheck-python-ruff-preview`, and `flycheck-python-ruff-args` for arbitrary `ruff check` arguments.
 - [#2237](https://github.com/flycheck/flycheck/pull/2237): Expose more `ruby-rubocop` options: `flycheck-rubocop-server` to keep a warm server process alive (`--server`), `flycheck-rubocop-only` and `flycheck-rubocop-except` to focus or suppress cops, and `flycheck-rubocop-args` for arbitrary arguments.
+- [#2238](https://github.com/flycheck/flycheck/pull/2238): Add `flycheck-python-mypy-args` for passing arbitrary arguments (such as `--strict` or `--ignore-missing-imports`) to `mypy`.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1131,6 +1131,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
          Python executable to collect the type information from PEP 561
          compliant packages.
 
+      .. defcustom:: flycheck-python-mypy-args
+
+         A list of additional arguments passed to ``mypy``, for options such as
+         ``--strict`` or ``--ignore-missing-imports``.
+
    .. syntax-checker:: python-pylint
 
       Check syntax and lint with `Pylint <https://pylint.org/>`_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -15253,6 +15253,9 @@ See URL `https://github.com/microsoft/pyright'."
   :safe #'string-or-null-p
   :package-version '(flycheck . "33"))
 
+(flycheck-def-args-var flycheck-python-mypy-args python-mypy
+  :package-version '(flycheck . "38.4"))
+
 (flycheck-define-checker python-mypy
   "Mypy syntax and type checker.  Requires mypy>=0.730.
 
@@ -15264,6 +15267,7 @@ See URL `https://mypy-lang.org/'."
             (config-file "--config-file" flycheck-python-mypy-config)
             (option "--cache-dir" flycheck-python-mypy-cache-dir)
             (option "--python-executable" flycheck-python-mypy-python-executable)
+            (eval flycheck-python-mypy-args)
             source-original)
   :error-patterns
   ((error line-start (file-name) ":" line (optional ":" column)

--- a/test/specs/languages/test-python.el
+++ b/test/specs/languages/test-python.el
@@ -46,6 +46,14 @@
        '(2 12 error "Incompatible return value type (got \"str\", expected \"int\")"
            :id "return-value" :checker python-mypy))))
 
+  (describe "the python-mypy checker command"
+    (it "appends flycheck-python-mypy-args before the source file"
+      (let ((flycheck-python-mypy-config nil)
+            (flycheck-python-mypy-args '("--strict" "--ignore-missing-imports")))
+        (let ((args (flycheck-checker-substituted-arguments 'python-mypy)))
+          (expect args :to-contain "--strict")
+          (expect args :to-contain "--ignore-missing-imports")))))
+
   (flycheck-buttercup-def-checker-test python-ruff python syntax-error
     (let ((flycheck-disabled-checkers '(python-flake8))
           (flycheck-checkers '(python-ruff))


### PR DESCRIPTION
Deep-check of `python-mypy`. It exposed only its config file, cache dir and python executable, so everyday flags like `--strict` and `--ignore-missing-imports` couldn't be set without a config file. A single args var covers the long tail.