### PR TITLE
Fix two annotation display bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Bugs fixed
 
+- [#2299](https://github.com/flycheck/flycheck/pull/2299): Show an annotation straight away when you jump to an error, rather than on the next thing you do ([#2293](https://github.com/flycheck/flycheck/issues/2293)). Annotations are built for the visible part of the buffer from `post-command-hook`, which runs before redisplay, so a jump that sends point off screen was building them while the window still described where it had been.
 - [#2299](https://github.com/flycheck/flycheck/pull/2299): Keep a `sideline` annotation off the column the continuation glyph needs, so a message that fits stops spilling onto the next line by one character ([#2292](https://github.com/flycheck/flycheck/issues/2292)). Without a right fringe to draw that glyph in, as on a terminal, the rightmost column is not text's to use.
 - [#2297](https://github.com/flycheck/flycheck/pull/2297): Read rebar3's diagnostics again. rebar3 3.24 replaced `file:line:column: message` with a box drawn around the offending line, which none of the patterns matched, so `erlang-rebar3` has been reporting nothing since. The mark under the offending line says which column it means, so the column survives. Older rebar3's plain output is still read.
 - [#2297](https://github.com/flycheck/flycheck/pull/2297): Read a parse error from the byte compiler on Emacs 31 and newer, which goes on to name the buffer it was reading and so no longer matched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Bugs fixed
 
+- [#2299](https://github.com/flycheck/flycheck/pull/2299): Keep a `sideline` annotation off the column the continuation glyph needs, so a message that fits stops spilling onto the next line by one character ([#2292](https://github.com/flycheck/flycheck/issues/2292)). Without a right fringe to draw that glyph in, as on a terminal, the rightmost column is not text's to use.
 - [#2297](https://github.com/flycheck/flycheck/pull/2297): Read rebar3's diagnostics again. rebar3 3.24 replaced `file:line:column: message` with a box drawn around the offending line, which none of the patterns matched, so `erlang-rebar3` has been reporting nothing since. The mark under the offending line says which column it means, so the column survives. Older rebar3's plain output is still read.
 - [#2297](https://github.com/flycheck/flycheck/pull/2297): Read a parse error from the byte compiler on Emacs 31 and newer, which goes on to name the buffer it was reading and so no longer matched.
 - [#2297](https://github.com/flycheck/flycheck/pull/2297): Point the `rst` checker at `rst2pseudoxml`. Docutils 0.21 dropped the `.py` from its front ends, so `rst2pseudoxml.py` has not existed since April 2024 and the checker had nothing to run.

--- a/flycheck.el
+++ b/flycheck.el
@@ -8226,6 +8226,9 @@ FOCUSED is ignored."
   (flycheck-annotate--make-overlay
    anchor (concat "  " (flycheck-annotate--compact-text errors))))
 
+(defun flycheck-annotate--reserved-columns ()
+  "Columns at the right edge that text must not be aligned into.
+
 (defun flycheck-annotate-sideline-style (errors anchor _focused)
   "Render ERRORS flushed to the window's right edge past line ANCHOR.
 
@@ -8234,7 +8237,7 @@ a stretch of whitespace, in the manner of `lsp-ui-sideline'.  When the
 code on the line is too long to leave room, the message simply follows it
 instead.  FOCUSED is ignored."
   (let* ((text (flycheck-annotate--compact-text errors))
-         (width (string-width text))
+         (width (+ (string-width text) (flycheck-annotate--reserved-columns)))
          (spacer (propertize " " 'display `(space :align-to (- right ,width)))))
     (flycheck-annotate--make-overlay anchor (concat spacer text))))
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -8229,6 +8229,13 @@ FOCUSED is ignored."
 (defun flycheck-annotate--reserved-columns ()
   "Columns at the right edge that text must not be aligned into.
 
+Without a right fringe to draw it in, the rightmost column belongs to
+the glyph marking a line that continues or was truncated, so text
+flush against `right' lands in it and spills onto the next line.  A
+terminal has no fringes; a graphical frame can have had them turned
+off just the same."
+  (if (zerop (or (nth 1 (window-fringes)) 0)) 1 0))
+
 (defun flycheck-annotate-sideline-style (errors anchor _focused)
   "Render ERRORS flushed to the window's right edge past line ANCHOR.
 
@@ -8438,6 +8445,29 @@ once per change."
                (eql (buffer-chars-modified-tick) flycheck-annotate--last-tick))
     (flycheck-annotate--refresh)))
 
+(defvar-local flycheck-annotate--rebuilding nil
+  "Whether a rebuild is already under way in this buffer.")
+
+(defun flycheck-annotate--after-scroll (window _start)
+  "Rebuild the overlays for WINDOW after it scrolled.
+
+`post-command-hook' runs before redisplay, so a command that sends
+point off screen has not scrolled the window by the time the overlays
+are rebuilt: `window-start' still describes where the window was, and
+the line being jumped to is not part of what looks visible.  Nothing
+is annotated, and nothing rebuilds it until the next command happens
+to come along.  See #2293.
+
+Scrolling is reported during redisplay instead, which is late enough
+to know where the window ended up."
+  (when (and (window-live-p window)
+             (eq (window-buffer window) (current-buffer))
+             (not flycheck-annotate--rebuilding))
+    (let ((flycheck-annotate--rebuilding t))
+      ;; Laying out an annotation can scroll the window again, and this
+      ;; runs inside redisplay, so guard against coming back round
+      (flycheck-annotate--post-command))))
+
 (defun flycheck-annotate--suppresses-echo-p ()
   "Return non-nil when inline display covers the at-point echo message.
 
@@ -8481,11 +8511,13 @@ annotated on the next command."
   (cond
    (flycheck-annotate-mode
     (add-hook 'post-command-hook #'flycheck-annotate--post-command nil t)
+    (add-hook 'window-scroll-functions #'flycheck-annotate--after-scroll nil t)
     (add-hook 'flycheck-after-syntax-check-hook
               #'flycheck-annotate--refresh nil t)
     (flycheck-annotate--refresh))
    (t
     (remove-hook 'post-command-hook #'flycheck-annotate--post-command t)
+    (remove-hook 'window-scroll-functions #'flycheck-annotate--after-scroll t)
     (remove-hook 'flycheck-after-syntax-check-hook
                  #'flycheck-annotate--refresh t)
     (flycheck-annotate--clear))))

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -587,6 +587,58 @@ a newline, so key it back under the code line."
                      (point-min) (line-end-position))
                     :to-equal "codeX")))))
 
+    (it "rebuilds when the window scrolls"
+      ;; `post-command-hook' runs before redisplay, so a jump that sends
+      ;; point off screen rebuilds while `window-start' still describes
+      ;; where the window was, and the line jumped to is not yet part of
+      ;; what looks visible.  Scrolling has to rebuild too.  See #2293.
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (dotimes (i 400) (ignore i) (insert "a line of code\n"))
+          (setq-local flycheck-mode t)
+          (let ((e (flycheck-error-new-at 380 1 'error "far away"
+                                          :buffer (current-buffer)
+                                          :checker 'emacs-lisp)))
+            (setq flycheck-current-errors (list e))
+            (mapc #'flycheck-add-overlay flycheck-current-errors))
+          (goto-char (point-min))
+          (let ((flycheck-annotate-current-line-style 'eol)
+                (flycheck-annotate-other-lines-style 'eol))
+            (flycheck-annotate-mode 1)
+            ;; Nothing is annotated while the error is far off screen
+            (expect (seq-filter #'test-annotate/text flycheck-annotate--overlays)
+                    :to-be nil)
+            ;; Jump there without redisplay, the way a command does
+            (goto-char (point-min))
+            (forward-line 379)
+            (flycheck-annotate--post-command)
+            ;; The window has not scrolled yet, so this found nothing
+            (expect (seq-filter #'test-annotate/text flycheck-annotate--overlays)
+                    :to-be nil)
+            ;; Redisplay scrolls and reports it, which is what rebuilds
+            (set-window-start (selected-window) (line-beginning-position))
+            (flycheck-annotate--after-scroll (selected-window) (window-start))
+            (expect (seq-filter #'test-annotate/text flycheck-annotate--overlays)
+                    :to-be-truthy)
+            (flycheck-annotate-mode -1)))))
+
+    (it "does not rebuild from inside its own rebuild"
+      ;; Laying out an annotation can scroll the window, and the scroll hook
+      ;; runs during redisplay, so it has to refuse to come back round
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (insert "abcdef\n")
+          (setq-local flycheck-mode t)
+          (let ((calls 0))
+            (cl-letf (((symbol-function 'flycheck-annotate--post-command)
+                       (lambda () (cl-incf calls)
+                         (flycheck-annotate--after-scroll
+                          (selected-window) (window-start)))))
+              (flycheck-annotate--after-scroll (selected-window) (window-start))
+              (expect calls :to-equal 1))))))
+
     (it "rebuilds after an edit that leaves point on its line"
       ;; An edit such as `open-line' changes the buffer without moving point
       ;; off its line or scrolling the window, so the line/window check alone

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -316,7 +316,37 @@ a newline, so key it back under the code line."
           ;; the leading char is a right-aligning stretch of whitespace
           (expect (car (get-text-property 0 'display s)) :to-be 'space)
           (expect (get-text-property 0 'display s)
-                  :to-equal '(space :align-to (- right 8)))))) ; width of "big (+1)"
+                  :to-equal
+                  ;; the width of "big (+1)", plus whatever the right edge
+                  ;; reserves where this spec is running
+                  `(space :align-to
+                          (- right ,(+ 8 (flycheck-annotate--reserved-columns))))))))
+
+    (it "keeps off the column the continuation glyph needs"
+      ;; Aligned flush to `right' with no fringe to draw the glyph in, the
+      ;; last character lands in the column it needs and wraps.  See #2292.
+      (flycheck-buttercup-with-temp-buffer
+        (insert "abcdef\n")
+        (let* ((errs (list (flycheck-error-new-at 1 1 'error "hi"
+                                                  :checker 'emacs-lisp)))
+               (flycheck-annotate--overlays nil))
+          (cl-letf (((symbol-function 'window-fringes) (lambda (&rest _) '(8 8 nil nil))))
+            (expect (flycheck-annotate--reserved-columns) :to-equal 0)
+            (expect (get-text-property
+                     0 'display
+                     (test-annotate/text
+                      (flycheck-annotate-sideline-style
+                       errs (line-end-position) nil)))
+                    :to-equal '(space :align-to (- right 2))))
+          (setq flycheck-annotate--overlays nil)
+          (cl-letf (((symbol-function 'window-fringes) (lambda (&rest _) '(0 0 nil nil))))
+            (expect (flycheck-annotate--reserved-columns) :to-equal 1)
+            (expect (get-text-property
+                     0 'display
+                     (test-annotate/text
+                      (flycheck-annotate-sideline-style
+                       errs (line-end-position) nil)))
+                    :to-equal '(space :align-to (- right 3)))))))
 
     (it "is registered as a built-in style"
       (expect (cdr (assq 'sideline flycheck-annotate-style-functions))


### PR DESCRIPTION
Both reported by @siebenmann yesterday, both in `flycheck-annotate-mode`.

Annotations are built for the visible part of the buffer from `post-command-hook`, which runs before redisplay. A command that sends point off screen therefore builds them while `window-start` still describes where the window was, so the line being jumped to does not look visible and nothing gets annotated — and nothing rebuilds it until the next command happens along, which is why moving the cursor made it appear. Scrolling is reported during redisplay instead, which is late enough to know where the window ended up. Laying out an annotation can scroll the window again and this runs inside redisplay, so it refuses to come back round on itself. Fixes #2293.

The `sideline` style aligned its message flush to `right`, which puts the last character in the column the glyph marking a continued line needs, so the line spilled over by exactly one character however wide the window was. A terminal has no fringe to draw that glyph in, and a graphical frame can have had its fringes turned off just the same, so the question is whether there is a right fringe rather than whether this is a terminal. Fixes #2292.

#2293 is not related to #2201 as the report guesses — that one was eldoc gating, this is the visible-region calculation. Same symptom, different cause.