### PR TITLE
Add args vars to the Go checkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#2247](https://github.com/flycheck/flycheck/pull/2247): Add args vars to the `elixir-credo`, `erlang` and `scala-scalastyle` checkers: `flycheck-elixir-credo-args`, `flycheck-erlang-args` and `flycheck-scalastyle-args`.
 - [#2248](https://github.com/flycheck/flycheck/pull/2248): Add args vars to the `protobuf-protoc`, `puppet-lint` and `statix` checkers: `flycheck-protoc-args`, `flycheck-puppet-lint-args` and `flycheck-statix-args`.
 - [#2249](https://github.com/flycheck/flycheck/pull/2249): Add args vars to the `markdown-markdownlint-cli`, `markdown-markdownlint-cli2` and `textlint` checkers: `flycheck-markdown-markdownlint-cli-args`, `flycheck-markdown-markdownlint-cli2-args` and `flycheck-textlint-args`.
+- [#2254](https://github.com/flycheck/flycheck/pull/2254): Add args vars to the Go checkers: `flycheck-go-gofmt-args`, `flycheck-go-vet-args`, `flycheck-go-build-args`, `flycheck-go-test-args` and `flycheck-go-errcheck-args`.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -501,6 +501,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check Go syntax with `gofmt <https://golang.org/cmd/gofmt/>`_.
 
+      .. defcustom:: flycheck-go-gofmt-args
+
+         A list of additional arguments passed to ``gofmt``.
+
    .. syntax-checker:: go-vet
 
       Check Go for suspicious code with vet_.
@@ -508,6 +512,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
       .. defcustom:: flycheck-go-build-tags
 
          A list of build tags.
+
+      .. defcustom:: flycheck-go-vet-args
+
+         A list of additional arguments passed to ``go vet``.
 
       .. _vet: https://pkg.go.dev/cmd/vet/
 
@@ -522,6 +530,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
          See `flycheck-go-build-tags`
 
+      .. defcustom:: flycheck-go-build-args
+
+         A list of additional arguments passed to ``go build``.
+
    .. syntax-checker:: go-test
 
       Check syntax and types of Go tests with the `Go compiler`_.
@@ -530,6 +542,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
          :noindex:
 
          See `flycheck-go-build-tags`
+
+      .. defcustom:: flycheck-go-test-args
+
+         A list of additional arguments passed to ``go test``.
 
    .. syntax-checker:: go-errcheck
 
@@ -546,6 +562,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
          :noindex:
 
          See `flycheck-go-build-tags`
+
+      .. defcustom:: flycheck-go-errcheck-args
+
+         A list of additional arguments passed to ``errcheck``.
 
    .. syntax-checker:: go-unconvert
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13303,11 +13303,15 @@ See URL https://github.com/rhysd/actionlint/."
                      (rx (or ".github/workflows" ".github\\workflows"))
                      (buffer-file-name)))))
 
+(flycheck-def-args-var flycheck-go-gofmt-args go-gofmt
+  :package-version '(flycheck . "38.4"))
+
 (flycheck-define-checker go-gofmt
   "A Go syntax and style checker using the gofmt utility.
 
 See URL `https://go.dev/cmd/gofmt/'."
-  :command ("gofmt")
+  :command ("gofmt"
+            (eval flycheck-go-gofmt-args))
   :standard-input t
   :error-patterns
   ((error line-start "<standard input>:" line ":" column ": "
@@ -13320,6 +13324,9 @@ See URL `https://go.dev/cmd/gofmt/'."
                   (warning . go-unconvert)
                   (warning . go-staticcheck)))
 
