### PR TITLE
Show the error message after a jump with the eldoc display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#2235](https://github.com/flycheck/flycheck/pull/2235): Fix `flycheck-verify-setup` erroring with `Wrong type argument: number-or-marker-p, nil` when `eslint` is not installed ([#2232](https://github.com/flycheck/flycheck/issues/2232)); `flycheck-call-checker-process-for-output` no longer chokes on a missing executable either.
 - [#2236](https://github.com/flycheck/flycheck/pull/2236): Detect the project root of a `javascript-eslint` buffer from a flat config file (`eslint.config.js` and its `.mjs`/`.cjs`/`.ts` variants), not only the legacy `.eslintrc`/`.eslintignore` that ESLint 9 dropped.
 - [#2244](https://github.com/flycheck/flycheck/pull/2244): Apply `flycheck-go-build-tags` to the `go-vet` checker as well, so a tagged build is checked consistently across the Go checkers.
+- [#2255](https://github.com/flycheck/flycheck/pull/2255): Fix the error message not reaching the echo area after `flycheck-next-error` and other jumps, with the default Eldoc-based display ([#2201](https://github.com/flycheck/flycheck/issues/2201)); Eldoc keeps out of the echo area unless the command that ran is one it knows, so Flycheck now asks it to document interactively.
 - [#2250](https://github.com/flycheck/flycheck/pull/2250): Fix several option-variable defects: `flycheck-cuda-includes` and `flycheck-tflint-variable-files` used a directory widget for options that are lists of files, `flycheck-annotate-format-function` and `flycheck-annotate-style-functions` were missing `:risky`, and a few options carried a malformed `:package-version`.
 
 ### Changes

--- a/flycheck.el
+++ b/flycheck.el
@@ -79,6 +79,7 @@
 (require 'help-mode)             ; `define-button-type'
 (require 'find-func)             ; `find-function-regexp-alist'
 (require 'ansi-color)            ; `flycheck-parse-with-patterns-without-color'
+(require 'eldoc)                 ; The default error display
 (require 'url-util)              ; `url-unhex-string' for `flycheck-parse-sarif'
 
 
@@ -7333,8 +7334,14 @@ sources, including `flycheck-eldoc-function', so refreshing it
 shows the Flycheck errors at point alongside e.g. Eglot's
 documentation.  This works from any display entry point --
 interactive commands, error navigation, automatic display after a
-check -- whether or not variable `eldoc-mode' is enabled."
-  (eldoc-print-current-symbol-info))
+check -- whether or not variable `eldoc-mode' is enabled.
+
+Eldoc is asked to document interactively, because reaching this
+function already means Flycheck decided to show the errors at
+point.  Left to its own devices Eldoc keeps out of the echo area
+unless the command that ran is one of `eldoc-message-commands',
+which error navigation is not, and the errors would go unseen."
+  (eldoc-print-current-symbol-info t))
 
 (defun flycheck-eldoc-function (callback &rest _ignored)
   "Document the Flycheck errors at point by calling CALLBACK.
@@ -7395,17 +7402,31 @@ If there are no errors, clears the error messages at point."
             (flycheck-display-errors errors)
           (flycheck-clear-displayed-errors))))))
 
+(defun flycheck--eldoc-refreshes-echo-area-p ()
+  "Whether Eldoc itself will refresh the echo area for this command.
+
+Eldoc only writes to the echo area after a command registered in
+`eldoc-message-commands' -- ordinary motion and editing.  After any
+other command, such as a jump from `consult-flycheck', it computes its
+documentation but leaves the echo area alone, so Flycheck has to ask
+for the display itself."
+  (and (flycheck--display-errors-via-eldoc-p)
+       (bound-and-true-p eldoc-mode)
+       (symbolp this-command)
+       this-command
+       (intern-soft (symbol-name this-command) eldoc-message-commands)
+       t))
+
 (defun flycheck-display-error-at-point-soon ()
   "Display error messages at point, with a delay."
   (flycheck-cancel-error-display-error-at-point-timer)
-  ;; When errors are displayed through Eldoc and `eldoc-mode' is active,
-  ;; its own post-command refresh covers this path; without `eldoc-mode'
-  ;; fall back to Flycheck's timer, which triggers the refresh itself.
-  ;; When inline display already covers the line at point, skip the
-  ;; echo-area message entirely (see `flycheck-annotate-suppress-echo').
+  ;; When errors are displayed through Eldoc and Eldoc will refresh the
+  ;; echo area on its own, let it; otherwise fall back to Flycheck's
+  ;; timer, which triggers the refresh itself.  When inline display
+  ;; already covers the line at point, skip the echo-area message
+  ;; entirely (see `flycheck-annotate-suppress-echo').
   (unless (or (flycheck-annotate--suppresses-echo-p)
-              (and (flycheck--display-errors-via-eldoc-p)
-                   (bound-and-true-p eldoc-mode)))
+              (flycheck--eldoc-refreshes-echo-area-p))
     (setq flycheck-display-error-at-point-timer
           (run-at-time flycheck-display-errors-delay nil
                        'flycheck-display-error-at-point))))

--- a/test/specs/test-error-display.el
+++ b/test/specs/test-error-display.el
@@ -85,14 +85,31 @@
           (expect (bound-and-true-p eldoc-mode) :to-be-truthy)
           (flycheck-mode -1))))
 
-    (it "keeps the display timer off only while eldoc-mode is active"
+    (it "asks eldoc to document interactively"
+      ;; Left to itself Eldoc keeps out of the echo area unless the
+      ;; command that ran is one of `eldoc-message-commands', which
+      ;; error navigation is not.  See #2201.
+      (let ((interactive 'unset))
+        (cl-letf (((symbol-function 'eldoc-print-current-symbol-info)
+                   (lambda (&optional arg) (setq interactive arg))))
+          (flycheck-display-errors-via-eldoc nil)
+          (expect interactive :to-be-truthy))))
+
+    (it "keeps the display timer off only when eldoc refreshes on its own"
       (flycheck-buttercup-with-temp-buffer
         ;; `eldoc-mode' refuses to activate without a documentation
         ;; source, so register Flycheck's first
         (flycheck-mode 1)
         (eldoc-mode 1)
-        (flycheck-display-error-at-point-soon)
-        (expect flycheck-display-error-at-point-timer :not :to-be-truthy)
+        ;; After ordinary motion Eldoc updates the echo area itself
+        (let ((this-command 'forward-char))
+          (flycheck-display-error-at-point-soon)
+          (expect flycheck-display-error-at-point-timer :not :to-be-truthy))
+        ;; After a jump it does not, so Flycheck has to (see #2201)
+        (let ((this-command 'flycheck-next-error))
+          (flycheck-display-error-at-point-soon)
+          (expect flycheck-display-error-at-point-timer :to-be-truthy)
+          (flycheck-cancel-error-display-error-at-point-timer))
         (eldoc-mode -1)
         ;; Without eldoc-mode the timer must pick up the slack
         (flycheck-display-error-at-point-soon)


### PR DESCRIPTION
Eldoc only writes to the echo area after commands it knows about, and error navigation isn't one of them - so since the eldoc display became the default, `flycheck-next-error` left the message unseen until you nudged point. The `*eldoc*` buffer updated all along, which is why it looked like a display bug.

Flycheck now asks eldoc to document interactively, and the post-command path only defers to eldoc when eldoc will actually refresh the echo area itself - that covers jumps from outside Flycheck like consult-flycheck.

Fixes #2201.