### PR TITLE
Chain the LSP bridges to each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Bugs fixed
 
+- [#2264](https://github.com/flycheck/flycheck/pull/2264): Make the two LSP bridges compose, so a lint server can run behind Eglot's server: with `flycheck-eglot-mode` and `flycheck-lsp-mode` both on and both `-exclusive` options nil, `eglot-check` now chains to `flycheck-lsp` and both report into the same error list. Previously each bridge chained only to a command checker and never to the other, so whichever mode enabled last silently won. Which of the two leads no longer depends on the order the modes enable in either.
 - [#2257](https://github.com/flycheck/flycheck/pull/2257): Fix the stale value of `flycheck-version`, which `M-x flycheck-version` reports when Flycheck was not installed as a package. Development builds now report `39.0-snapshot`.
 - [#2259](https://github.com/flycheck/flycheck/pull/2259): Stop marking every LSP diagnostic as fixable. A code-action fix is only fetched when applied, so Flycheck cannot know in advance that one exists, and marking it anyway replaced the familiar double-arrow indicator with the fix indicator on every diagnostic in an Eglot or `flycheck-lsp` buffer. The fix indicator, the error list's `[fix]` badge and the inline fix marker now appear only where a fix is known to exist; `C-c ! f` still asks the server on any diagnostic.
 - [#2259](https://github.com/flycheck/flycheck/pull/2259): Explain the mode-line indicator when no error counts sit behind it: `-`, `!`, `.` and `?` now say what they mean in a tooltip, and clicking one runs `flycheck-verify-setup` on the buffer.

--- a/doc/user/syntax-checkers.rst
+++ b/doc/user/syntax-checkers.rst
@@ -398,6 +398,23 @@ reported, the next checker of the sequence runs and its errors are reported,
 etc. until there are no more checkers in the sequence.  This sequence is called
 a *checker chain*.
 
+.. code-block:: text
+
+   python-mypy  ──▶  python-flake8  ──▶  (end of chain)
+        │                  │
+        ▼                  ▼
+     errors             errors           all reported together
+
+Each checker's errors are added to the ones already reported, so what you end
+up looking at is every checker's findings in one list, not just the last one's.
+
+A chain stops as soon as a checker has no next checker left to run.  At each
+step Flycheck takes the first entry of ``:next-checkers`` that fits: its error
+level has to match (see below) and the checker has to be usable in this buffer.
+An entry that doesn't fit is skipped rather than ending the chain, so a chain
+can name a checker that is only sometimes available and still reach the ones
+behind it.
+
 Some checker chains are already set up by default in Flycheck: e.g.,
 `emacs-lisp` will be followed by `emacs-lisp-checkdoc`, and `python-mypy` will
 be followed by `python-flake8`.

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -207,9 +207,10 @@ display, navigation and the error list:
 .. defcustom:: flycheck-eglot-exclusive
 
    When non-nil (the default), an Eglot buffer reports only the LSP server's
-   diagnostics.  Set to nil to have ``eglot-check`` chain to the first command
-   checker that supports the buffer's major mode, so an LSP server and a
-   command checker both contribute.
+   diagnostics.  Set to nil to have ``eglot-check`` chain onward: to
+   ``flycheck-lsp`` when that bridge is on as well, and then to the first
+   command checker that supports the buffer's major mode.  See
+   :ref:`flycheck-lsp-alongside-eglot`.
 
 When the server supports code actions, an Eglot diagnostic's ``quickfix``
 action is offered as a Flycheck fix: press ``C-c ! f`` on the error to apply it
@@ -314,6 +315,69 @@ In short: reach for ``flycheck-lsp-mode`` when you just want a linter that
 happens to speak LSP, and for ``flycheck-eglot-mode`` (see above) when you want
 a full language server whose diagnostics Flycheck should own.
 
+.. _flycheck-lsp-alongside-eglot:
+
+Eglot and a second server together
+----------------------------------
+
+The two are not an either/or.  The common case is a project where one server
+is the one you edit with and another only lints: Tailwind CSS alongside a
+TypeScript or HTML server, ESLint alongside ``typescript-language-server``, and
+so on.  Eglot runs the first, Flycheck runs the second, and both sets of
+diagnostics land in the same error list.
+
+Name the lint server for the mode and turn both bridges on:
+
+.. code-block:: elisp
+
+   ;; Eglot keeps doing completion, hover and rename, as always.
+   (add-to-list 'flycheck-lsp-servers
+                '(html-mode "tailwindcss-language-server" "--stdio"))
+
+   (setq flycheck-eglot-exclusive nil
+         flycheck-lsp-exclusive nil)
+   (global-flycheck-eglot-mode 1)
+   (global-flycheck-lsp-mode 1)
+
+Clearing the two ``exclusive`` options is what asks each bridge to chain onward
+instead of reporting alone.  With both on, the buffer runs:
+
+.. code-block:: text
+
+   eglot-check   ──▶   flycheck-lsp   ──▶   a command checker
+   (Eglot's server)    (Tailwind)           (if one fits the mode)
+        │                   │                      │
+        ▼                   ▼                      ▼
+     errors              errors                 errors
+                                          all in one error list
+
+Eglot leads because it is the full language server, and the order is fixed, so
+it does not matter which mode you enable first or which one connects first.
+
+Each step is skipped when it does not apply to the buffer.  Open a file Eglot
+does not manage and the chain starts at ``flycheck-lsp``; open one with no
+Tailwind server configured and ``eglot-check`` goes straight on to the command
+checker.  So the same configuration is fine to set globally.
+
+Leave either ``exclusive`` option at its default and that bridge reports on its
+own, ending the chain there.  That is the setting to reach for when you want
+just the one server's diagnostics.
+
+.. note::
+
+   ``flycheck-lsp-servers`` maps each major mode to a single server, so
+   Flycheck adds one lint server to a mode, not several.  Eglot's server plus
+   one lint server works; two lint servers on top of Eglot does not, yet.
+
+If you would rather not use the ``eglot-check`` bridge at all, and just have
+Eglot report through Flymake as it normally does while Flycheck runs the lint
+server, enable only ``global-flycheck-lsp-mode``.  To silence Eglot's Flymake
+diagnostics in that setup:
+
+.. code-block:: elisp
+
+   (add-to-list 'eglot-stay-out-of 'flymake)
+
 Configuring servers
 -------------------
 
@@ -363,9 +427,10 @@ Configuring servers
 .. defcustom:: flycheck-lsp-exclusive
 
    When non-nil (the default), a buffer reports only the language server's
-   diagnostics.  Set to nil to have ``flycheck-lsp`` chain to the first command checker
-   that supports the buffer's major mode, so the server and a command checker
-   both contribute.
+   diagnostics.  Set to nil to have ``flycheck-lsp`` chain to the first command
+   checker that supports the buffer's major mode, so the server and a command
+   checker both contribute.  See :ref:`flycheck-lsp-alongside-eglot` for running
+   it behind Eglot's server.
 
 .. defcustom:: flycheck-lsp-code-actions
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -10719,20 +10719,60 @@ fix is applied right after."
        :edits (mapcar #'flycheck-lsp--text-edit (append (cdar targets) nil))
        :tick (buffer-chars-modified-tick)))))
 
+(defconst flycheck-lsp--bridges '(eglot-check flycheck-lsp)
+  "The LSP bridge checkers, in the order they run when both are active.
+
+Eglot comes first because it is the full language server, with the
+single-purpose lint server behind it.  The order is fixed rather than
+decided by whichever mode happened to enable last, and it is what keeps
+the chaining acyclic: a bridge only ever chains forwards.")
+
+(defun flycheck-lsp--primary-bridge ()
+  "Return the bridge checker that should start the chain in this buffer.
+
+The first of `flycheck-lsp--bridges' whose mode is on, or nil when
+neither is.  Both bridges compute the buffer's checker with this, so
+enabling them in either order settles on the same one."
+  (seq-find (lambda (checker)
+              (pcase checker
+                ('eglot-check (flycheck-eglot--enabled-p))
+                ('flycheck-lsp (flycheck-lsp--enabled-p))))
+            flycheck-lsp--bridges))
+
+(defun flycheck-lsp--select-primary-bridge ()
+  "Point the buffer's `flycheck-checker' at `flycheck-lsp--primary-bridge'.
+
+Leave a checker the user selected by hand alone, and fall back to
+automatic selection once no bridge is left."
+  (when (or (null flycheck-checker)
+            (memq flycheck-checker flycheck-lsp--bridges))
+    (setq flycheck-checker (flycheck-lsp--primary-bridge))))
+
 (defun flycheck-lsp--register-checker (checker exclusive)
   "Teach CHECKER the current buffer's major mode and set up its chaining.
 
-With EXCLUSIVE non-nil, CHECKER is the buffer's sole checker; otherwise it
-chains to the first other checker that supports the mode, so an LSP
-backend and a command checker both contribute.  Shared by the `flycheck-lsp' and
-`eglot-check' bridges."
+With EXCLUSIVE non-nil, CHECKER reports alone.  Otherwise it chains to
+the bridges after it in `flycheck-lsp--bridges', so an Eglot server and a
+lint server both contribute, and then to the first command checker that
+supports the mode, so a command checker contributes too.
+
+Chaining to a bridge is safe whether or not that bridge is on in a given
+buffer: its predicate refuses the buffer, and Flycheck moves on to the
+next entry.  That matters because `next-checkers' is a property of the
+checker, shared by every buffer, while the modes are buffer-local.
+
+Shared by the `flycheck-lsp' and `eglot-check' bridges."
   (unless (flycheck-checker-supports-major-mode-p checker major-mode)
     (flycheck-add-mode checker major-mode))
-  (if exclusive
-      (setf (flycheck-checker-get checker 'next-checkers) nil)
+  ;; Rebuild from scratch, so enabling a mode repeatedly cannot pile up
+  ;; duplicate entries
+  (setf (flycheck-checker-get checker 'next-checkers) nil)
+  (unless exclusive
+    (dolist (bridge (cdr (memq checker flycheck-lsp--bridges)))
+      (flycheck-add-next-checker checker bridge 'append))
     (when-let* ((next (seq-find
                        (lambda (c)
-                         (and (not (eq c checker))
+                         (and (not (memq c flycheck-lsp--bridges))
                               (flycheck-checker-supports-major-mode-p c major-mode)))
                        flycheck-checkers)))
       (flycheck-add-next-checker checker next 'append))))
@@ -10825,9 +10865,13 @@ and `flycheck-eglot-mode' instead."
   "Whether the `flycheck-lsp' checker is the only checker or chains to others.
 
 When non-nil (the default), a buffer using `flycheck-lsp-mode' reports
-only the language server's diagnostics.  When nil, `flycheck-lsp' chains to the
-first other checker that supports the buffer's major mode, so the server
-and a command checker can both contribute.
+only the language server's diagnostics.  When nil, `flycheck-lsp' chains to
+the first command checker that supports the buffer's major mode, so the
+server and a command checker can both contribute.
+
+To run this server behind Eglot's rather than instead of it, turn
+`flycheck-eglot-mode' on as well and clear `flycheck-eglot-exclusive' too;
+Eglot leads and `flycheck-lsp' follows.
 
 Note that this takes effect globally when a buffer enables the mode: it is
 stored in `flycheck-lsp's chain, not per buffer."
@@ -11346,7 +11390,7 @@ Added to `kill-emacs-hook' the first time a server starts."
 A no-op unless the mode's server is configured and installed."
   (when (flycheck-lsp--available-command major-mode)
     (flycheck-lsp--register-checker 'flycheck-lsp flycheck-lsp-exclusive)
-    (setq flycheck-checker 'flycheck-lsp)
+    (flycheck-lsp--select-primary-bridge)
     ;; Give the recheck guard a real buffer-local binding, so the `let' that
     ;; sets it around a push-triggered check isolates to this buffer instead
     ;; of leaking a global value to others (see `flycheck-lsp--suppress-recheck').
@@ -11357,8 +11401,9 @@ A no-op unless the mode's server is configured and installed."
 (defun flycheck-lsp--disable ()
   "Undo `flycheck-lsp--enable' in the current buffer."
   (flycheck-lsp--close-buffer)
-  (when (eq flycheck-checker 'flycheck-lsp)
-    (setq flycheck-checker nil))
+  ;; Hand the buffer to the other bridge if it is still on, else back to
+  ;; automatic selection
+  (flycheck-lsp--select-primary-bridge)
   (when flycheck-mode
     (flycheck-buffer-deferred)))
 
@@ -11447,12 +11492,15 @@ feature off."
   "Whether `eglot-check' is the only checker or chains to others.
 
 When non-nil (the default), a buffer using `flycheck-eglot-mode' reports
-only Eglot's diagnostics.  When nil, `eglot-check' chains to the first
-other checker that supports the buffer's major mode, so an LSP server and
-a command checker can both contribute.
+only Eglot's diagnostics.  When nil, `eglot-check' chains onward: to
+`flycheck-lsp' in a buffer that also uses `flycheck-lsp-mode', so a lint
+server can run behind Eglot's, and then to the first command checker that
+supports the buffer's major mode.
 
 Note that this takes effect globally when a buffer enables the mode: it is
-stored in `eglot-check's chain, not per buffer."
+stored in `eglot-check's chain, not per buffer.  The chain is still safe
+in buffers that use only one of the bridges, because each checker's
+predicate refuses a buffer whose mode is off."
   :group 'flycheck
   :type 'boolean
   :safe #'booleanp
@@ -11622,7 +11670,7 @@ ORIG is the advised function; BEG, END and ARGS are its arguments."
   "Set up the current buffer to report Eglot diagnostics through Flycheck."
   (when (flycheck-eglot--available-p)
     (flycheck-lsp--register-checker 'eglot-check flycheck-eglot-exclusive)
-    (setq flycheck-checker 'eglot-check)
+    (flycheck-lsp--select-primary-bridge)
     ;; Suppress the recheck the synchronous report may fire; the trailing
     ;; `flycheck-buffer-deferred' triggers the first check instead.
     (let ((flycheck-eglot--suppress-recheck t))
@@ -11639,8 +11687,9 @@ ORIG is the advised function; BEG, END and ARGS are its arguments."
   "Undo `flycheck-eglot--enable' in the current buffer."
   (when (flycheck-eglot--available-p)
     (ignore-errors (eglot-flymake-backend #'ignore)))
-  (when (eq flycheck-checker 'eglot-check)
-    (setq flycheck-checker nil))
+  ;; Hand the buffer to the other bridge if it is still on, else back to
+  ;; automatic selection
+  (flycheck-lsp--select-primary-bridge)
   (setq flycheck-eglot--diagnostics nil)
   (when flycheck-mode
     (flycheck-buffer-deferred)))

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -211,4 +211,77 @@
           (advice-remove 'flymake-diagnostics
                          #'flycheck-eglot--flymake-diagnostics))))))
 
+(describe "Chaining the LSP bridges"
+  ;; Both bridges write to `flycheck-checker' and to checker properties
+  ;; shared by every buffer, so the order the modes happen to enable in
+  ;; must not decide what runs.
+  (defun test-bridges/with-both (order body)
+    "Enable both bridges in ORDER, then call BODY."
+    (flycheck-buttercup-with-temp-buffer
+      (text-mode)
+      (let ((flycheck-eglot-exclusive nil)
+            (flycheck-lsp-exclusive nil)
+            (flycheck-lsp-servers '((text-mode "true"))))
+        (cl-letf (((symbol-function 'eglot-managed-p) (lambda () t))
+                  ((symbol-function 'eglot-flymake-backend) #'ignore)
+                  ((symbol-function 'flycheck-mode) #'ignore)
+                  ((symbol-function 'flymake-mode) #'ignore)
+                  ((symbol-function 'flycheck-lsp--close-buffer) #'ignore)
+                  ((symbol-function 'flycheck-buffer-deferred) #'ignore))
+          (dolist (which order)
+            (pcase which
+              ('eglot (flycheck-eglot-mode 1))
+              ('lsp (flycheck-lsp-mode 1))))
+          (funcall body)
+          (flycheck-eglot-mode -1)
+          (flycheck-lsp-mode -1))
+        (advice-remove 'flymake-diagnostics
+                       #'flycheck-eglot--flymake-diagnostics))))
+
+  (it "starts from the same bridge whichever mode enabled last"
+    (dolist (order '((eglot lsp) (lsp eglot)))
+      (test-bridges/with-both
+       order (lambda () (expect flycheck-checker :to-be 'eglot-check)))))
+
+  (it "chains the leading bridge to the other one"
+    (test-bridges/with-both
+     '(eglot lsp)
+     (lambda ()
+       (expect (flycheck-checker-get 'eglot-check 'next-checkers)
+               :to-contain 'flycheck-lsp))))
+
+  (it "never chains backwards, which would loop forever"
+    (test-bridges/with-both
+     '(eglot lsp)
+     (lambda ()
+       (expect (flycheck-checker-get 'flycheck-lsp 'next-checkers)
+               :not :to-contain 'eglot-check))))
+
+  (it "does not pile up duplicate entries when a mode re-enables"
+    (test-bridges/with-both
+     '(eglot lsp eglot lsp)
+     (lambda ()
+       (let ((next (flycheck-checker-get 'eglot-check 'next-checkers)))
+         (expect (length next) :to-equal (length (delete-dups (copy-sequence next))))))))
+
+  (it "leaves a checker the user selected by hand alone"
+    (flycheck-buttercup-with-temp-buffer
+      (text-mode)
+      (setq flycheck-checker 'emacs-lisp)
+      (cl-letf (((symbol-function 'eglot-managed-p) (lambda () t))
+                ((symbol-function 'eglot-flymake-backend) #'ignore)
+                ((symbol-function 'flycheck-mode) #'ignore)
+                ((symbol-function 'flymake-mode) #'ignore)
+                ((symbol-function 'flycheck-buffer-deferred) #'ignore))
+        (flycheck-eglot-mode 1)
+        (expect flycheck-checker :to-be 'emacs-lisp)
+        (flycheck-eglot-mode -1))
+      (advice-remove 'flymake-diagnostics
+                     #'flycheck-eglot--flymake-diagnostics)))
+
+  (describe "flycheck-lsp--primary-bridge"
+    (it "is nil when neither bridge is on"
+      (flycheck-buttercup-with-temp-buffer
+        (expect (flycheck-lsp--primary-bridge) :to-be nil)))))
+
 ;;; test-eglot.el ends here


### PR DESCRIPTION
Clearing both `exclusive` options was meant to let an Eglot server and a lint server both report, which is what people are after when they want Tailwind's or ESLint's server next to the one they edit with. It didn't work: each bridge chained to the first other checker supporting the mode in `flycheck-checkers` order, and both bridges sit at the end of that list, so each found a command checker and never the other bridge. Whichever mode enabled last also won the buffer's checker, so the other was quietly dropped.

Now the bridges have a fixed order and each chains to the ones behind it before falling through to a command checker. Eglot leads, being the full language server. Fixing the order rather than deriving it from enable order is also what keeps this acyclic, since chaining both directions would loop forever.

The chain is a checker property shared by every buffer while the modes are buffer-local, which is fine: a bridge's predicate refuses a buffer whose mode is off and Flycheck skips to the next entry. A buffer with only one bridge behaves exactly as before.

Docs rewritten around the Tailwind case, with diagrams for chaining in general and for this setup. Supersedes #2263.