### PR TITLE
Read rebar3 and the Emacs 31 byte compiler again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@
 
 ### Bugs fixed
 
+- [#2297](https://github.com/flycheck/flycheck/pull/2297): Read rebar3's diagnostics again. rebar3 3.24 replaced `file:line:column: message` with a box drawn around the offending line, which none of the patterns matched, so `erlang-rebar3` has been reporting nothing since. The mark under the offending line says which column it means, so the column survives. Older rebar3's plain output is still read.
 - [#2297](https://github.com/flycheck/flycheck/pull/2297): Read a parse error from the byte compiler on Emacs 31 and newer, which goes on to name the buffer it was reading and so no longer matched.
+- [#2297](https://github.com/flycheck/flycheck/pull/2297): Point the `rst` checker at `rst2pseudoxml`. Docutils 0.21 dropped the `.py` from its front ends, so `rst2pseudoxml.py` has not existed since April 2024 and the checker had nothing to run.
 - [#2289](https://github.com/flycheck/flycheck/pull/2289): Report `check-declare` warnings again on Emacs 29 and newer. Emacs 29 put the whole warning on one line where earlier versions broke it across two, which the pattern did not allow, so `flycheck-emacs-lisp-check-declare` has been finding nothing since.
 - [#2289](https://github.com/flycheck/flycheck/pull/2289): Stop byte-compiling and checkdoc'ing `Eask` files, which hold data rather than code. The list of such files still named only Cask and Carton, and the `Eldev` exclusion beside it compared a whole path against a bare file name, so it never applied either.
 - [#2289](https://github.com/flycheck/flycheck/pull/2289): Drop the program name jq 1.7 puts in front of its diagnostics, so a `json-jq` message reads `Expected value before ','` rather than `jq: parse error: Expected value before ','`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Bugs fixed
 
+- [#2297](https://github.com/flycheck/flycheck/pull/2297): Read a parse error from the byte compiler on Emacs 31 and newer, which goes on to name the buffer it was reading and so no longer matched.
 - [#2289](https://github.com/flycheck/flycheck/pull/2289): Report `check-declare` warnings again on Emacs 29 and newer. Emacs 29 put the whole warning on one line where earlier versions broke it across two, which the pattern did not allow, so `flycheck-emacs-lisp-check-declare` has been finding nothing since.
 - [#2289](https://github.com/flycheck/flycheck/pull/2289): Stop byte-compiling and checkdoc'ing `Eask` files, which hold data rather than code. The list of such files still named only Cask and Carton, and the `Eldev` exclusion beside it compared a whole path against a bare file name, so it never applied either.
 - [#2289](https://github.com/flycheck/flycheck/pull/2289): Drop the program name jq 1.7 puts in front of its diagnostics, so a `json-jq` message reads `Expected value before ','` rather than `jq: parse error: Expected value before ','`.

--- a/flycheck.el
+++ b/flycheck.el
@@ -13502,6 +13502,9 @@ See Info Node `(elisp)Byte Compilation'."
                             (zero-or-more not-newline))))
           (optional "," (zero-or-more whitespace) line
                     "," (zero-or-more whitespace) column)
+          ;; Emacs 31 goes on to name the buffer it was reading, which is
+          ;; always the compiler's own and tells nobody anything
+          (optional ":" (zero-or-more not-newline))
           line-end)
    (warning line-start (file-name) ":" line ":" column ":"
             (zero-or-more whitespace) "Warning:" (zero-or-more whitespace)

--- a/flycheck.el
+++ b/flycheck.el
@@ -13796,10 +13796,61 @@ directory name is \"test\" or \"eqc\", or else \"default\"."
                           (file-name-directory buffer-file-name)))))
    "default"))
 
+(defconst flycheck-rebar3--diagnostic-rx
+  (rx line-start (zero-or-more " ") "┌─ " (group (one-or-more (not (any "\n"))))
+      ":" (zero-or-more " ") "\n"
+      ;; The empty gutter line above the source
+      (zero-or-more " ") "│" (zero-or-more " ") "\n"
+      ;; The offending line, echoed after its number
+      (zero-or-more " ") (group (one-or-more digit)) " │"
+      (group (zero-or-more " ")) (zero-or-more (not (any "\n"))) "\n"
+      ;; And the message, under a mark sitting at the column it means
+      (zero-or-more " ") "│" (group (zero-or-more " ")) "╰"
+      (one-or-more "─") " " (group (one-or-more (not (any "\n")))))
+  "Matches one diagnostic in the format rebar3 3.24 introduced.")
+
+(defun flycheck-parse-rebar3--boxed (output checker buffer)
+  "Parse the diagnostics rebar3 draws in a box out of OUTPUT.
+
+CHECKER and BUFFER are as in `flycheck-parse-output'.
+
+The mark under the offending line is what says which column the
+diagnostic is about, so the column is the distance between that
+mark and the start of the echoed source."
+  (let (errors (start 0))
+    (while (string-match flycheck-rebar3--diagnostic-rx output start)
+      (setq start (match-end 0))
+      (let* ((file (match-string 1 output))
+             (line (string-to-number (match-string 2 output)))
+             (source-indent (length (match-string 3 output)))
+             (mark-indent (length (match-string 4 output)))
+             (message (match-string 5 output))
+             (warningp (string-prefix-p "Warning: " message)))
+        (push (flycheck-error-new-at
+               line
+               (max 1 (1+ (- mark-indent source-indent)))
+               (if warningp 'warning 'error)
+               (if warningp (substring message (length "Warning: ")) message)
+               :checker checker :buffer buffer :filename file)
+              errors)))
+    (nreverse errors)))
+
+(defun flycheck-parse-rebar3 (output checker buffer)
+  "Parse rebar3's OUTPUT, in either of the two shapes it comes in.
+
+CHECKER and BUFFER are as in `flycheck-parse-output'.
+
+rebar3 3.24 replaced `file:line:column: message' with a box drawn
+around the offending line.  Older rebar3 is still about, so the
+plain form is still read when the boxed one finds nothing."
+  (let ((plain (ansi-color-filter-apply output)))
+    (or (flycheck-parse-rebar3--boxed plain checker buffer)
+        (flycheck-parse-with-patterns plain checker buffer))))
+
 (flycheck-define-checker erlang-rebar3
   "An Erlang syntax checker using the rebar3 build tool."
   :command ("rebar3" "as" (eval (flycheck-erlang-rebar3-get-profile)) "compile")
-  :error-parser flycheck-parse-with-patterns-without-color
+  :error-parser flycheck-parse-rebar3
   :error-patterns
   ((warning line-start (file-name) ":" line ":" (optional column ":")
             " Warning:" (message) line-end)

--- a/test/fixtures/erlang-rebar3/erlang-error.erl.txt
+++ b/test/fixtures/erlang-rebar3/erlang-error.erl.txt
@@ -1,0 +1,19 @@
+[0;32m===> Verifying dependencies...
+[0m[0;32m===> App dependency is a checkout dependency and cannot be locked.
+[0m[0;32m===> Analyzing applications...
+[0m[0;32m===> Compiling dependency
+[0m[0;32m===> Analyzing applications...
+[0m[0;32m===> Compiling erlang-rebar3
+[0m[0;31m===> [1mCompiling src/erlang-error.erl failed
+[0m[0m   ┌─ src/erlang-error.erl:
+   │
+ 7 │  [1;31merror_func[0m() ->[0m
+   │  [1;31m╰──[0m[0m head mismatch: previous function great_func/0 is distinct from error_func/0. Is the semicolon in great_func/0 unwanted?
+
+
+   ┌─ src/erlang-error.erl:
+   │
+ 3 │  -[1;31mcompile[0m(export_all).[0m
+   │   [1;31m╰──[0m[0m Warning: export_all flag enabled - all functions will be exported
+
+

--- a/test/specs/languages/test-erlang.el
+++ b/test/specs/languages/test-erlang.el
@@ -25,27 +25,25 @@
                                     " list, but the argument list contains 1 argument")
               :checker erlang))))
 
-  ;; rebar3 3.24 replaced its compiler diagnostics with a rich format that
-  ;; draws a box around the offending line and colours it, so the file name,
-  ;; the line number and the message each land on a line of their own with
-  ;; escape sequences in between, and none of the patterns match any more.
-  ;; `{compiler_error_format, minimal}' in rebar.config restores the old
-  ;; `file:line:column: message' output, but only the project can set that.
   (flycheck-buttercup-def-checker-test erlang-rebar3 erlang error
-    :expected-result :failed
     (let ((col (flycheck-buttercup-erlang-shows-column 'erlang-rebar3)))
       (flycheck-buttercup-should-syntax-check
        "language/erlang/rebar3/src/erlang-error.erl" 'erlang-mode
        `(3 ,(when col 2) warning "export_all flag enabled - all functions will be exported" :checker erlang-rebar3)
-       `(7 ,(when col 1) error "head mismatch" :checker erlang-rebar3))))
+       `(7 ,(when col 1) error ,(concat "head mismatch: previous function great_func/0 is"
+                        " distinct from error_func/0. Is the semicolon in"
+                        " great_func/0 unwanted?")
+           :checker erlang-rebar3))))
 
   (flycheck-buttercup-def-checker-test erlang-rebar3 erlang build
-    :expected-result :failed
     (let ((col (flycheck-buttercup-erlang-shows-column 'erlang-rebar3)))
       (shut-up
         (flycheck-buttercup-should-syntax-check
          "language/erlang/rebar3/_checkouts/dependency/src/dependency.erl" 'erlang-mode
-         `(7 ,(when col 1) error "head mismatch" :checker erlang-rebar3
+         `(7 ,(when col 1) error ,(concat "head mismatch: previous function great_func/0 is"
+                        " distinct from error_func/0. Is the semicolon in"
+                        " great_func/0 unwanted?")
+             :checker erlang-rebar3
              :filename ,(flycheck-buttercup-resource-filename "language/erlang/rebar3/src/erlang-error.erl"))))
       (expect (not (file-exists-p
                     (flycheck-buttercup-resource-filename
@@ -64,6 +62,9 @@
 
     (flycheck-buttercup-def-parse-test erlang "language/erlang/erlang/error.erl"
       '(7 1 error "head mismatch")
+      '(3 2 warning "export_all flag enabled - all functions will be exported"))
+    (flycheck-buttercup-def-parse-test erlang-rebar3 "language/erlang/rebar3/src/erlang-error.erl"
+      '(7 1 error "head mismatch: previous function great_func/0 is distinct from error_func/0. Is the semicolon in great_func/0 unwanted?")
       '(3 2 warning "export_all flag enabled - all functions will be exported"))))
 
 ;;; test-erlang.el ends here


### PR DESCRIPTION
The two checkers that were reporting nothing.

rebar3 3.24 replaced `file:line:column: message` with a box drawn around the offending line, so the file name, the line number and the message each land on a line of their own and none of the patterns matched. The mark under the offending line is what says which column the diagnostic is about, so the column comes from the distance between that mark and the start of the echoed source rather than being lost. Older rebar3's plain output is still read when the boxed form finds nothing. The two specs for this were marked expected-failing when the breakage was found and pass now, and there is a recording of the boxed format so the parsing is asserted without rebar3 installed.

The byte compiler on Emacs 31 goes on to name the buffer it was reading, so the line reads `End of file during parsing:  *Compiler Input*` and stopped matching a pattern that wanted the end of the line right after the message. That is what has been failing the snapshot jobs. Checked against Emacs 30 and 32 in containers: both report the same error at the same place now, which is what the spec already expected of anything past 28. The buffer name stays out of the message.