### PR TITLE
python-ruff correct config priority

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -15719,7 +15719,7 @@ Requires Flake8 3.0 or newer. See URL
                   (warning . python-mypy)))
 
 (flycheck-def-config-file-var flycheck-python-ruff-config python-ruff
-                              '("pyproject.toml" "ruff.toml" ".ruff.toml"))
+                              '(".ruff.toml" "ruff.toml" "pyproject.toml"))
 
 (flycheck-def-args-var flycheck-python-ruff-args python-ruff
   :package-version '(flycheck . "39"))

--- a/flycheck.el
+++ b/flycheck.el
@@ -15718,6 +15718,8 @@ Requires Flake8 3.0 or newer. See URL
   :next-checkers ((warning . python-pylint)
                   (warning . python-mypy)))
 
+;; same precedence as ruff when multiple configuration file detected
+;; https://docs.astral.sh/ruff/configuration/#config-file-discovery
 (flycheck-def-config-file-var flycheck-python-ruff-config python-ruff
                               '(".ruff.toml" "ruff.toml" "pyproject.toml"))
 


### PR DESCRIPTION
All of the above rules apply equivalently to pyproject.toml, ruff.toml, and .ruff.toml files. If Ruff detects multiple configuration files in the same directory, the .ruff.toml file will take precedence over the ruff.toml file, and the ruff.toml file will take precedence over the pyproject.toml file.

source: https://docs.astral.sh/ruff/configuration/#config-file-discovery