### PR TITLE
Build the manual without warnings, and keep it that way

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,4 +31,6 @@ jobs:
     - name: Build the manual
       run: |
         pip install -r doc/requirements.txt
-        make -C doc SPHINXOPTS=-n html
+        # -W matches `fail_on_warning' in .readthedocs.yaml, so a broken
+        # reference is caught here rather than on the published site
+        make -C doc SPHINXOPTS="-n -W --keep-going" html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,7 @@ sphinx:
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
-  # fail_on_warning: true
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:

--- a/doc/developer/developing.rst
+++ b/doc/developer/developing.rst
@@ -314,7 +314,7 @@ feedback to users; its output gets included when users invoke
 Finally, the ``shellcheck`` checker includes an error explainer, which opens the
 relevant page on the ShellCheck wiki when users run
 `flycheck-explain-error-at-point`.  It is built with
-`flycheck-error-explainer-from-url`, a helper that turns a URL format string
+``flycheck-error-explainer-from-url``, a helper that turns a URL format string
 keyed by the error ID into an explainer; many tools document their diagnostics
 online this way, so their checkers can define an explainer in a single line.
 
@@ -347,7 +347,7 @@ applies with ``C-c ! f`` (`flycheck-fix-error-at-point`), ``C-c ! F``
 ``:error-filter`` -- wherever you already build the error and have the fix data
 (a linter's suggested replacement, a SARIF ``fix``, an LSP code action).
 
-A fix is a `flycheck-fix`: a description and a list of `flycheck-fix-edit`
+A fix is a ``flycheck-fix``: a description and a list of ``flycheck-fix-edit``
 objects applied together as one undoable change.  Each edit replaces the region
 from one-based ``LINE``/``COLUMN`` to ``END-LINE``/``END-COLUMN`` with
 ``REPLACEMENT`` (an insertion has the two positions equal; a deletion has an
@@ -363,14 +363,14 @@ empty replacement):
                         :replacement ""))
           :tick (buffer-chars-modified-tick)))
 
-Set ``:tick`` to the buffer's `buffer-chars-modified-tick` when you build the
-fix: `flycheck-apply-fix` refuses to apply a fix if the buffer changed since,
+Set ``:tick`` to the buffer's ``buffer-chars-modified-tick`` when you build the
+fix: ``flycheck-apply-fix`` refuses to apply a fix if the buffer changed since,
 so stale positions can never silently corrupt the buffer.
 
 If computing the fix is expensive (an LSP code-action request, say), make
 ``:fix`` a *function* of one argument, the error, instead of a ready
-`flycheck-fix`.  Flycheck calls it only when the user applies the fix (see
-`flycheck-error-resolve-fix`), so a non-nil ``:fix`` still marks the error as
+``flycheck-fix``.  Flycheck calls it only when the user applies the fix (see
+``flycheck-error-resolve-fix``), so a non-nil ``:fix`` still marks the error as
 fixable without paying the cost up front.
 
 Related locations
@@ -379,7 +379,7 @@ Related locations
 When an error points at more than one place -- the earlier definition behind a
 "redefined" error, the borrow behind a Rust lifetime error -- attach the
 secondary places as the error's ``:relations``, a list of
-`flycheck-related-location` objects.  The user visits them with ``C-c ! j``
+``flycheck-related-location`` objects.  The user visits them with ``C-c ! j``
 (`flycheck-visit-related-location`), and they show up after the message in the
 echo area, Eldoc, the error list and the inline annotations.  A related
 location carries only a position and a message, and may live in another file:

--- a/doc/info.py
+++ b/doc/info.py
@@ -87,11 +87,16 @@ def expand_node_name(node):
 class HTMLXRefDB(object):
     """Cross-reference database for Info manuals."""
 
