### PR TITLE
Let dockerfile-hadolint use a config file and extra arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#2234](https://github.com/flycheck/flycheck/pull/2234): Make the `python-ruff` checker configurable without a config file: `flycheck-python-ruff-select`, `flycheck-python-ruff-extend-select` and `flycheck-python-ruff-ignore` for rule tuning, `flycheck-python-ruff-target-version`, `flycheck-python-ruff-preview`, and `flycheck-python-ruff-args` for arbitrary `ruff check` arguments.
 - [#2237](https://github.com/flycheck/flycheck/pull/2237): Expose more `ruby-rubocop` options: `flycheck-rubocop-server` to keep a warm server process alive (`--server`), `flycheck-rubocop-only` and `flycheck-rubocop-except` to focus or suppress cops, and `flycheck-rubocop-args` for arbitrary arguments.
 - [#2238](https://github.com/flycheck/flycheck/pull/2238): Add `flycheck-python-mypy-args` for passing arbitrary arguments (such as `--strict` or `--ignore-missing-imports`) to `mypy`.
+- [#2239](https://github.com/flycheck/flycheck/pull/2239): Add `flycheck-dockerfile-hadolint-config` to point `dockerfile-hadolint` at a `.hadolint.yaml` file (via `--config`) and `flycheck-dockerfile-hadolint-args` for arbitrary arguments.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -331,6 +331,12 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _hadolint: https://github.com/hadolint/hadolint
 
+      .. syntax-checker-config-file:: flycheck-dockerfile-hadolint-config
+
+      .. defcustom:: flycheck-dockerfile-hadolint-args
+
+         A list of additional arguments passed to ``hadolint``.
+
 .. supported-language:: Elixir
 
    .. syntax-checker:: elixir-credo

--- a/flycheck.el
+++ b/flycheck.el
@@ -12556,11 +12556,20 @@ ShellCheck link to ShellCheck's wiki."
      ((string-prefix-p "SC" id)
       (cons 'url (format "https://github.com/koalaman/shellcheck/wiki/%s" id))))))
 
+(flycheck-def-config-file-var flycheck-dockerfile-hadolint-config
+    dockerfile-hadolint '(".hadolint.yaml" ".hadolint.yml"))
+
+(flycheck-def-args-var flycheck-dockerfile-hadolint-args dockerfile-hadolint
+  :package-version '(flycheck . "38.4"))
+
 (flycheck-define-checker dockerfile-hadolint
   "A Dockerfile syntax checker using hadolint.
 
 See URL `https://github.com/hadolint/hadolint/'."
-  :command ("hadolint" "--format" "sarif" "-")
+  :command ("hadolint" "--format" "sarif"
+            (config-file "--config" flycheck-dockerfile-hadolint-config)
+            (eval flycheck-dockerfile-hadolint-args)
+            "-")
   :standard-input t
   :error-parser flycheck-parse-sarif
   :error-filter

--- a/test/specs/languages/test-dockerfile.el
+++ b/test/specs/languages/test-dockerfile.el
@@ -21,4 +21,17 @@ expecting '#', '\\', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHC
      '(3 nil error "Use absolute WORKDIR"
          :id "DL3000" :checker dockerfile-hadolint))))
 
+  (describe "the dockerfile-hadolint checker command"
+    (it "adds no config or extra arguments by default"
+      (let ((flycheck-dockerfile-hadolint-config nil)
+            (flycheck-dockerfile-hadolint-args nil))
+        (expect (flycheck-checker-substituted-arguments 'dockerfile-hadolint)
+                :to-equal '("--format" "sarif" "-"))))
+
+    (it "appends flycheck-dockerfile-hadolint-args before the stdin marker"
+      (let ((flycheck-dockerfile-hadolint-config nil)
+            (flycheck-dockerfile-hadolint-args '("--no-fail")))
+        (expect (flycheck-checker-substituted-arguments 'dockerfile-hadolint)
+                :to-equal '("--format" "sarif" "--no-fail" "-")))))
+
 ;;; test-dockerfile.el ends here


### PR DESCRIPTION
Deep-check of `dockerfile-hadolint`. It had zero options, so pointing hadolint at a `.hadolint.yaml` - the usual way to ignore rules or set trusted registries - relied on it auto-discovering the file from the working directory.

Adds `flycheck-dockerfile-hadolint-config` (`--config`) and `flycheck-dockerfile-hadolint-args`. Verified against hadolint 2.14.0 that `--config` suppresses rules in the SARIF output over stdin; command-construction specs and docs included.