### PR TITLE
Make flycheck-stylelint-args a real user option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#2238](https://github.com/flycheck/flycheck/pull/2238): Add `flycheck-python-mypy-args` for passing arbitrary arguments (such as `--strict` or `--ignore-missing-imports`) to `mypy`.
 - [#2239](https://github.com/flycheck/flycheck/pull/2239): Add `flycheck-dockerfile-hadolint-config` to point `dockerfile-hadolint` at a `.hadolint.yaml` file (via `--config`) and `flycheck-dockerfile-hadolint-args` for arbitrary arguments.
 - [#2240](https://github.com/flycheck/flycheck/pull/2240): Expose more `terraform-tflint` options: `flycheck-tflint-config` for a `.tflint.hcl` file (`--config`), `flycheck-tflint-enabled-rules`/`flycheck-tflint-disabled-rules` (`--enable-rule`/`--disable-rule`), and `flycheck-tflint-args` for arbitrary arguments.
+- [#2241](https://github.com/flycheck/flycheck/pull/2241): Turn `flycheck-stylelint-args` into a real user option, so the four stylelint checkers (`css`/`scss`/`sass`/`less`) accept arbitrary arguments such as `--custom-syntax`.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -243,6 +243,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          Whether to run stylelint in quiet mode via ``--quiet``.
 
+      .. defcustom:: flycheck-stylelint-args
+
+         A list of additional arguments passed to ``stylelint`` by all four
+         stylelint checkers, for options such as ``--custom-syntax``.
+
 .. supported-language:: CUDA C/C++
    :index_as: CUDA
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -12206,8 +12206,9 @@ See URL `https://coffeescript.org/'."
           ": error: " (message) line-end))
   :modes coffee-mode)
 
-(defconst flycheck-stylelint-args '("--formatter" "json")
-  "Common arguments to stylelint invocations.")
+(flycheck-def-args-var flycheck-stylelint-args
+    (css-stylelint scss-stylelint sass-stylelint less-stylelint)
+  :package-version '(flycheck . "38.4"))
 
 ;; Limit the length of the generated docstring by including only the first three
 ;; checker symbols, otherwise emacs will complain about the docstring length
@@ -12351,6 +12352,7 @@ about the JSON format of stylelint."
 
 See URL `https://stylelint.io/'."
   :command ("stylelint"
+            "--formatter" "json"
             (eval flycheck-stylelint-args)
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc)
@@ -14150,6 +14152,7 @@ See URL `https://lesscss.org'."
 
 See URL `https://stylelint.io/'."
   :command ("stylelint"
+            "--formatter" "json"
             (eval flycheck-stylelint-args)
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
@@ -16520,6 +16523,7 @@ See URL `https://call-cc.org/'."
 
 See URL `https://stylelint.io/'."
   :command ("stylelint"
+            "--formatter" "json"
             (eval flycheck-stylelint-args)
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))
@@ -16536,6 +16540,7 @@ See URL `https://stylelint.io/'."
 
 See URL `https://stylelint.io/'."
   :command ("stylelint"
+            "--formatter" "json"
             (eval flycheck-stylelint-args)
             (option-flag "--quiet" flycheck-stylelint-quiet)
             (config-file "--config" flycheck-stylelintrc))

--- a/test/specs/languages/test-css.el
+++ b/test/specs/languages/test-css.el
@@ -11,6 +11,24 @@
       (flycheck-buttercup-should-syntax-check
        "language/css/syntax-error.css" 'css-mode
        '(4 5 error "Unknown word font-size (CssSyntaxError)"
-           :id "CssSyntaxError" :checker css-stylelint)))))
+           :id "CssSyntaxError" :checker css-stylelint))))
+
+  (describe "the stylelint checker command"
+    (it "always requests JSON output"
+      (let ((flycheck-stylelintrc nil)
+            (flycheck-stylelint-args nil))
+        (expect (flycheck-checker-substituted-arguments 'css-stylelint)
+                :to-contain "--formatter")
+        (expect (flycheck-checker-substituted-arguments 'css-stylelint)
+                :to-contain "json")))
+
+    (it "appends flycheck-stylelint-args after the JSON formatter"
+      (let ((flycheck-stylelintrc nil)
+            (flycheck-stylelint-args '("--custom-syntax" "postcss-scss")))
+        (let ((args (flycheck-checker-substituted-arguments 'scss-stylelint)))
+          (expect args :to-contain "--custom-syntax")
+          (expect args :to-contain "postcss-scss")
+          ;; the mandatory JSON formatter is still there
+          (expect args :to-contain "json"))))))
 
 ;;; test-css.el ends here


### PR DESCRIPTION
Deep-check of the stylelint checkers. `flycheck-stylelint-args` was a defconst pinned to `("--formatter" "json")`, so there was no way to pass stylelint extra flags like `--custom-syntax`.

Move the mandatory JSON formatter into each checker's command as literals and turn `flycheck-stylelint-args` into a real args var shared by the four stylelint checkers (`css`/`scss`/`sass`/`less`).