### PR TITLE
Add args vars to the Python flake8 and pylint checkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2241](https://github.com/flycheck/flycheck/pull/2241): Turn `flycheck-stylelint-args` into a real user option, so the four stylelint checkers (`css`/`scss`/`sass`/`less`) accept arbitrary arguments such as `--custom-syntax`.
 - [#2242](https://github.com/flycheck/flycheck/pull/2242): Add `flycheck-luacheck-globals` to allow extra globals (`--globals`) and `flycheck-luacheck-args` for arbitrary arguments to `lua-luacheck`.
 - [#2243](https://github.com/flycheck/flycheck/pull/2243): Add `flycheck-yamllint-args` for passing arbitrary arguments to `yamllint`.
+- [#2245](https://github.com/flycheck/flycheck/pull/2245): Add `flycheck-flake8-args` and `flycheck-pylint-args` for passing arbitrary arguments (such as flake8's `--select`/`--ignore` or pylint's `--disable`/`--load-plugins`) to the `python-flake8` and `python-pylint` checkers.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1084,6 +1084,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          The maximum length of lines.
 
+      .. defcustom:: flycheck-flake8-args
+
+         A list of additional arguments passed to ``flake8``, for options such
+         as ``--select`` or ``--extend-ignore``.
+
       .. syntax-checker-config-file:: flycheck-flake8rc
 
    .. syntax-checker:: python-ruff
@@ -1168,6 +1173,11 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          Whether to report symbolic (e.g. ``no-name-in-module``) or numeric
          (e.g. ``E0611``) message identifiers.
+
+      .. defcustom:: flycheck-pylint-args
+
+         A list of additional arguments passed to ``pylint``, for options such
+         as ``--disable`` or ``--load-plugins``.
 
       .. syntax-checker-config-file:: flycheck-pylintrc
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -14925,6 +14925,9 @@ of 79 characters if there is no configuration with this setting."
                  (integer :tag "Maximum line length in characters"))
   :safe #'integerp)
 
+(flycheck-def-args-var flycheck-flake8-args python-flake8
+  :package-version '(flycheck . "38.4"))
+
 (defun flycheck-flake8-fix-error-level (err)
   "Fix the error level of ERR.
 
@@ -14955,6 +14958,7 @@ Requires Flake8 3.0 or newer. See URL
             (eval (when buffer-file-name
                     (concat "--stdin-display-name="
                             (flycheck-buffer-file-local-name))))
+            (eval flycheck-flake8-args)
             "-")
   :standard-input t
   :working-directory flycheck-python-find-project-root
@@ -15145,6 +15149,9 @@ which should be used and reported to the user."
   :safe #'booleanp
   :package-version '(flycheck . "0.25"))
 
+(flycheck-def-args-var flycheck-pylint-args python-pylint
+  :package-version '(flycheck . "38.4"))
+
 (defun flycheck-parse-pylint (output checker buffer)
   "Parse JSON OUTPUT of CHECKER on BUFFER as Pylint errors."
   (mapcar (lambda (err)
@@ -15182,6 +15189,7 @@ See URL `https://www.pylint.org/'."
             "--reports=n"
             "--output-format=json"
             (config-file "--rcfile=" flycheck-pylintrc concat)
+            (eval flycheck-pylint-args)
             ;; Need `source-inplace' for relative imports (e.g. `from .foo
             ;; import bar'), see https://github.com/flycheck/flycheck/issues/280
             source-inplace)

--- a/test/specs/languages/test-python.el
+++ b/test/specs/languages/test-python.el
@@ -54,6 +54,24 @@
           (expect args :to-contain "--strict")
           (expect args :to-contain "--ignore-missing-imports")))))
 
+  (describe "the python-flake8 checker command"
+    (it "appends flycheck-flake8-args before the stdin marker"
+      (let ((flycheck-flake8rc nil)
+            (flycheck-flake8-args '("--select=F401" "--max-doc-length=72")))
+        (let ((args (flycheck-checker-substituted-arguments 'python-flake8)))
+          (expect args :to-contain "--select=F401")
+          (expect args :to-contain "--max-doc-length=72")
+          ;; the stdin marker stays last
+          (expect (car (last args)) :to-equal "-")))))
+
+  (describe "the python-pylint checker command"
+    (it "appends flycheck-pylint-args"
+      (let ((flycheck-pylintrc nil)
+            (flycheck-pylint-args '("--disable=C0114" "--jobs=2")))
+        (let ((args (flycheck-checker-substituted-arguments 'python-pylint)))
+          (expect args :to-contain "--disable=C0114")
+          (expect args :to-contain "--jobs=2")))))
+
   (flycheck-buttercup-def-checker-test python-ruff python syntax-error
     (let ((flycheck-disabled-checkers '(python-flake8))
           (flycheck-checkers '(python-ruff))


### PR DESCRIPTION
Second-tier deep-check, Python group. `python-ruff` got an args var (and dedicated select/ignore vars) in the last sweep, but `python-flake8` and `python-pylint` - both still heavily used - had no escape hatch at all, so flake8's `--select`/`--ignore`/`--per-file-ignores` and pylint's `--disable`/`--enable`/`--load-plugins` needed a config file.

Adds `flycheck-flake8-args` and `flycheck-pylint-args`. Verified the flags against flake8 7.3 and pylint 3.3; command-construction specs and docs included.