### PR TITLE
Call the development version 39.0-snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bugs fixed
 
+- [#2257](https://github.com/flycheck/flycheck/pull/2257): Fix the stale value of `flycheck-version`, which `M-x flycheck-version` reports when Flycheck was not installed as a package. Development builds now report `39.0-snapshot`.
 - [#2259](https://github.com/flycheck/flycheck/pull/2259): Stop marking every LSP diagnostic as fixable. A code-action fix is only fetched when applied, so Flycheck cannot know in advance that one exists, and marking it anyway replaced the familiar double-arrow indicator with the fix indicator on every diagnostic in an Eglot or `flycheck-lsp` buffer. The fix indicator, the error list's `[fix]` badge and the inline fix marker now appear only where a fix is known to exist; `C-c ! f` still asks the server on any diagnostic.
 - [#2259](https://github.com/flycheck/flycheck/pull/2259): Explain the mode-line indicator when no error counts sit behind it: `-`, `!`, `.` and `?` now say what they mean in a tooltip, and clicking one runs `flycheck-verify-setup` on the buffer.
 - [#2259](https://github.com/flycheck/flycheck/pull/2259): Replace the wall of text Flycheck printed to the echo area when it could not read a checker's output. A crashing linter, such as a misconfigured `python-flake8` printing a traceback, now produces one line naming the checker and pointing at `C-c ! v`, which shows what the checker actually printed. Flycheck no longer suggests filing a bug report against itself for what is nearly always a local setup problem.

--- a/Eask
+++ b/Eask
@@ -1,7 +1,7 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
 (package "flycheck"
-         "38.3"
+         "39.0-snapshot"
          "On-the-fly syntax checking")
 
 (website-url "https://github.com/flycheck/flycheck")

--- a/flycheck.el
+++ b/flycheck.el
@@ -10,7 +10,7 @@
 ;;             Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: https://github.com/flycheck/flycheck
 ;; Keywords: convenience, languages, tools
-;; Version: 38.3
+;; Version: 39.0-snapshot
 ;; Package-Requires: ((emacs "28.1") (seq "2.24"))
 
 ;; This file is not part of GNU Emacs.
@@ -1508,11 +1508,12 @@ Only has effect when variable `global-flycheck-mode' is non-nil."
 
 
 
-(defconst flycheck-version "39.0"
+(defconst flycheck-version "39.0-snapshot"
   "The current version of Flycheck.
 
-Should be kept in sync with the package version metadata.
-Used as fallback when `package-get-version' returns nil.")
+Kept in sync with the `Version' header and the Eask package version, which
+a spec enforces.  Used as fallback when `package-get-version' returns nil,
+which is the case when Flycheck was not installed as a package.")
 
 (defun flycheck--pkg-version ()
   "Extract FLYCHECK's package version from its package metadata."

--- a/test/specs/test-package-metadata.el
+++ b/test/specs/test-package-metadata.el
@@ -1,0 +1,62 @@
+;;; test-package-metadata.el --- Flycheck Specs: Package metadata -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Specs for Flycheck's own package metadata.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+(require 'test-helpers)
+(require 'lisp-mnt)
+
+(defun flycheck/version-header ()
+  "Return the `Version' header of flycheck.el."
+  (let ((file (expand-file-name "flycheck.el" flycheck-test-source-directory)))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (lm-header "version"))))
+
+(defun flycheck/eask-version ()
+  "Return the version the Eask file declares."
+  (let ((file (expand-file-name "Eask" flycheck-test-source-directory)))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (when (re-search-forward
+             (rx "(package" (1+ space) "\"flycheck\"" (1+ (any space "\n"))
+                 "\"" (group (1+ (not (any "\"")))) "\"")
+             nil 'noerror)
+        (match-string 1)))))
+
+(describe "Package metadata"
+
+  ;; `flycheck-version' is only a fallback for when Flycheck was not
+  ;; installed as a package, so nothing at runtime notices it going
+  ;; stale.  It sat at 37.0 through three releases before anyone did.
+  (it "declares the same version in flycheck.el, its header and Eask"
+    (expect (flycheck/version-header) :to-equal flycheck-version)
+    (expect (flycheck/eask-version) :to-equal flycheck-version))
+
+  (it "declares a version Emacs can compare"
+    (expect (ignore-errors (version-to-list flycheck-version))
+            :not :to-be nil)))
+
+;;; test-package-metadata.el ends here


### PR DESCRIPTION
`flycheck-version` claimed 37.0 for three releases, then jumped to 39.0 in #2257 while the header still said 38.3. Nothing at runtime reads it unless Flycheck was installed outside a package, which is why it drifted twice without anyone noticing.

The header, the Eask package version and the defconst now all say 39.0-snapshot, which sorts above 38.3 and below the eventual 39.0. There's a spec that fails when they disagree, so the release bump can't miss one again.