### PR TITLE
Make the JavaScript and data-format checkers configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#2248](https://github.com/flycheck/flycheck/pull/2248): Add args vars to the `protobuf-protoc`, `puppet-lint` and `statix` checkers: `flycheck-protoc-args`, `flycheck-puppet-lint-args` and `flycheck-statix-args`.
 - [#2249](https://github.com/flycheck/flycheck/pull/2249): Add args vars to the `markdown-markdownlint-cli`, `markdown-markdownlint-cli2` and `textlint` checkers: `flycheck-markdown-markdownlint-cli-args`, `flycheck-markdown-markdownlint-cli2-args` and `flycheck-textlint-args`.
 - [#2254](https://github.com/flycheck/flycheck/pull/2254): Add args vars to the Go checkers: `flycheck-go-gofmt-args`, `flycheck-go-vet-args`, `flycheck-go-build-args`, `flycheck-go-test-args` and `flycheck-go-errcheck-args`.
+- [#2256](https://github.com/flycheck/flycheck/pull/2256): Make the JavaScript and data-format checkers configurable: `javascript-oxlint` gains `flycheck-javascript-oxlint-config`, `flycheck-javascript-oxlint-deny` and `flycheck-javascript-oxlint-allow` for rules and categories, and an args var; `yaml-actionlint` gains `flycheck-yaml-actionlint-config`; and `javascript-standard`, `json-jq` and `yaml-jsyaml` gain args vars.
 
 ### Bugs fixed
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -723,9 +723,27 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Lint JavaScript and TypeScript with `oxlint <https://oxc.rs/>`_.
 
+      .. syntax-checker-config-file:: flycheck-javascript-oxlint-config
+
+      .. defcustom:: flycheck-javascript-oxlint-deny
+
+         A list of rules or categories to report, via ``--deny``.
+
+      .. defcustom:: flycheck-javascript-oxlint-allow
+
+         A list of rules or categories to suppress, via ``--allow``.
+
+      .. defcustom:: flycheck-javascript-oxlint-args
+
+         A list of additional arguments passed to ``oxlint``.
+
    .. syntax-checker:: javascript-standard
 
       Check syntax and code style with Standard_ or Semistandard_.
+
+      .. defcustom:: flycheck-javascript-standard-args
+
+         A list of additional arguments passed to ``standard``.
 
       .. _Standard: https://github.com/standard/standard
       .. _Semistandard: https://github.com/standard/semistandard
@@ -743,6 +761,10 @@ to view the docstring of the syntax checker.  Likewise, you may use
       Check JSON with jq_.
 
       This checker accepts multiple consecutive JSON values in a single input, which is useful for jsonlines data.
+
+      .. defcustom:: flycheck-json-jq-args
+
+         A list of additional arguments passed to ``jq``.
 
       .. _jq: https://stedolan.github.io/jq/
 
@@ -1838,9 +1860,19 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check syntax with `actionlint <https://github.com/rhysd/actionlint>`_.
 
+      .. syntax-checker-config-file:: flycheck-yaml-actionlint-config
+
+      .. defcustom:: flycheck-yaml-actionlint-args
+
+         A list of additional arguments passed to ``actionlint``.
+
    .. syntax-checker:: yaml-jsyaml
 
       Check syntax with `js-yaml <https://github.com/nodeca/js-yaml>`_.
+
+      .. defcustom:: flycheck-yaml-jsyaml-args
+
+         A list of additional arguments passed to ``js-yaml``.
 
    .. syntax-checker:: yaml-yamllint
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13311,11 +13311,21 @@ Uses GCC's Fortran compiler gfortran.  See URL
             "Warning: " (message) line-end))
   :modes (fortran-mode f90-mode))
 
