### PR TITLE
Write down how a checker gets tested

### DIFF
--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -123,6 +123,10 @@ Record the output on a machine that has the tool, commit it, and the spec runs
 for everyone.  When a tool changes its format, re-record and the diff shows
 exactly what moved.
 
+:ref:`Testing your checker <flycheck-testing-a-checker>` in the developer's
+guide covers this from the other end, for somebody adding a checker rather than
+maintaining one, and lists the mistakes that keep being made.
+
 The catch is that a recording says what the tool printed on the day it was
 made, and the spec reading it keeps passing whatever the tool does afterwards.
 ``make verify-fixtures`` closes that: it runs the tools that are installed and

--- a/doc/contributor/style-guide.rst
+++ b/doc/contributor/style-guide.rst
@@ -116,8 +116,19 @@ Tests
   :file:`test/specs/`.  Check whether the specs fit into an existing spec file,
   or add a new file instead.  In doubt, use a new file.
 
-* For new syntax checkers add at least one syntax checker test to
-  :file:`test/specs/languages/`.
+* For a new syntax checker, add both kinds of spec to
+  :file:`test/specs/languages/`: a ``flycheck-buttercup-def-parse-test``
+  reading output recorded from the tool, and a
+  ``flycheck-buttercup-def-checker-test`` running the tool itself.  Only the
+  second needs the tool installed, which is why the first is the one that keeps
+  the checker honest on everybody else's machine.  :ref:`Testing your checker
+  <flycheck-testing-a-checker>` walks through it, including how to record the
+  output and what not to assert.
+
+* Do not assert on anything the machine decides: a tool's version, which
+  compiler answers to a name, or which quotes it prints around a symbol.  Those
+  differ between contributors and between CI runners, and a spec that pins them
+  fails for people who changed nothing.
 
 Documentation
 =============

--- a/doc/developer/developing.rst
+++ b/doc/developer/developing.rst
@@ -391,6 +391,74 @@ location carries only a position and a message, and may live in another file:
                 :filename "other.rb" :line 12 :column 3
                 :message "first defined here")))
 
+.. _flycheck-testing-a-checker:
+
+Testing your checker
+--------------------
+
+A checker is three separable things: the command Flycheck builds, the output the
+tool prints, and the errors Flycheck reads back out of it.  Only the middle one
+needs the tool installed, and that matters more than it sounds: Flycheck drives
+over a hundred different programs, nobody has them all, and a spec that needs a
+missing tool skips itself.  A checker whose parsing breaks would then go red
+nowhere.
+
+So the parsing is tested against output recorded from the tool, which runs
+everywhere:
+
+.. code-block:: elisp
+
+   (flycheck-buttercup-def-parse-test json-jq "language/json.json"
+     '(1 44 error "Expected value before ','"))
+
+Record that output with :file:`test/record-fixture.el`, on a machine that has
+the tool:
+
+.. code-block:: console
+
+   $ emacs -Q --batch -l test/record-fixture.el \
+       -f flycheck-record-fixture-batch json-jq language/json.json
+
+It runs the checker's own command, substituted the way a real check substitutes
+it, and writes what the tool printed to
+:file:`test/fixtures/{checker}/{resource}.txt`.  Commit that alongside the spec.
+If you do not have the tool, ``make record-fixtures`` records in a container
+that has most of them; see :ref:`the contributor's guide
+<flycheck-recorded-output>`.
+
+Add a live check as well, which runs the real tool where it is installed and
+skips where it is not:
+
+.. code-block:: elisp
+
+   (flycheck-buttercup-def-checker-test json-jq json nil
+     (flycheck-buttercup-should-syntax-check
+      "language/json.json" 'json-mode
+      '(1 44 error "Expected value before ','" :checker json-jq)))
+
+Both go in :file:`test/specs/languages/`, in the file for the language.
+
+A few things are worth knowing before you write the expectations, because each
+of them has bitten us:
+
+* **Name the checker under test.**  ``(flycheck-checkers '(your-checker))`` beats
+  disabling the others, which silently stops covering anything the day somebody
+  adds a checker for the same language ahead of yours.
+
+* **Do not assert what the machine decides.**  Tool versions word things
+  differently, GCC quotes with ``‘…’`` where Clang uses ``'…'``, and the name
+  ``gcc`` belongs to Clang on macOS.  Ask the version, the way the Erlang and
+  Ruby specs do, or let the recorded output carry it.
+
+* **The skip guard tests the name you give it.**  Name a checker that does not
+  exist and it guards nothing, so the spec runs with the tool missing and fails
+  for a reason that has nothing to do with your change.  There is a spec that
+  checks this, and one that checks no recording is left behind by a rename.
+
+* **An interpreter is not a linter.**  A checker that runs ``python3 -m flake8``
+  has ``python3`` for an executable, and finding it says nothing about flake8
+  being installed.  Ask whether the module imports.
+
 Sharing your checker
 --------------------
 


### PR DESCRIPTION
The developer's guide has a section on adding a checker that stopped short of how to test one, and the style guide asked for "at least one syntax checker test" — which is no longer what we want, since that spec skips itself on every machine without the tool.

So: what the two kinds of spec are for, how to record a tool's output, and the four mistakes that keep coming up. Disabling the other checkers instead of naming yours, which stops covering anything the day somebody adds a checker for the same language ahead of it. Asserting something the machine decides, like a tool version or which compiler answers to the name `gcc`. Naming a checker that doesn't exist, so the skip guard guards nothing. And mistaking an interpreter for the linter it runs.

Mostly so there's something to point a pull request at instead of explaining it again each time.