### PR TITLE
Re-record what the checkers read, against the current image

### DIFF
--- a/test/fixtures/ada-gnat/language/ada/syntaxerror.adb.txt
+++ b/test/fixtures/ada-gnat/language/ada/syntaxerror.adb.txt
@@ -1,4 +1,4 @@
-aarch64-linux-gnu-gcc-13 -c  -gnatf -gnatef -gnatwa -gnat2012 -I- -o syntaxerror.o syntaxerror.adb
+aarch64-linux-gnu-gcc-14 -c  -gnatf -gnatef -gnatwa -gnat2012 -I- -o syntaxerror.o syntaxerror.adb
 syntaxerror.adb:7:32: error: missing ";"
 syntaxerror.adb:8:05: error: misspelling of "SYNTAXERROR"
 gnatmake: "syntaxerror.adb" compilation error

--- a/test/fixtures/c_c++-cppcheck/language/c_c++/style2.cpp.txt
+++ b/test/fixtures/c_c++-cppcheck/language/c_c++/style2.cpp.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <results version="2">
-    <cppcheck version="2.13.0"/>
+    <cppcheck version="2.19.0"/>
     <errors>
         <error id="variableScope" severity="style" msg="The scope of the variable &apos;i&apos; can be reduced." verbose="The scope of the variable &apos;i&apos; can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. Here is an example where cppcheck will write that the scope for &apos;i&apos; can be reduced:\012void f(int x)\012{\012    int i = 0;\012    if (x) {\012        // it&apos;s safe to move &apos;int i = 0;&apos; here\012        for (int n = 0; n &lt; 10; ++n) {\012            // it is possible but not safe to move &apos;int i = 0;&apos; here\012            do_something(&amp;i);\012        }\012    }\012}\012When you see this message it is always safe to reduce the variable scope 1 level." cwe="398" file0="style2.cpp">
             <location file="style2.cpp" line="3" column="7"/>

--- a/test/fixtures/css-stylelint/language/css/syntax-error.css.txt
+++ b/test/fixtures/css-stylelint/language/css/syntax-error.css.txt
@@ -1,9 +1,1 @@
-file:///usr/local/lib/node_modules/stylelint/lib/utils/getLexer.mjs:2
-import syntaxPatchesJson from '@csstools/css-syntax-patches-for-csstree' with { type: 'json' };
-                                                                         ^^^^
-
-SyntaxError: Unexpected token 'with'
-    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:152:18)
-    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:298:14)
-
-Node.js v18.19.1
+[{"source":"test/resources/language/css/syntax-error.css","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":true,"warnings":[{"line":4,"column":5,"endLine":4,"endColumn":14,"rule":"CssSyntaxError","severity":"error","text":"Unknown word font-size (CssSyntaxError)"}]}]

