### PR TITLE
Fix current version variable value

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -1508,7 +1508,7 @@ Only has effect when variable `global-flycheck-mode' is non-nil."
 
 
 
-(defconst flycheck-version "37.0"
+(defconst flycheck-version "39.0"
   "The current version of Flycheck.
 
 Should be kept in sync with the package version metadata.


### PR DESCRIPTION
Fixes the value of the `flyway-version` variable, which is currently outdated. The value of this variable is useful for scripts.