### PR TITLE
Check every recording weekly, not the dozen a runner has

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -19,7 +19,11 @@ on:
       - 'test/record-fixture.el'
 
 jobs:
-  compare:
+  # On a pull request, against whatever the runner can be given quickly.
+  # This is for telling someone their recording is wrong while they are
+  # still looking at it, not for covering every checker.
+  changed:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -46,3 +50,31 @@ jobs:
 
     - name: Compare the recordings against the tools
       run: make verify-fixtures
+
+  # Weekly, against the image, which has nearly every tool we record from.
+  # Hand-listing them above reaches a fraction of the recordings and drifts
+  # from the image besides, so the run that has to be thorough uses the
+  # same thing `make record-fixtures' records with.
+  everything:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    # The image is large, and a runner arrives with tens of gigabytes of
+    # toolchains this job has no use for.
+    - name: Make room for the image
+      run: |
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+          /usr/local/share/boost /usr/share/swift
+        df -h /
+
+    # Plain `docker build': the image runs to several gigabytes, which is
+    # not something to push through the Actions cache every week.  Once a
+    # week from scratch is the cheaper trade.
+    - name: Build the image
+      run: make checker-image
+
+    - name: Compare every recording against its tool
+      run: make verify-fixtures-in-image

--- a/Makefile
+++ b/Makefile
@@ -105,14 +105,24 @@ specs: compile
 DOCKER ?= docker
 CHECKER_IMAGE ?= flycheck-checkers
 
+# Mounting the checkout means anything written lands in it, so run as the
+# user who owns it rather than leaving root-owned files behind.  That user
+# does not own /root, so point HOME somewhere writable: without it `go
+# vet' cannot create its build cache and reports that instead of the code.
+CHECKER_RUN = $(DOCKER) run --rm -v "$(CURDIR)":/flycheck \
+	-u "$$(id -u):$$(id -g)" -e HOME=/tmp $(CHECKER_IMAGE)
+# `load-prefer-newer' because a checkout compiled on the host carries .elc
+# files this Emacs may not be able to read
+CHECKER_EMACS = emacs -Q --batch --eval "(setq load-prefer-newer t)" \
+	-L . -l test/record-fixture.el
+
 .PHONY: checker-image
 checker-image:
 	$(DOCKER) build -t $(CHECKER_IMAGE) test/docker
 
 .PHONY: record-fixtures
 record-fixtures: checker-image
-	$(DOCKER) run --rm -v "$(CURDIR)":/flycheck -u "$$(id -u):$$(id -g)" \
-		$(CHECKER_IMAGE)
+	$(CHECKER_RUN)
 
 .PHONY: checker-shell
 checker-shell: checker-image
@@ -123,6 +133,17 @@ checker-shell: checker-image
 verify-fixtures:
 	$(EASK) exec emacs --batch -L . -l test/record-fixture.el \
 		-f flycheck-verify-fixtures-batch
+
+# The same check against the image, which has far more of the tools than
+# any one machine does, so it reaches recordings `verify-fixtures' skips.
+.PHONY: verify-fixtures-image
+verify-fixtures-image: checker-image verify-fixtures-in-image
+
+# Split out so a build that made the image some other way can run the
+# check without a second `docker build' throwing that work away.
+.PHONY: verify-fixtures-in-image
+verify-fixtures-in-image:
+	$(CHECKER_RUN) $(CHECKER_EMACS) -f flycheck-verify-fixtures-batch
 
 .PHONY: images
 images: $(IMGS)

--- a/doc/contributor/contributing.rst
+++ b/doc/contributor/contributing.rst
@@ -140,8 +140,17 @@ stopped understanding its tool, which is what every one of these has looked
 like: jq grew a prefix, rebar3 replaced its format, the byte compiler moved a
 warning onto one line.
 
-A weekly job runs the same target, so a format change turns up as a dated
-notification rather than as a bug report months later.
+That target only reaches the tools the machine running it happens to have, so
+there is a second one that runs the check inside the image described below:
+
+.. code-block:: console
+
+   $ make verify-fixtures-image
+
+This reaches nearly every recording rather than the handful a given machine can
+answer for, which is why it is the one the weekly job runs.  A pull request that
+touches a recording gets the quicker, thinner check instead, so the answer
+arrives while somebody is still looking at it.
 
 Recording in bulk
 -----------------