+(flycheck-def-args-var flycheck-go-vet-args go-vet
+  :package-version '(flycheck . "38.4"))
+
 (flycheck-define-checker go-vet
   "A Go syntax checker using the `go vet' command.
 
@@ -13328,6 +13335,7 @@ See URL `https://go.dev/cmd/go/' and URL
   :command ("go" "vet"
             (option "-tags=" flycheck-go-build-tags concat
                     flycheck-option-comma-separated-list)
+            (eval flycheck-go-vet-args)
             (source ".go"))
   :error-patterns
   ((warning line-start (file-name) ":" line ": " (message) line-end))
@@ -13370,6 +13378,9 @@ details."
   :safe #'string-or-null-p
   :package-version '(flycheck . "0.32"))
 
+(flycheck-def-args-var flycheck-go-build-args go-build
+  :package-version '(flycheck . "38.4"))
+
 (flycheck-define-checker go-build
   "A Go syntax and type checker using the `go build' command.
 
@@ -13378,6 +13389,7 @@ See URL `https://go.dev/cmd/go/'."
             ;; multiple tags are comma-separated: "dev,debug"
             (option "-tags=" flycheck-go-build-tags concat
                     flycheck-option-comma-separated-list)
+            (eval flycheck-go-build-args)
             "-o" null-device)
   :error-patterns
   ((error line-start (file-name) ":" line ":"
@@ -13410,6 +13422,9 @@ See URL `https://go.dev/cmd/go/'."
                   (warning . go-unconvert)
                   (warning . go-staticcheck)))
 
+(flycheck-def-args-var flycheck-go-test-args go-test
+  :package-version '(flycheck . "38.4"))
+
 (flycheck-define-checker go-test
   "A Go syntax and type checker using the `go test' command.
 
@@ -13417,6 +13432,7 @@ See URL `https://go.dev/cmd/go/'."
   :command ("go" "test"
             (option "-tags=" flycheck-go-build-tags concat
                     flycheck-option-comma-separated-list)
+            (eval flycheck-go-test-args)
             "-c" "-o" null-device)
   :error-patterns
   ((error line-start (file-name) ":" line ":"
@@ -13432,6 +13448,9 @@ See URL `https://go.dev/cmd/go/'."
                   (warning . go-unconvert)
                   (warning . go-staticcheck)))
 
+(flycheck-def-args-var flycheck-go-errcheck-args go-errcheck
+  :package-version '(flycheck . "38.4"))
+
 (flycheck-define-checker go-errcheck
   "A Go checker for unchecked errors.
 
@@ -13442,6 +13461,7 @@ See URL `https://github.com/kisielk/errcheck'."
             "-abspath"
             (option "-tags=" flycheck-go-build-tags concat
                     flycheck-option-comma-separated-list)
+            (eval flycheck-go-errcheck-args)
             ".")
   :error-patterns
   ((warning line-start

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -64,6 +64,22 @@
         (expect (flycheck-checker-substituted-arguments 'go-vet)
                 :not :to-contain "-tags="))))
 
+  (describe "the Go checker args vars"
+    (it "threads flycheck-go-gofmt-args into gofmt"
+      (let ((flycheck-go-gofmt-args '("-s")))
+        (expect (flycheck-checker-substituted-arguments 'go-gofmt)
+                :to-contain "-s")))
+
+    (it "threads flycheck-go-build-args into go build"
+      (let ((flycheck-go-build-args '("-race")))
+        (expect (flycheck-checker-substituted-arguments 'go-build)
+                :to-contain "-race")))
+
+    (it "threads flycheck-go-errcheck-args into errcheck"
+      (let ((flycheck-go-errcheck-args '("-blank")))
+        (expect (flycheck-checker-substituted-arguments 'go-errcheck)
+                :to-contain "-blank"))))
+
   (describe "Checker tests"
     (flycheck-buttercup-def-checker-test go-gofmt go syntax-error
       (flycheck-buttercup-should-syntax-check


### PR DESCRIPTION
From the remaining-checkers audit. The Go checkers only shared `flycheck-go-build-tags` and had no generic escape hatch - unlike the rust/haskell checkers - so common flags (`gofmt -s`/`-e`, `go build -race`/`-gcflags`, `go test -run`, `errcheck -blank`/`-ignoretests`) had no way through.

Adds `flycheck-go-gofmt-args`, `flycheck-go-vet-args`, `flycheck-go-build-args`, `flycheck-go-test-args` and `flycheck-go-errcheck-args`. Left `go-unconvert` alone (effectively optionless). Verified `gofmt` flags against the local toolchain; command-construction specs and docs included.