### PR TITLE
Rename flycheck-pylintrc to flycheck-pylint-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [#2251](https://github.com/flycheck/flycheck/pull/2251): Improve two stale defaults: `flycheck-gfortran-language-standard` now defaults to nil (GFortran's own default) instead of the 1995 standard, and `flycheck-phpcs-changed-git-base` defaults to `"main"` instead of `"trunk"`.
 - [#2252](https://github.com/flycheck/flycheck/pull/2252): Give the config-file options a single, consistent name scheme: the `…rc` variables (`flycheck-flake8rc`, `flycheck-rubocoprc`, `flycheck-stylelintrc`, and the rest) are renamed to a `…-config` suffix (`flycheck-flake8-config`, `flycheck-rubocop-config`, `flycheck-stylelint-config`, …), matching the newer checkers. The old names keep working as obsolete aliases.
 - [#2253](https://github.com/flycheck/flycheck/pull/2253): Pick more modern defaults when several checkers support a language: `python-ruff` is now preferred over `python-flake8`, `markdown-markdownlint-cli2` over `markdown-markdownlint-cli`, and `python-pyright` is reachable (ahead of `python-pycompile`) instead of a silent no-op. Reorder `flycheck-checkers` or use `flycheck-select-checker` to override.
+- [#2267](https://github.com/flycheck/flycheck/pull/2267): Rename `flycheck-pylintrc` to `flycheck-pylint-config`, the one config-file option [#2252](https://github.com/flycheck/flycheck/pull/2252) left on the old scheme. The old name keeps working as an obsolete alias.
 
 ## 38.3 (2026-07-29)
 

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1259,7 +1259,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
          A list of additional arguments passed to ``pylint``, for options such
          as ``--disable`` or ``--load-plugins``.
 
-      .. syntax-checker-config-file:: flycheck-pylintrc
+      .. syntax-checker-config-file:: flycheck-pylint-config
 
    .. syntax-checker:: python-pycompile
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -15637,8 +15637,10 @@ See URL `https://docs.astral.sh/ruff/'."
   :modes (python-mode python-ts-mode)
   :next-checkers ((warning . python-mypy)))
 
+(define-obsolete-variable-alias 'flycheck-pylintrc
+  'flycheck-pylint-config "39")
 (flycheck-def-config-file-var
-    flycheck-pylintrc python-pylint
+    flycheck-pylint-config python-pylint
     '("pylintrc" ".pylintrc" "pyproject.toml" "setup.cfg"))
 
 (flycheck-def-option-var flycheck-pylint-use-symbolic-id t python-pylint
@@ -15690,7 +15692,7 @@ See URL `https://www.pylint.org/'."
             (eval (flycheck-python-module-args 'python-pylint "pylint"))
             "--reports=n"
             "--output-format=json"
-            (config-file "--rcfile=" flycheck-pylintrc concat)
+            (config-file "--rcfile=" flycheck-pylint-config concat)
             (eval flycheck-pylint-args)
             ;; Need `source-inplace' for relative imports (e.g. `from .foo
             ;; import bar'), see https://github.com/flycheck/flycheck/issues/280

--- a/test/specs/languages/test-python.el
+++ b/test/specs/languages/test-python.el
@@ -66,7 +66,7 @@
 
   (describe "the python-pylint checker command"
     (it "appends flycheck-pylint-args"
-      (let ((flycheck-pylintrc nil)
+      (let ((flycheck-pylint-config nil)
             (flycheck-pylint-args '("--disable=C0114" "--jobs=2")))
         (let ((args (flycheck-checker-substituted-arguments 'python-pylint)))
           (expect args :to-contain "--disable=C0114")


### PR DESCRIPTION
The sweep that put the config-file options on a single `-config` suffix missed pylint's, so the one Python linter option most people touch stayed on the old scheme while flake8's, ruff's and mypy's moved. #2252's changelog entry claimed it covered the rest of them.

Old name stays as an obsolete alias, same as the others.