@@ -156,8 +165,9 @@ many of them as is practical:
 That builds :file:`test/docker/Dockerfile`, mounts your checkout into it, and
 records every checker whose tool it has and whose spec names a file to check.
 ``make checker-shell`` drops you into the same container if you would rather
-poke at a tool by hand.  The image is Ubuntu, the same release the CI runners
-use, so what comes out of it matches what the weekly job later sees.
+poke at a tool by hand.  The image is the current Ubuntu LTS, and the weekly
+job runs inside it too, so what comes out of a recording session is what that
+job later sees.
 
 Recording in bulk will not write a recording that its own checker reads nothing
 out of, because that is what a tool failing to start looks like: ``credo``
@@ -167,6 +177,15 @@ tool has to say.
 
 Read what it wrote before committing it.  A recording nobody looked at is the
 same trap as a spec that never ran.
+
+Because your checkout is mounted rather than copied, anything a build on your
+own machine left in it goes into the container too, and a tool that meets a
+build artefact from a different version of itself can fail in ways that read
+exactly like a checker that stopped understanding its tool.  A stale
+:file:`_build` under the rebar3 resource is the one that has actually happened:
+rebar3 could not read the ``.beam`` files a newer Erlang had written and died
+before it compiled anything.  ``git clean -xfd test/resources`` before a run
+that reports something surprising.
 
 Pull requests
 =============

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,11 +1,13 @@
 # An image with as many of Flycheck's checkers installed as is practical,
 # for recording what they print.  See test/record-fixture.el.
 #
-# Ubuntu rather than anything smaller, and the same release the CI runners
-# use, so what is recorded here is what the weekly job meets when it asks
-# whether the checkers can still read their tools.
+# Ubuntu rather than anything smaller, and the current LTS rather than the
+# one the runners happen to boot: the weekly job runs inside this image, so
+# what matters is that a checker meets a version of its tool close to the
+# one its users have.  A release behind means recording what a linter
+# printed two years ago and calling the checker current.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
@@ -18,7 +20,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
       ca-certificates curl git make unzip xz-utils \
       emacs-nox \
       build-essential clang cppcheck gcc gfortran gnat \
-      cfengine3 chicken-bin ghdl groovy \
+      chicken-bin ghdl groovy \
       llvm luarocks php-cli protobuf-compiler puppet \
       python3 python3-pip python3-venv \
       r-base-core racket ruby ruby-dev \
@@ -81,10 +83,10 @@ RUN gem install --no-document \
       standard \
       puppet-lint
 
-# Ubuntu's Go is a release behind what some of these need to build, so
-# take it from upstream.  The version is whatever is current: this image
-# is for recording, not for shipping, and a checker's output does not
-# depend on the Go that built its linter.
+# Go from upstream rather than apt, so the Go checkers run against the
+# current release however long this Ubuntu has been out.  The version is
+# whatever is current: this image is for recording, not for shipping, and
+# a checker's output does not depend on the Go that built its linter.
 RUN arch="$(dpkg --print-architecture)" \
     && version="$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -1)" \
     && curl -fsSL "https://go.dev/dl/${version}.linux-${arch}.tar.gz" \
@@ -133,6 +135,8 @@ RUN arch="$(dpkg --print-architecture)" \
 
 # Deliberately not here:
 #
+#   cfengine3              dropped from Ubuntu, and there is no recording
+#                          of it to keep working
 #   cuda-nvcc, processing  need toolchains far larger than the rest of
 #                          this image put together
 #   d-dmd, hlint, stack    each pull in a whole language toolchain for


### PR DESCRIPTION
The weekly job hand-listed its tools through apt/pip/npm, which reached 37 of the 78 recordings and had already drifted from the image `make record-fixtures` uses. It now runs in that image and answers for all 78, and it can't drift from what recording uses because it's the same thing.

The image was on Ubuntu 24.04 to match the CI runners, which stops making sense once the job runs inside the container. Moving to the current LTS was most of the work: of the four checkers that read nothing in there, three were just 24.04's package ages (markdownlint and markdownlint-cli2 need Node 20 for the `v` regexp flag, rebar3 3.19 couldn't build the recording's project, oxlint's native binding got skipped). The fourth was ours: we run as the checkout's owner, who can't write to `/root`, so `go vet` reported a build-cache failure instead of the code.

cfengine3 is gone from Ubuntu. No recording of it exists, so nothing breaks, but it can't be made here any more.

Pull requests touching a recording keep the quick check against whatever the runner has. The thorough one is weekly and on demand.