### PR TITLE
Expose more terraform-tflint options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2237](https://github.com/flycheck/flycheck/pull/2237): Expose more `ruby-rubocop` options: `flycheck-rubocop-server` to keep a warm server process alive (`--server`), `flycheck-rubocop-only` and `flycheck-rubocop-except` to focus or suppress cops, and `flycheck-rubocop-args` for arbitrary arguments.
 - [#2238](https://github.com/flycheck/flycheck/pull/2238): Add `flycheck-python-mypy-args` for passing arbitrary arguments (such as `--strict` or `--ignore-missing-imports`) to `mypy`.
 - [#2239](https://github.com/flycheck/flycheck/pull/2239): Add `flycheck-dockerfile-hadolint-config` to point `dockerfile-hadolint` at a `.hadolint.yaml` file (via `--config`) and `flycheck-dockerfile-hadolint-args` for arbitrary arguments.
+- [#2240](https://github.com/flycheck/flycheck/pull/2240): Expose more `terraform-tflint` options: `flycheck-tflint-config` for a `.tflint.hcl` file (`--config`), `flycheck-tflint-enabled-rules`/`flycheck-tflint-disabled-rules` (`--enable-rule`/`--disable-rule`), and `flycheck-tflint-args` for arbitrary arguments.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1619,6 +1619,20 @@ to view the docstring of the syntax checker.  Likewise, you may use
          A list of files to resolve terraform variables.  Relative paths are
          relative to the path of the buffer being checked.
 
+      .. syntax-checker-config-file:: flycheck-tflint-config
+
+      .. defcustom:: flycheck-tflint-enabled-rules
+
+         A list of tflint rules to enable, via ``--enable-rule``.
+
+      .. defcustom:: flycheck-tflint-disabled-rules
+
+         A list of tflint rules to disable, via ``--disable-rule``.
+
+      .. defcustom:: flycheck-tflint-args
+
+         A list of additional arguments passed to ``tflint``.
+
 .. supported-language:: Text
 
    .. syntax-checker:: proselint

--- a/flycheck.el
+++ b/flycheck.el
@@ -16846,6 +16846,28 @@ Relative files are relative to the file being checked."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "32"))
 
+(flycheck-def-config-file-var flycheck-tflint-config terraform-tflint
+                              '(".tflint.hcl"))
+
+(flycheck-def-args-var flycheck-tflint-args terraform-tflint
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-tflint-enabled-rules nil terraform-tflint
+  "A list of tflint rules to enable, via `--enable-rule'.
+
+Each element is a rule name, such as \"terraform_unused_declarations\"."
+  :type '(repeat (string :tag "Rule name"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "38.4"))
+
+(flycheck-def-option-var flycheck-tflint-disabled-rules nil terraform-tflint
+  "A list of tflint rules to disable, via `--disable-rule'.
+
+Each element is a rule name, such as \"terraform_deprecated_syntax\"."
+  :type '(repeat (string :tag "Rule name"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "38.4"))
+
 (defun flycheck-parse-tflint-linter (output checker buffer)
   "Parse tflint warnings from JSON OUTPUT.
 
@@ -16877,7 +16899,11 @@ information about tflint."
 
 See URL `https://github.com/terraform-linters/tflint'."
   :command ("tflint" "--format=json" "--force"
-            (option-list "--var-file=" flycheck-tflint-variable-files concat))
+            (config-file "--config" flycheck-tflint-config)
+            (option-list "--enable-rule=" flycheck-tflint-enabled-rules concat)
+            (option-list "--disable-rule=" flycheck-tflint-disabled-rules concat)
+            (option-list "--var-file=" flycheck-tflint-variable-files concat)
+            (eval flycheck-tflint-args))
   :error-parser flycheck-parse-tflint-linter
   :predicate flycheck-buffer-saved-p
   :modes (terraform-mode terraform-ts-mode))

--- a/test/specs/languages/test-terraform.el
+++ b/test/specs/languages/test-terraform.el
@@ -44,6 +44,32 @@
          :end-line 2 :end-column 44)
      '(7 19 error "\"t1.2xlarge\" is an invalid value as instance_type"
          :id "aws_instance_invalid_type" :checker terraform-tflint
-         :end-line 7 :end-column 31))))
+         :end-line 7 :end-column 31)))
+
+  (describe "the terraform-tflint checker command"
+    (it "adds no config or rule flags by default"
+      (let ((flycheck-tflint-config nil)
+            (flycheck-tflint-enabled-rules nil)
+            (flycheck-tflint-disabled-rules nil)
+            (flycheck-tflint-variable-files nil)
+            (flycheck-tflint-args nil))
+        (expect (flycheck-checker-substituted-arguments 'terraform-tflint)
+                :to-equal '("--format=json" "--force"))))
+
+    (it "passes one --enable-rule and --disable-rule per rule"
+      (let ((flycheck-tflint-config nil)
+            (flycheck-tflint-enabled-rules '("terraform_unused_declarations"))
+            (flycheck-tflint-disabled-rules '("terraform_deprecated_syntax"
+                                              "aws_instance_invalid_type")))
+        (let ((args (flycheck-checker-substituted-arguments 'terraform-tflint)))
+          (expect args :to-contain "--enable-rule=terraform_unused_declarations")
+          (expect args :to-contain "--disable-rule=terraform_deprecated_syntax")
+          (expect args :to-contain "--disable-rule=aws_instance_invalid_type"))))
+
+    (it "appends flycheck-tflint-args"
+      (let ((flycheck-tflint-config nil)
+            (flycheck-tflint-args '("--minimum-failure-severity=error")))
+        (expect (flycheck-checker-substituted-arguments 'terraform-tflint)
+                :to-contain "--minimum-failure-severity=error")))))
 
 ;;; test-terraform.el ends here


### PR DESCRIPTION
Deep-check of `terraform-tflint`. It only offered `--var-file`, so selecting a config file or toggling rules meant patching the command.

Adds `flycheck-tflint-config` (`--config`, `.tflint.hcl`), `flycheck-tflint-enabled-rules`/`flycheck-tflint-disabled-rules` (`--enable-rule`/`--disable-rule`), and a `flycheck-tflint-args` escape hatch. Verified the flags against tflint 0.64.