### PR TITLE
Improve two stale checker defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Changes
 
 - [#2250](https://github.com/flycheck/flycheck/pull/2250): Tidy up the configuration for consistency: rename `flycheck-mode-success-indicator` to `flycheck-mode-line-success-indicator`, `flycheck-jsonnet-command-args` to `flycheck-jsonnet-args`, and the markdownlint-cli `-enable-rules`/`-disable-rules` options to `-enabled-rules`/`-disabled-rules` (the old names remain as obsolete aliases), and mark more options `:safe` so they can be set as file- or directory-local variables.
+- [#2251](https://github.com/flycheck/flycheck/pull/2251): Improve two stale defaults: `flycheck-gfortran-language-standard` now defaults to nil (GFortran's own default) instead of the 1995 standard, and `flycheck-phpcs-changed-git-base` defaults to `"main"` instead of `"trunk"`.
 
 ## 38.3 (2026-07-29)
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13195,7 +13195,7 @@ Relative paths are relative to the file being checked."
   :safe #'flycheck-string-list-p
   :package-version '(flycheck . "0.20"))
 
-(flycheck-def-option-var flycheck-gfortran-language-standard "f95"
+(flycheck-def-option-var flycheck-gfortran-language-standard nil
                          fortran-gfortran
   "The language standard to use in GFortran.
 
@@ -14540,7 +14540,7 @@ See URL `https://pear.php.net/package/PHP_CodeSniffer/'."
   ;; buffer is empty, see https://github.com/flycheck/flycheck/issues/907
   :predicate flycheck-buffer-nonempty-p)
 
-(flycheck-def-option-var flycheck-phpcs-changed-git-base "trunk"
+(flycheck-def-option-var flycheck-phpcs-changed-git-base "main"
                          php-phpcs-changed
   "The git base branch for PHPCS-Changed.
 


### PR DESCRIPTION
From the config-audit follow-ups. Two defaults that no longer fit most users:

- `flycheck-gfortran-language-standard` defaulted to `"f95"`, so any project using Fortran 2003/2008/2018 got its modern constructs flagged. Now defaults to nil (no `-std`), letting GFortran use its own permissive default.
- `flycheck-phpcs-changed-git-base` defaulted to `"trunk"` (SVN-era); now `"main"`.

Both remain fully configurable; this only changes the out-of-the-box value.