+(flycheck-def-config-file-var flycheck-yaml-actionlint-config
+                              yaml-actionlint nil
+  :package-version '(flycheck . "39"))
+
+(flycheck-def-args-var flycheck-yaml-actionlint-args yaml-actionlint
+  :package-version '(flycheck . "39"))
+
 (flycheck-define-checker yaml-actionlint
   "A YAML syntax checker using actionlint.
 
 See URL https://github.com/rhysd/actionlint/."
-  :command ("actionlint" "-oneline" source)
+  :command ("actionlint" "-oneline"
+            (config-file "-config-file" flycheck-yaml-actionlint-config)
+            (eval flycheck-yaml-actionlint-args)
+            source)
   :error-patterns ((error line-start (file-name) ":" line ":" column ": " (message) line-end))
   :modes (yaml-mode yaml-ts-mode)
   :predicate (lambda ()
@@ -14103,12 +14113,43 @@ See URL `https://eslint.org/'."
    ;; skip non-builtin (plugin) rules, which eslint.org does not document
    (lambda (id) (unless (seq-contains-p id ?/) id))))
 
+(flycheck-def-config-file-var flycheck-javascript-oxlint-config
+                              javascript-oxlint nil
+  :package-version '(flycheck . "39"))
+
+(flycheck-def-option-var flycheck-javascript-oxlint-deny nil javascript-oxlint
+  "Rules or categories oxlint should report as errors.
+
+The value of this variable is a list of strings, where each
+string is the name of a rule or of a category such as
+`correctness' or `pedantic', passed to oxlint via `--deny'."
+  :type '(repeat (string :tag "Rule or category"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "39"))
+
+(flycheck-def-option-var flycheck-javascript-oxlint-allow nil javascript-oxlint
+  "Rules or categories oxlint should not report.
+
+The value of this variable is a list of strings, where each
+string is the name of a rule or of a category such as
+`correctness' or `pedantic', passed to oxlint via `--allow'."
+  :type '(repeat (string :tag "Rule or category"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "39"))
+
+(flycheck-def-args-var flycheck-javascript-oxlint-args javascript-oxlint
+  :package-version '(flycheck . "39"))
+
 (flycheck-define-checker javascript-oxlint
   "A JavaScript and TypeScript linter using oxlint.
 
 See URL `https://oxc.rs/'."
   :command ("oxlint"
             "--format" "checkstyle"
+            (config-file "--config" flycheck-javascript-oxlint-config)
+            (option-list "--deny" flycheck-javascript-oxlint-deny)
+            (option-list "--allow" flycheck-javascript-oxlint-allow)
+            (eval flycheck-javascript-oxlint-args)
             source-inplace)
   :error-parser flycheck-parse-checkstyle
   :error-filter
@@ -14117,6 +14158,9 @@ See URL `https://oxc.rs/'."
      (flycheck-dequalify-error-ids errors)))
   :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode rjsx-mode
                   typescript-mode js-ts-mode typescript-ts-mode tsx-ts-mode))
+
+(flycheck-def-args-var flycheck-javascript-standard-args javascript-standard
+  :package-version '(flycheck . "39"))
 
 (flycheck-define-checker javascript-standard
   "A Javascript code and style checker for the (Semi-)Standard Style.
@@ -14127,7 +14171,8 @@ to the former.  To use it with the latter, set
 
 See URL `https://github.com/standard/standard' and URL
 `https://github.com/Flet/semistandard'."
-  :command ("standard" "--stdin")
+  :command ("standard" "--stdin"
+            (eval flycheck-javascript-standard-args))
   :standard-input t
   :error-patterns
   ((error line-start "  <text>:" line ":" column ":" (message) line-end))
@@ -14151,6 +14196,9 @@ See URL `https://docs.python.org/3.5/library/json.html#command-line-interface'."
   ;; The JSON parser chokes if the buffer is empty and has no JSON inside
   :predicate flycheck-buffer-nonempty-p)
 
+(flycheck-def-args-var flycheck-json-jq-args json-jq
+  :package-version '(flycheck . "39"))
+
 (flycheck-define-checker json-jq
   "JSON checker using the jq tool.
 
@@ -14158,7 +14206,7 @@ This checker accepts multiple consecutive JSON values in a
 single input, which is useful for jsonlines data.
 
 See URL `https://stedolan.github.io/jq/'."
-  :command ("jq" "." source null-device)
+  :command ("jq" (eval flycheck-json-jq-args) "." source null-device)
   ;; Example error message:
   ;;   parse error: Expected another key-value pair at line 3, column 1
   :error-patterns
@@ -17315,11 +17363,14 @@ The xmllint is part of libxml2, see URL
    (error line-start "-:" line ": " (message) line-end))
   :modes (xml-mode nxml-mode))
 
+(flycheck-def-args-var flycheck-yaml-jsyaml-args yaml-jsyaml
+  :package-version '(flycheck . "39"))
+
 (flycheck-define-checker yaml-jsyaml
   "A YAML syntax checker using JS-YAML.
 
 See URL `https://github.com/nodeca/js-yaml'."
-  :command ("js-yaml")
+  :command ("js-yaml" (eval flycheck-yaml-jsyaml-args))
   :standard-input t
   :error-patterns
   ((error line-start

--- a/test/specs/languages/test-javascript.el
+++ b/test/specs/languages/test-javascript.el
@@ -201,6 +201,33 @@ Some more explanation here.")
          '(4 6 error "'foo' is assigned a value but never used."
              :checker javascript-standard)
          '(4 13 error "Strings must use singlequote."
-             :checker javascript-standard))))))
+             :checker javascript-standard)))))
+
+  (describe "the javascript-oxlint checker command"
+    (it "passes the deny and allow rules as repeated options"
+      (let ((flycheck-javascript-oxlint-deny '("pedantic" "no-debugger"))
+            (flycheck-javascript-oxlint-allow '("no-console")))
+        ;; The trailing argument is the temporary copy of the buffer
+        (expect (butlast (flycheck-checker-substituted-arguments 'javascript-oxlint))
+                :to-equal '("--format" "checkstyle"
+                            "--deny" "pedantic" "--deny" "no-debugger"
+                            "--allow" "no-console"))))
+
+    (it "passes flycheck-javascript-oxlint-config via --config"
+      (let ((flycheck-javascript-oxlint-config ".oxlintrc.json"))
+        (spy-on 'flycheck-locate-config-file :and-return-value "/c/.oxlintrc.json")
+        (expect (flycheck-checker-substituted-arguments 'javascript-oxlint)
+                :to-contain "--config")))
+
+    (it "threads flycheck-javascript-oxlint-args into oxlint"
+      (let ((flycheck-javascript-oxlint-args '("--react-plugin")))
+        (expect (flycheck-checker-substituted-arguments 'javascript-oxlint)
+                :to-contain "--react-plugin"))))
+
+  (describe "the javascript-standard checker command"
+    (it "threads flycheck-javascript-standard-args into standard"
+      (let ((flycheck-javascript-standard-args '("--env" "mocha")))
+        (expect (flycheck-checker-substituted-arguments 'javascript-standard)
+                :to-equal '("--stdin" "--env" "mocha"))))))
 
 ;;; test-javascript.el ends here

--- a/test/specs/languages/test-json.el
+++ b/test/specs/languages/test-json.el
@@ -13,6 +13,12 @@
     (let ((flycheck-disabled-checkers '(json-python-json)))
       (flycheck-buttercup-should-syntax-check
        "language/json.json" 'json-mode
-       '(1 44 error "Expected value before ','" :checker json-jq)))))
+       '(1 44 error "Expected value before ','" :checker json-jq))))
+
+  (describe "the json-jq checker command"
+    (it "threads flycheck-json-jq-args in before the filter"
+      (let ((flycheck-json-jq-args '("--seq")))
+        (expect (flycheck-checker-substituted-arguments 'json-jq)
+                :to-contain "--seq")))))
 
 ;;; test-json.el ends here

--- a/test/specs/languages/test-yaml.el
+++ b/test/specs/languages/test-yaml.el
@@ -50,6 +50,24 @@
       (let ((flycheck-yamllint-config nil)
             (flycheck-yamllint-args '("--strict")))
         (expect (flycheck-checker-substituted-arguments 'yaml-yamllint)
-                :to-equal '("-f" "parsable" "--strict" "-"))))))
+                :to-equal '("-f" "parsable" "--strict" "-")))))
+
+  (describe "the yaml-jsyaml checker command"
+    (it "threads flycheck-yaml-jsyaml-args into js-yaml"
+      (let ((flycheck-yaml-jsyaml-args '("--trace")))
+        (expect (flycheck-checker-substituted-arguments 'yaml-jsyaml)
+                :to-equal '("--trace")))))
+
+  (describe "the yaml-actionlint checker command"
+    (it "passes flycheck-yaml-actionlint-config via -config-file"
+      (let ((flycheck-yaml-actionlint-config "actionlint.yaml"))
+        (spy-on 'flycheck-locate-config-file :and-return-value "/c/actionlint.yaml")
+        (expect (flycheck-checker-substituted-arguments 'yaml-actionlint)
+                :to-contain "-config-file")))
+
+    (it "threads flycheck-yaml-actionlint-args into actionlint"
+      (let ((flycheck-yaml-actionlint-args '("-shellcheck=")))
+        (expect (flycheck-checker-substituted-arguments 'yaml-actionlint)
+                :to-contain "-shellcheck=")))))
 
 ;;; test-yaml.el ends here


### PR DESCRIPTION
From the optionless-checker sweep. oxlint had no knobs at all despite a rich flag surface, so there was no way to reach its rule categories or point it at a config file. It gets a config-file var, `--deny`/`--allow` lists and an args var; actionlint gets its `-config-file`; standard, jq and js-yaml get the usual args escape hatch.

Every new option defaults to nil, so the constructed command lines stay byte-identical until one is set. Verified the oxlint flags against the local binary.