### PR TITLE
Apply build tags to go-vet too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#2233](https://github.com/flycheck/flycheck/pull/2233): Fix `flycheck-annotate-mode`'s `below` style trapping vertical motion on the annotated line - `next-line` needed an extra press to get past it and `evil-next-visual-line` could not move past it at all. The multi-line message now hangs off the following line instead of the annotated line's newline.
 - [#2235](https://github.com/flycheck/flycheck/pull/2235): Fix `flycheck-verify-setup` erroring with `Wrong type argument: number-or-marker-p, nil` when `eslint` is not installed ([#2232](https://github.com/flycheck/flycheck/issues/2232)); `flycheck-call-checker-process-for-output` no longer chokes on a missing executable either.
 - [#2236](https://github.com/flycheck/flycheck/pull/2236): Detect the project root of a `javascript-eslint` buffer from a flat config file (`eslint.config.js` and its `.mjs`/`.cjs`/`.ts` variants), not only the legacy `.eslintrc`/`.eslintignore` that ESLint 9 dropped.
+- [#2244](https://github.com/flycheck/flycheck/pull/2244): Apply `flycheck-go-build-tags` to the `go-vet` checker as well, so a tagged build is checked consistently across the Go checkers.
 
 ## 38.3 (2026-07-29)
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13293,7 +13293,10 @@ See URL `https://go.dev/cmd/gofmt/'."
 
 See URL `https://go.dev/cmd/go/' and URL
 `https://pkg.go.dev/cmd/vet/'."
-  :command ("go" "vet" (source ".go"))
+  :command ("go" "vet"
+            (option "-tags=" flycheck-go-build-tags concat
+                    flycheck-option-comma-separated-list)
+            (source ".go"))
   :error-patterns
   ((warning line-start (file-name) ":" line ": " (message) line-end))
   :modes (go-mode go-ts-mode)
@@ -13315,7 +13318,7 @@ See URL `https://go.dev/cmd/go/' and URL
                 :face (if have-vet 'success '(bold error)))))))
 
 (flycheck-def-option-var flycheck-go-build-tags nil
-                         (go-build go-test go-errcheck go-staticcheck)
+                         (go-vet go-build go-test go-errcheck go-staticcheck)
   "A list of tags for `go build'.
 
 Each item is a string with a tag to be given to `go build'."

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -53,6 +53,17 @@
                   :filename "/home/gastove/golang/src/github.com/Gastove/test/pkg/lib/lib.go")
                  )))))
 
+  (describe "the go-vet checker command"
+    (it "threads flycheck-go-build-tags into go vet"
+      (let ((flycheck-go-build-tags '("integration" "linux")))
+        (expect (flycheck-checker-substituted-arguments 'go-vet)
+                :to-contain "-tags=integration,linux")))
+
+    (it "omits -tags when no build tags are set"
+      (let ((flycheck-go-build-tags nil))
+        (expect (flycheck-checker-substituted-arguments 'go-vet)
+                :not :to-contain "-tags="))))
+
   (describe "Checker tests"
     (flycheck-buttercup-def-checker-test go-gofmt go syntax-error
       (flycheck-buttercup-should-syntax-check


### PR DESCRIPTION
Deep-check of the Go checkers. `flycheck-go-build-tags` fed `go-build`, `go-test`, `go-errcheck` and `go-staticcheck` but not `go-vet`, so a buffer guarded by build tags was vetted without them. Thread `-tags` into the `go vet` command and add `go-vet` to the option's checker list. Verified `go vet -tags` against the local Go.