### PR TITLE
Fail when a spec builds its body and drops it

### DIFF
--- a/test/specs/test-checker-specs.el
+++ b/test/specs/test-checker-specs.el
@@ -36,6 +36,54 @@
    'full "\\.el\\'")
   "Every language spec file.")
 
+(defconst flycheck-spec--all-spec-files
+  (directory-files-recursively
+   (expand-file-name "specs" flycheck-test-directory) "\\.el\\'")
+  "Every spec file, language specs included.")
+
+(defun flycheck-spec--forms (file)
+  "Return every form in FILE, read."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (let (forms form)
+      (while (setq form (condition-case nil (read (current-buffer)) (end-of-file)))
+        (push form forms))
+      (nreverse forms))))
+
+(defun flycheck-spec--dropped-body-p (form)
+  "Whether FORM is a spec that builds a function and drops it.
+
+`it' wraps whatever it is given in a function of its own, so a body
+form that is itself a `lambda' is made, never called, and takes every
+assertion inside it along.  The spec then passes without having run,
+which is how 307 of them passed for six months.
+
+Any such form counts, not only a body that is nothing else: the
+mistake once lived in a macro that put the `lambda' after the forms
+that skip the spec."
+  (and (consp form)
+       (memq (car form) '(it xit))
+       (seq-some (lambda (subform)
+                   (and (consp subform)
+                        (memq (car subform) '(lambda closure function))))
+                 (cddr form))))
+
+(defun flycheck-spec--find-dropped-bodies (form)
+  "Return the specs under FORM whose body would be dropped.
+
+The spine is walked rather than mapped, because a spec file holds
+plenty of dotted pairs and long lists, and neither survives `mapcar'
+and recursion respectively."
+  (cond
+   ((not (consp form)) nil)
+   ((flycheck-spec--dropped-body-p form) (list form))
+   (t (let ((tail form) found)
+        (while (consp tail)
+          (setq found (nconc found (flycheck-spec--find-dropped-bodies (car tail)))
+                tail (cdr tail)))
+        found))))
+
 (defun flycheck-spec--declared-checkers (file)
   "Return the checkers named by `def-checker-test' forms in FILE."
   (with-temp-buffer
@@ -86,6 +134,34 @@
                        (file-exists-p (flycheck-record-fixture--resource resource)))
             (push (file-relative-name recording flycheck-record-fixture-directory)
                   astray))))
-      (expect (nreverse astray) :to-equal nil))))
+      (expect (nreverse astray) :to-equal nil)))
+
+  (it "give buttercup a body to run, rather than one to drop"
+    ;; Written out, this is a spec whose whole body is `(lambda () ...)'
+    (let (dropped)
+      (dolist (file flycheck-spec--all-spec-files)
+        (dolist (form (flycheck-spec--forms file))
+          (dolist (spec (flycheck-spec--find-dropped-bodies form))
+            (push (format "%s: %S" (file-name-nondirectory file) (cadr spec))
+                  dropped))))
+      (expect (nreverse dropped) :to-equal nil)))
+
+  (it "reach the spec through the macros that define them"
+    ;; The same mistake once lived in the macros instead, where no
+    ;; reading of the spec files could see it: they expand to the `it'
+    ;; whose body was being dropped.  Both of ours are checked by
+    ;; expanding them, since that is the only place it shows.
+    (let ((expansions
+           (list (macroexpand-1
+                  '(flycheck-buttercup-def-checker-test emacs-lisp emacs-lisp nil
+                     (flycheck-spec--canary)))
+                 (macroexpand-1
+                  '(flycheck-buttercup-def-parse-test emacs-lisp "warnings.el"
+                     '(1 1 error "x"))))))
+      (dolist (expansion expansions)
+        (expect (car expansion) :to-be 'it)
+        (expect (flycheck-spec--dropped-body-p expansion) :to-be nil))
+      ;; and the body given is the body that arrives
+      (expect (car expansions) :to-contain '(flycheck-spec--canary)))))
 
 ;;; test-checker-specs.el ends here


### PR DESCRIPTION
`it` wraps whatever it's given in a function of its own, so a body form that's itself a `lambda` gets built, never called, and takes every assertion inside it along. That's how 307 specs passed for six months, and nothing would catch it happening again.

Two specs, because the mistake has two hiding places. One reads every spec file looking for the shape written out by hand. The other expands the two macros that define specs here, which is the only place it shows when it lives in a macro instead - the spec files then just hold a macro call and read as perfectly ordinary. That's where it actually was.

Checked both by putting the bug back: wrapping a body fails the first, restoring the `lambda` that `flycheck-buttercup-def-checker-test` used to emit fails the second.