--- a/test/fixtures/erlang-rebar3/language/erlang/rebar3/src/erlang-error.erl.txt
+++ b/test/fixtures/erlang-rebar3/language/erlang/rebar3/src/erlang-error.erl.txt
@@ -1,19 +1,19 @@
-[0;32m===> Verifying dependencies...
-[0m[0;32m===> App dependency is a checkout dependency and cannot be locked.
-[0m[0;32m===> Analyzing applications...
-[0m[0;32m===> Compiling dependency
-[0m[0;32m===> Analyzing applications...
-[0m[0;32m===> Compiling erlang-rebar3
-[0m[0;31m===> [1mCompiling src/erlang-error.erl failed
-[0m[0m   ┌─ src/erlang-error.erl:
+===> Verifying dependencies...
+===> App dependency is a checkout dependency and cannot be locked.
+===> Analyzing applications...
+===> Compiling dependency
+===> Analyzing applications...
+===> Compiling erlang-rebar3
+===> Compiling src/erlang-error.erl failed
+   ┌─ src/erlang-error.erl:
    │
- 7 │  [1;31merror_func[0m() ->[0m
-   │  [1;31m╰──[0m[0m head mismatch: previous function great_func/0 is distinct from error_func/0. Is the semicolon in great_func/0 unwanted?
+ 7 │  error_func() ->
+   │  ╰── head mismatch: previous function great_func/0 is distinct from error_func/0. Is the semicolon in great_func/0 unwanted?
 
 
    ┌─ src/erlang-error.erl:
    │
- 3 │  -[1;31mcompile[0m(export_all).[0m
-   │   [1;31m╰──[0m[0m Warning: export_all flag enabled - all functions will be exported
+ 3 │  -compile(export_all).
+   │   ╰── Warning: export_all flag enabled - all functions will be exported
 
 

--- a/test/fixtures/erlang/language/erlang/erlang/error.erl.txt
+++ b/test/fixtures/erlang/language/erlang/erlang/error.erl.txt
@@ -1,4 +1,4 @@
-error.erl:7:1: head mismatch
+error.erl:7:1: head mismatch: previous function great_func/0 is distinct from error_func/0. Is the semicolon in great_func/0 unwanted?
 %    7| error_func() ->
 %     | ^
 

--- a/test/fixtures/handlebars/language/handlebars.hbs.txt
+++ b/test/fixtures/handlebars/language/handlebars.hbs.txt
@@ -17,4 +17,4 @@ Expecting 'ID', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 
     at module.exports.cli (/usr/local/lib/node_modules/handlebars/dist/cjs/precompiler.js:225:18)
     at /usr/local/lib/node_modules/handlebars/bin/handlebars:116:17
 
-Node.js v18.19.1
+Node.js v22.22.1

--- a/test/fixtures/less-stylelint/language/less/syntax-error.less.txt
+++ b/test/fixtures/less-stylelint/language/less/syntax-error.less.txt
@@ -1,9 +1,1 @@
-file:///usr/local/lib/node_modules/stylelint/lib/utils/getLexer.mjs:2
-import syntaxPatchesJson from '@csstools/css-syntax-patches-for-csstree' with { type: 'json' };
-                                                                         ^^^^
-
-SyntaxError: Unexpected token 'with'
-    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:152:18)
-    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:298:14)
-
-Node.js v18.19.1
+[{"source":"<input css 1>","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":true,"warnings":[{"line":1,"column":1,"rule":"CssSyntaxError","severity":"error","text":"Unclosed block (CssSyntaxError)"}]}]

--- a/test/fixtures/markdown-markdownlint-cli2/language/markdown.md.txt
+++ b/test/fixtures/markdown-markdownlint-cli2/language/markdown.md.txt
@@ -1,6 +1,7 @@
-markdownlint-cli2 v0.21.0 (markdownlint v0.40.0)
+markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
 Finding: markdown.md
-Linting: 1 file(s)
-Summary: 2 error(s)
+Linting: 1 file
+Summary: 3 issues in 1 file
+markdown.md:1 error MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "## Second Header First"]
 markdown.md:3 error MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
 markdown.md:4:15 error MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 7]

--- a/test/fixtures/ocaml-dune/language/ocaml-dune/lib/typeerror.ml.txt
+++ b/test/fixtures/ocaml-dune/language/ocaml-dune/lib/typeerror.ml.txt
@@ -1,5 +1,5 @@
 File "lib/typeerror.ml", line 4, characters 16-28:
 4 | let bad : int = "not an int"
                     ^^^^^^^^^^^^
-Error: This expression has type string but an expression was expected of type
+Error: This constant has type string but an expression was expected of type
          int

--- a/test/fixtures/opam/language/opam.opam.txt
+++ b/test/fixtures/opam/language/opam.opam.txt
@@ -4,4 +4,5 @@ Errors.
            warning 25: Missing field 'authors'
            warning 35: Missing field 'homepage'
            warning 36: Missing field 'bug-reports'
-             error 57: Synopsis and description must not be both empty
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'

--- a/test/fixtures/php/language/php/syntax-error.php.txt
+++ b/test/fixtures/php/language/php/syntax-error.php.txt
@@ -1,3 +1,5 @@
 
 Fatal error: Assignments can only happen to writable values in syntax-error.php on line 8
+Stack trace:
+#0 {main}
 Errors parsing syntax-error.php

--- a/test/fixtures/pug/language/pug/pug.pug.txt
+++ b/test/fixtures/pug/language/pug/pug.pug.txt
@@ -35,4 +35,4 @@ unexpected token "indent"
   toJSON: [Function (anonymous)]
 }
 
-Node.js v18.19.1
+Node.js v22.22.1

--- a/test/fixtures/puppet-parser/language/puppet/parser-error.pp.txt
+++ b/test/fixtures/puppet-parser/language/puppet/parser-error.pp.txt
@@ -1,0 +1,1 @@
+Error: Could not parse for environment production: Syntax error at '>' (line: 3, column: 9)

--- a/test/fixtures/python-pylint/language/python/test.py.txt
+++ b/test/fixtures/python-pylint/language/python/test.py.txt
@@ -1,5 +1,3 @@
-Unable to create directory /.cache/pylint
-Unable to create file /.cache/pylint/python.flycheck_test_1.stats: [Errno 2] No such file or directory: '/.cache/pylint/python.flycheck_test_1.stats'
 [
     {
         "type": "convention",

--- a/test/fixtures/python-pyright/language/python/invalid_type.py.txt
+++ b/test/fixtures/python-pyright/language/python/invalid_type.py.txt
@@ -1,6 +1,6 @@
 {
     "version": "1.1.411",
-    "time": "1785830303310",
+    "time": "1785933253892",
     "generalDiagnostics": [
         {
             "file": "test/resources/language/python/flycheck_invalid_type.py",
@@ -24,7 +24,7 @@
         "errorCount": 1,
         "warningCount": 0,
         "informationCount": 0,
-        "timeInSec": 0.14
+        "timeInSec": 0.122
     }
 }
 

--- a/test/fixtures/ruby-rubocop/language/ruby/syntax-error.rb.txt
+++ b/test/fixtures/ruby-rubocop/language/ruby/syntax-error.rb.txt
@@ -41,6 +41,8 @@ Lint/DataDefineOverride: # new in 1.85
   Enabled: true
 Lint/DeprecatedConstants: # new in 1.8
   Enabled: true
+Lint/DeprecatedReference: # new in 1.89
+  Enabled: true
 Lint/DuplicateBranch: # new in 1.3
   Enabled: true
 Lint/DuplicateMagicComment: # new in 1.37
@@ -68,6 +70,8 @@ Lint/LambdaWithoutLiteralBlock: # new in 1.8
 Lint/LiteralAssignmentInCondition: # new in 1.58
   Enabled: true
 Lint/MixedCaseRange: # new in 1.53
+  Enabled: true
+Lint/NameTypo: # new in 1.89
   Enabled: true
 Lint/NoReturnInBeginEndBlocks: # new in 1.2
   Enabled: true

--- a/test/fixtures/ruby-standard/language/ruby/syntax-error.rb.txt
+++ b/test/fixtures/ruby-standard/language/ruby/syntax-error.rb.txt
@@ -1,1 +1,2 @@
-test/resources/language/ruby/syntax-error.rb:5:7: F: Lint/Syntax: unexpected token tCONSTANT (Using Ruby 3.2 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+test/resources/language/ruby/syntax-error.rb:5:7: F: Lint/Syntax: unexpected constant, expecting end-of-input (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+test/resources/language/ruby/syntax-error.rb:5:25: F: Lint/Syntax: unterminated string meets end of file (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)

--- a/test/fixtures/ruby/language/ruby/syntax-error.rb.txt
+++ b/test/fixtures/ruby/language/ruby/syntax-error.rb.txt
@@ -2,4 +2,4 @@
 -:5: syntax error, unexpected constant, expecting end-of-input
 puts "Here are the days"
       ^~~~
--: compile error (SyntaxError)
+/usr/bin/ruby: compile error (SyntaxError)

--- a/test/fixtures/sass-stylelint/language/sass/error.sass.txt
+++ b/test/fixtures/sass-stylelint/language/sass/error.sass.txt
@@ -1,9 +1,1 @@
-file:///usr/local/lib/node_modules/stylelint/lib/utils/getLexer.mjs:2
-import syntaxPatchesJson from '@csstools/css-syntax-patches-for-csstree' with { type: 'json' };
-                                                                         ^^^^
-
-SyntaxError: Unexpected token 'with'
-    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:152:18)
-    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:298:14)
-
-Node.js v18.19.1
+[{"source":"<input css 1>","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":true,"warnings":[{"line":1,"column":1,"endLine":1,"endColumn":3,"rule":"CssSyntaxError","severity":"error","text":"Unknown word // (CssSyntaxError)"}]}]

--- a/test/fixtures/scss-stylelint/language/scss/error.scss.txt
+++ b/test/fixtures/scss-stylelint/language/scss/error.scss.txt
@@ -1,9 +1,1 @@
-file:///usr/local/lib/node_modules/stylelint/lib/utils/getLexer.mjs:2
-import syntaxPatchesJson from '@csstools/css-syntax-patches-for-csstree' with { type: 'json' };
-                                                                         ^^^^
-
-SyntaxError: Unexpected token 'with'
-    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:152:18)
-    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:298:14)
-
-Node.js v18.19.1
+[{"source":"<input css 1>","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":true,"warnings":[{"line":3,"column":11,"endLine":3,"endColumn":15,"rule":"CssSyntaxError","severity":"error","text":"Unknown word olor (CssSyntaxError)"}]}]

--- a/test/fixtures/systemd-analyze/language/systemd-analyze-test.service.txt
+++ b/test/fixtures/systemd-analyze/language/systemd-analyze-test.service.txt
@@ -1,5 +1,5 @@
 systemd-analyze-test.service:3: Invalid URL, ignoring: foo://bar
-systemd-analyze-test.service:6: Unknown key name 'ExecSmart' in section 'Service', ignoring.
+systemd-analyze-test.service:6: Unknown key 'ExecSmart' in section [Service], ignoring.
 systemd-analyze-test.service:8: Unknown section 'Dog'. Ignoring.
 systemd-analyze-test.service: Service has no ExecStart=, ExecStop=, or SuccessAction=. Refusing.
 Unit systemd-analyze-test.service has a bad unit file setting.

--- a/test/fixtures/verilog-verilator/language/verilog/verilator_error.v.txt
+++ b/test/fixtures/verilog-verilator/language/verilog/verilator_error.v.txt
@@ -1,7 +1,7 @@
 %Warning-DECLFILENAME: verilator_error.v:1:8: Filename 'verilator_error' does not match MODULE name: 'verilog_verilator_error'
     1 | module verilog_verilator_error;
       |        ^~~~~~~~~~~~~~~~~~~~~~~
-                       ... For warning description see https://verilator.org/warn/DECLFILENAME?v=5.020
+                       ... For warning description see https://verilator.org/warn/DECLFILENAME?v=5.032
                        ... Use "/* verilator lint_off DECLFILENAME */" and lint_on around source to disable this message.
 %Error: verilator_error.v:4:10: Can't find definition of variable: 'i'
     4 |          i = $fopen("test.log");

--- a/test/fixtures/xml-xmllint/language/xml.xml.txt
+++ b/test/fixtures/xml-xmllint/language/xml.xml.txt
@@ -1,6 +1,3 @@
 -:4: parser error : Opening and ending tag mismatch: spam line 3 and with
   </with>
          ^
--:5: parser error : Extra content at the end of the document
-</spam>
-^

--- a/test/specs/languages/test-css.el
+++ b/test/specs/languages/test-css.el
@@ -62,6 +62,6 @@
     ;; not the tool is installed here
 
     (flycheck-buttercup-def-parse-test css-stylelint "language/css/syntax-error.css"
-      '(1 nil error "Unexpected token 'with'" :id "SyntaxError"))))
+      '(4 5 error "Unknown word font-size (CssSyntaxError)" :id "CssSyntaxError"))))
 
 ;;; test-css.el ends here

--- a/test/specs/languages/test-erlang.el
+++ b/test/specs/languages/test-erlang.el
@@ -61,7 +61,7 @@
     ;; not the tool is installed here
 
     (flycheck-buttercup-def-parse-test erlang "language/erlang/erlang/error.erl"
-      '(7 1 error "head mismatch")
+      '(7 1 error "head mismatch: previous function great_func/0 is distinct from error_func/0. Is the semicolon in great_func/0 unwanted?")
       '(3 2 warning "export_all flag enabled - all functions will be exported"))
     (flycheck-buttercup-def-parse-test erlang-rebar3 "language/erlang/rebar3/src/erlang-error.erl"
       '(7 1 error "head mismatch: previous function great_func/0 is distinct from error_func/0. Is the semicolon in great_func/0 unwanted?")

--- a/test/specs/languages/test-less.el
+++ b/test/specs/languages/test-less.el
@@ -35,7 +35,7 @@
     ;; not the tool is installed here
 
     (flycheck-buttercup-def-parse-test less-stylelint "language/less/syntax-error.less"
-      '(1 nil error "Unexpected token 'with'" :id "SyntaxError"))
+      '(1 1 error "Unclosed block (CssSyntaxError)" :id "CssSyntaxError"))
     (flycheck-buttercup-def-parse-test less "language/less/file-error.less"
       '(3 1 error "'no-such-file.less' wasn't found. Tried - no-such-file.less,npm://no-such-file.less,no-such-file.less"))))
 

--- a/test/specs/languages/test-markdown.el
+++ b/test/specs/languages/test-markdown.el
@@ -78,6 +78,7 @@
       '(3 nil error "Multiple consecutive blank lines [Expected: 1; Actual: 2]" :id "MD012/no-multiple-blanks")
       '(4 15 error "Trailing spaces [Expected: 0 or 2; Actual: 7]" :id "MD009/no-trailing-spaces"))
     (flycheck-buttercup-def-parse-test markdown-markdownlint-cli2 "language/markdown.md"
+      '(1 nil error "First line in a file should be a top-level heading [Context: \"## Second Header First\"]" :id "MD041/first-line-heading/first-line-h1")
       '(3 nil error "Multiple consecutive blank lines [Expected: 1; Actual: 2]" :id "MD012/no-multiple-blanks")
       '(4 15 error "Trailing spaces [Expected: 0 or 2; Actual: 7]" :id "MD009/no-trailing-spaces"))
     (flycheck-buttercup-def-parse-test markdown-mdl "language/markdown.md"

--- a/test/specs/languages/test-ocaml.el
+++ b/test/specs/languages/test-ocaml.el
@@ -60,7 +60,7 @@
     ;; The location line, the echoed source and the wrapped message all
     ;; have to be read as one error
     (flycheck-buttercup-def-parse-test ocaml-dune "language/ocaml-dune/lib/typeerror.ml"
-      '(4 17 error "This expression has type string but an expression was expected of type\n         int" :end-line 4 :end-column 29)))
+      '(4 17 error "This constant has type string but an expression was expected of type\n         int" :end-line 4 :end-column 29)))
 
   (describe "reading the tool's output"
     ;; Read from output recorded earlier, so this runs whether or

--- a/test/specs/languages/test-opam.el
+++ b/test/specs/languages/test-opam.el
@@ -28,6 +28,7 @@
       '(0 nil warning "Missing field 'authors'" :id "25")
       '(0 nil warning "Missing field 'homepage'" :id "35")
       '(0 nil warning "Missing field 'bug-reports'" :id "36")
-      '(0 nil error "Synopsis and description must not be both empty" :id "57"))))
+      '(0 nil error "Synopsis must not be empty" :id "57")
+      '(0 nil warning "Missing field 'license'" :id "68"))))
 
 ;;; test-opam.el ends here

--- a/test/specs/languages/test-puppet.el
+++ b/test/specs/languages/test-puppet.el
@@ -45,6 +45,8 @@
     ;; Read from output recorded earlier, so this runs whether or
     ;; not the tool is installed here
 
+    (flycheck-buttercup-def-parse-test puppet-parser "language/puppet/parser-error.pp"
+      '(3 9 error "Syntax error at '>'"))
     (flycheck-buttercup-def-parse-test puppet-lint "language/puppet/warnings.pp"
       '(2 nil error "foo::bar not in autoload module layout (autoloader_layout)")
       '(3 nil warning "case statement without a default case (case_without_default)")

--- a/test/specs/languages/test-ruby.el
+++ b/test/specs/languages/test-ruby.el
@@ -219,6 +219,7 @@
     (flycheck-buttercup-def-parse-test ruby-reek "language/ruby/warnings.rb"
       '(3 nil warning "Person assumes too much for instance variable '@name'" :id "InstanceVariableAssumption"))
     (flycheck-buttercup-def-parse-test ruby-standard "language/ruby/syntax-error.rb"
-      '(5 7 error "unexpected token tCONSTANT (Using Ruby 3.2 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)" :id "Lint/Syntax"))))
+      '(5 7 error "unexpected constant, expecting end-of-input (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)" :id "Lint/Syntax")
+      '(5 25 error "unterminated string meets end of file (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)" :id "Lint/Syntax"))))
 
 ;;; test-ruby.el ends here

--- a/test/specs/languages/test-sass.el
+++ b/test/specs/languages/test-sass.el
@@ -18,6 +18,6 @@
     ;; not the tool is installed here
 
     (flycheck-buttercup-def-parse-test sass-stylelint "language/sass/error.sass"
-      '(1 nil error "Unexpected token 'with'" :id "SyntaxError"))))
+      '(1 1 error "Unknown word // (CssSyntaxError)" :id "CssSyntaxError"))))
 
 ;;; test-sass.el ends here

--- a/test/specs/languages/test-scss.el
+++ b/test/specs/languages/test-scss.el
@@ -18,6 +18,6 @@
     ;; not the tool is installed here
 
     (flycheck-buttercup-def-parse-test scss-stylelint "language/scss/error.scss"
-      '(1 nil error "Unexpected token 'with'" :id "SyntaxError"))))
+      '(3 11 error "Unknown word olor (CssSyntaxError)" :id "CssSyntaxError"))))
 
 ;;; test-scss.el ends here

--- a/test/specs/languages/test-systemd.el
+++ b/test/specs/languages/test-systemd.el
@@ -49,7 +49,7 @@
 
     (flycheck-buttercup-def-parse-test systemd-analyze "language/systemd-analyze-test.service"
       '(3 nil error "Invalid URL, ignoring: foo://bar")
-      '(6 nil error "Unknown key name 'ExecSmart' in section 'Service', ignoring.")
+      '(6 nil error "Unknown key 'ExecSmart' in section [Service], ignoring.")
       '(8 nil error "Unknown section 'Dog'. Ignoring.")
       '(0 nil error "Service has no ExecStart=, ExecStop=, or SuccessAction=. Refusing."))))
 

--- a/test/specs/languages/test-xml.el
+++ b/test/specs/languages/test-xml.el
@@ -45,8 +45,9 @@
     ;; Read from output recorded earlier, so this runs whether or
     ;; not the tool is installed here
 
+    ;; libxml2 2.14 stops at the first parser error, where older releases
+    ;; carried on and also reported the extra content that followed
     (flycheck-buttercup-def-parse-test xml-xmllint "language/xml.xml"
-      '(4 nil error "parser error : Opening and ending tag mismatch: spam line 3 and with")
-      '(5 nil error "parser error : Extra content at the end of the document"))))
+      '(4 nil error "parser error : Opening and ending tag mismatch: spam line 3 and with"))))
 
 ;;; test-xml.el ends here


### PR DESCRIPTION
Once the image moved to the current Ubuntu, about twenty recordings started reporting "prints something else, and still reads as N errors" - the message that means they've gone stale. Re-recorded, with each expectation regenerated from the new output rather than edited by hand.

Four were worse than stale. The stylelint recordings for CSS, SCSS, Sass and Less held a Node 18 stack trace, because stylelint imports its lexer with an import attribute Node couldn't parse. The specs then asserted the crash, `Unexpected token 'with'` and all, so four checkers had a green test that said nothing about reading CSS. They read real diagnostics now.

The rest is ordinary drift. xmllint stops at the first parser error where it used to carry on, so that spec loses an error. puppet-parser picked up its first recording and a spec to go with it.