-    #: URLs of the htmlxref database of GNU Texinfo (split into two files
-    #: since late 2024)
-    XREF_URLS = [
-        'https://ftpmirror.gnu.org/texinfo/htmlxref.d/Texinfo_GNU.cnf',
-        'https://ftpmirror.gnu.org/texinfo/htmlxref.d/Texinfo_nonGNU.cnf',
+    #: Names of the htmlxref database files of GNU Texinfo (split into two
+    #: files since late 2024)
+    XREF_FILES = ['Texinfo_GNU.cnf', 'Texinfo_nonGNU.cnf']
+
+    #: Where to look for them.  ftpmirror redirects to a nearby mirror, which
+    #: is the polite default but is not always healthy, so fall back to the
+    #: canonical host.
+    XREF_BASE_URLS = [
+        'https://ftpmirror.gnu.org/gnu/texinfo/htmlxref.d',
+        'https://ftp.gnu.org/gnu/texinfo/htmlxref.d',
     ]
 
     #: Regular expression to parse entries from an xref DB
@@ -135,18 +140,44 @@ class HTMLXRefDB(object):
             return manual_url + filename + '.html#' + anchor
 
 
+def fetch_htmlxref():
+    """Download and parse the Texinfo htmlxref database.
+
+    Try each base URL in turn and return the first that yields any manuals.
+    Return None when none of them do, so that references resolve quietly
+    instead of warning once per reference about the same missing database.
+    """
+    for base_url in HTMLXRefDB.XREF_BASE_URLS:
+        combined = ''
+        for name in HTMLXRefDB.XREF_FILES:
+            try:
+                response = requests.get('{0}/{1}'.format(base_url, name),
+                                        timeout=30)
+                # A mirror that is unwell answers with an HTML error page,
+                # which parses to nothing at all rather than raising
+                response.raise_for_status()
+                combined += response.text + '\n'
+            except requests.exceptions.RequestException as error:
+                logger.info('htmlxref: %s/%s unavailable (%s)',
+                            base_url, name, error)
+        database = HTMLXRefDB.parse(combined)
+        if database.entries:
+            return database
+    return None
+
+
 def update_htmlxref(app):
     if not isinstance(getattr(app.env, 'info_htmlxref', None), HTMLXRefDB):
         logger.info('fetching Texinfo htmlxref database...')
-        try:
-            combined = ''
-            for url in HTMLXRefDB.XREF_URLS:
-                combined += requests.get(url).text + '\n'
-            app.env.info_htmlxref = HTMLXRefDB.parse(combined)
-        except requests.exceptions.ConnectionError:
-            logger.warning('Failed to load xref DB.  '
-                           'Info references will not be resolved')
-            app.env.info_htmlxref = None
+        database = fetch_htmlxref()
+        if database is None:
+            # Not a warning: the database lives on someone else's server, and
+            # a build that fails on warnings should fail for defects in the
+            # documentation, not because GNU's mirrors are having a bad day.
+            # Info references degrade to plain text when it cannot be had.
+            logger.info('No xref DB available.  '
+                        'Info references will not be resolved')
+        app.env.info_htmlxref = database
 
 
 def resolve_info_references(app, _env, refnode, contnode):

--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -110,8 +110,8 @@ customising:
 
 By default Flycheck documents the errors at point through Eldoc, alongside
 other Eldoc sources such as Eglot.  This honors your Eldoc customizations,
-e.g. `eldoc-echo-area-use-multiline-p` or alternative Eldoc frontends like
-`eldoc-box`.  The behaviour is entirely customisable:
+e.g. ``eldoc-echo-area-use-multiline-p`` or alternative Eldoc frontends like
+``eldoc-box``.  The behaviour is entirely customisable:
 
 .. defcustom:: flycheck-display-errors-function
 
@@ -125,7 +125,7 @@ Flycheck provides three built-in functions for this option:
 .. defun:: flycheck-display-errors-via-eldoc errors
 
    The default.  Errors at point are shown through Eldoc.  Messages too
-   long for the echo area (see `eldoc-echo-area-use-multiline-p`) can be
+   long for the echo area (see ``eldoc-echo-area-use-multiline-p``) can be
    read in full with :kbd:`M-x eldoc-doc-buffer`.
 
 .. defun:: flycheck-display-error-messages errors
@@ -235,7 +235,7 @@ Related locations
 Many errors point at more than one place.  A "redefined variable" error
 refers back to the first definition, a Rust lifetime error to the borrow that
 outlives it, and so on.  Language servers report these secondary locations as
-an LSP diagnostic's ``relatedInformation``; with :mode:`flycheck-eglot-mode`
+an LSP diagnostic's ``relatedInformation``; with :mode:`flycheck-eglot`
 Flycheck keeps them (Flymake, which shows Eglot's diagnostics, drops them).
 Other checkers can attach them too, through an error's ``relations`` slot.
 
@@ -243,7 +243,7 @@ Other checkers can attach them too, through an error's ``relations`` slot.
 
 Flycheck shows an error's related locations right after its message - in the
 echo area, through Eldoc, in the help-echo tooltip, and, with
-:mode:`flycheck-annotate-mode`, on their own lines below the code.  Each is a
+:mode:`flycheck-annotate`, on their own lines below the code.  Each is a
 ``↳`` line naming the place and its message.  In the :ref:`error list
 <flycheck-error-list>` an error that carries related locations is badged with
 ``↳N`` (how many), listed in the badge's tooltip.
@@ -262,7 +262,7 @@ Afterwards, step through the rest without prompting:
                 M-x flycheck-previous-related-location
 
    Visit the next (or previous) related location, cycling.  With
-   `repeat-mode` on, :kbd:`n` and :kbd:`p` keep walking.  With a prefix
+   ``repeat-mode`` on, :kbd:`n` and :kbd:`p` keep walking.  With a prefix
    argument, move that many locations.
 
 .. image:: /images/flycheck-related-locations.gif
@@ -280,7 +280,7 @@ Some checkers report a machine-applicable fix along with an error - the
 replacement text a tool like ``eslint --fix``, ``cargo clippy`` or a SARIF
 analyzer already computes.  Flycheck keeps that fix and can apply it for you.
 A fixable error gets a distinct fringe indicator, its ``[fix]`` marker in the
-error list, and, under :mode:`flycheck-annotate-mode`, a ``[fix]`` tag before
+error list, and, under :mode:`flycheck-annotate`, a ``[fix]`` tag before
 its inline message - like an editor's "fix available" lightbulb.
 
 A language server's fixes work differently: its ``quickfix`` code action is

--- a/doc/user/error-list.rst
+++ b/doc/user/error-list.rst
@@ -84,7 +84,7 @@ Press :kbd:`RET` on an error in another file to jump straight to it.
    checked again, since Flycheck cannot tell that another file changed without
    re-running a check.
 
-The project of a buffer is Emacs' project (see `project-current`) when one is
+The project of a buffer is Emacs' project (see ``project-current``) when one is
 found, and the checker's working directory otherwise.  The current scope is
 shown as ``[project]`` in the error list's mode line.
 
@@ -140,14 +140,14 @@ Tune error list display
 
 By default the error list pops up in a side window at the bottom of the frame,
 a quarter of the frame tall, like similar lists in contemporary IDEs.  Side
-windows are not affected by :kbd:`C-x 1` (`delete-other-windows`); dismiss the
+windows are not affected by :kbd:`C-x 1` (``delete-other-windows``); dismiss the
 error list with :kbd:`q` in its window instead.  You can change or disable
 this behavior:
 
 .. defcustom:: flycheck-error-list-display-buffer-action
 
-   The `display-buffer` action used to display the error list.  Set to ``nil``
-   to fall back to the default behavior of `display-buffer`, where the error
+   The ``display-buffer`` action used to display the error list.  Set to ``nil``
+   to fall back to the default behavior of ``display-buffer``, where the error
    list pops up at an arbitrary place wherever Emacs finds a window for it.
 
 Entries in the built-in option `display-buffer-alist` matching the error list

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -139,7 +139,7 @@ You can customise this behaviour with `flycheck-check-syntax-automatically`:
 .. defcustom:: flycheck-check-syntax-automatically-remote
 
    The same as `flycheck-check-syntax-automatically`, but for buffers visiting
-   remote files (see `file-remote-p`).  Checking a remote buffer spawns a
+   remote files (see ``file-remote-p``).  Checking a remote buffer spawns a
    process on the remote host over TRAMP, which is slow, so by default the
    change-driven triggers (``idle-change``, ``new-line`` and
    ``idle-buffer-switch``) are excluded and remote buffers are only checked on


### PR DESCRIPTION
Every cross-reference into the Emacs and Elisp manuals was a dead link. The Texinfo xref database gets fetched from `texinfo/htmlxref.d/`, which isn't where it lives - the real path has a `gnu/` in it. The wrong URL answered with a mirror error page, and an HTML error page parses to an empty database rather than raising, so all 21 references then warned that the manual couldn't be resolved. Fixing the path, falling back to the canonical host when the mirror is unwell, and checking the HTTP status restores 27 links.

The rest was markup. `:mode:` appends `-mode` to its target itself, so writing the mode name in full asked for `flycheck-eglot-mode-mode`. And a single-backtick reference to something Flycheck doesn't document - an Emacs built-in, or one of the fix API structs - can't resolve, so those became literals.

The build is now clean, so `fail_on_warning` is on and CI matches it with `-W`. One deliberate exception: failing to reach the xref database is logged, not warned. It's someone else's server, ftpmirror was 502ing today, and info references degrading to plain text shouldn't fail a build.

Worth noting separately: the fix and related-location APIs aren't formally documented, which is why those references had nothing to point at.