### PR TITLE
Test the LSP bridges end to end against a scripted server

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -12067,8 +12067,11 @@ as a fallback."
   "Return the lazy code-action fix provider, or nil when unavailable.
 
 Non-nil only when `flycheck-eglot-code-actions' is on and the server
-advertises code actions; see `flycheck-eglot--code-action-fix'."
+advertises code actions; see `flycheck-eglot--code-action-fix'.  The
+capability probe needs a live server, so a buffer Eglot does not
+manage never asks."
   (when (and flycheck-eglot-code-actions
+             (flycheck-eglot--available-p)
              (fboundp 'eglot-server-capable)
              (eglot-server-capable :codeActionProvider))
     #'flycheck-eglot--code-action-fix))

--- a/test/mock-lsp-server.py
+++ b/test/mock-lsp-server.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""A scripted LSP server for Flycheck's integration specs.
+
+Speaks LSP over stdio, using only the standard library.  The scenario is
+picked by the first argument:
+
+  push    after didOpen, publish one warning, then republish the
+          identical set four more times, the way a server republishes
+          freely while it indexes or builds
+  change  publish one warning, then a set with an error added, so the
+          client has one real change to react to
+  pull    advertise diagnosticProvider and answer
+          textDocument/diagnostic requests, and follow each answer with
+          the same diagnostics as a push: the two halves of one answer
+          that Emacs 31's Eglot receives.  Also publishes once on
+          didOpen, like a real server, so a client that never pulls
+          (Emacs 30's Eglot) still hears about the diagnostics
+
+Every incoming method is counted, and the counts are rewritten to the
+file named by the MOCK_LSP_STATS environment variable after each
+message, one "method count" pair per line.  A spec reads that file to
+assert the client did not storm the server with requests.
+"""
+
+import json
+import os
+import sys
+
+scenario = sys.argv[1] if len(sys.argv) > 1 else "push"
+stats_file = os.environ.get("MOCK_LSP_STATS")
+counts = {}
+
+stdin = sys.stdin.buffer
+stdout = sys.stdout.buffer
+
+
+def read_message():
+    length = None
+    while True:
+        line = stdin.readline()
+        if not line:
+            return None
+        line = line.strip()
+        if not line:
+            break
+        if line.lower().startswith(b"content-length:"):
+            length = int(line.split(b":")[1])
+    if length is None:
+        return None
+    body = stdin.read(length)
+    if len(body) < length:
+        # The client died mid-message; exit cleanly rather than raise
+        return None
+    return json.loads(body.decode("utf-8"))
+
+
+def send(message):
+    body = json.dumps(message).encode("utf-8")
+    stdout.write(b"Content-Length: %d\r\n\r\n" % len(body))
+    stdout.write(body)
+    stdout.flush()
+
+
+def respond(msg, result):
+    send({"jsonrpc": "2.0", "id": msg["id"], "result": result})
+
+
+def notify(method, params):
+    send({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def count(method):
+    counts[method] = counts.get(method, 0) + 1
+    if stats_file:
+        # Written atomically so a spec reading mid-update never sees a
+        # torn line, and guarded because teardown may have removed the
+        # directory before the last messages are processed
+        try:
+            with open(stats_file + ".tmp", "w") as f:
+                for name, n in sorted(counts.items()):
+                    f.write("%s %d\n" % (name, n))
+            os.replace(stats_file + ".tmp", stats_file)
+        except OSError:
+            pass
+
+
+WARNING = {
+    "range": {
+        "start": {"line": 0, "character": 0},
+        "end": {"line": 0, "character": 4},
+    },
+    "severity": 2,
+    "code": "M1",
+    "message": "mock warning",
+}
+
+ERROR = {
+    "range": {
+        "start": {"line": 1, "character": 0},
+        "end": {"line": 1, "character": 3},
+    },
+    "severity": 1,
+    "code": "M2",
+    "message": "mock error",
+}
+
+
+def capabilities():
+    caps = {"textDocumentSync": 1}
+    if scenario == "pull":
+        caps["diagnosticProvider"] = {
+            "interFileDependencies": False,
+            "workspaceDiagnostics": False,
+        }
+    return caps
+
+
+def publish(uri, diags):
+    notify(
+        "textDocument/publishDiagnostics",
+        {"uri": uri, "diagnostics": diags},
+    )
+
+
+def on_did_open(uri):
+    if scenario == "push":
+        for _ in range(5):
+            publish(uri, [WARNING])
+    elif scenario == "change":
+        publish(uri, [WARNING])
+        publish(uri, [WARNING, ERROR])
+    elif scenario == "pull":
+        publish(uri, [WARNING])
+
+
+while True:
+    msg = read_message()
+    if msg is None:
+        break
+    method = msg.get("method")
+    if method:
+        count(method)
+    if method == "initialize":
+        respond(msg, {"capabilities": capabilities()})
+    elif method == "textDocument/didOpen":
+        on_did_open(msg["params"]["textDocument"]["uri"])
+    elif method == "textDocument/diagnostic":
+        respond(msg, {"kind": "full", "items": [WARNING]})
+        publish(msg["params"]["textDocument"]["uri"], [WARNING])
+    elif method == "shutdown":
+        respond(msg, None)
+    elif method == "exit":
+        break
+    elif method and "id" in msg:
+        # Politely decline anything else the client asks for
+        respond(msg, None)

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -250,15 +250,23 @@ half-assembled answer and passes for the wrong reason."
 
   (describe "code-action fixes"
 
-    (it "provides the code-action fix only when enabled and supported"
-      (let ((flycheck-eglot-code-actions t))
-        (cl-letf (((symbol-function 'eglot-server-capable) (lambda (&rest _) t)))
-          (expect (flycheck-eglot--fix-provider)
-                  :to-be 'flycheck-eglot--code-action-fix))
-        (cl-letf (((symbol-function 'eglot-server-capable) (lambda (&rest _) nil)))
+    (it "provides the code-action fix only when enabled, managed and supported"
+      (cl-letf (((symbol-function 'eglot-managed-p) (lambda () t)))
+        (let ((flycheck-eglot-code-actions t))
+          (cl-letf (((symbol-function 'eglot-server-capable) (lambda (&rest _) t)))
+            (expect (flycheck-eglot--fix-provider)
+                    :to-be 'flycheck-eglot--code-action-fix))
+          (cl-letf (((symbol-function 'eglot-server-capable) (lambda (&rest _) nil)))
+            (expect (flycheck-eglot--fix-provider) :to-be nil)))
+        (let ((flycheck-eglot-code-actions nil))
           (expect (flycheck-eglot--fix-provider) :to-be nil)))
-      (let ((flycheck-eglot-code-actions nil))
-        (expect (flycheck-eglot--fix-provider) :to-be nil)))
+      ;; The capability probe needs a live server, so an unmanaged buffer
+      ;; must not reach it
+      (cl-letf (((symbol-function 'eglot-managed-p) (lambda () nil))
+                ((symbol-function 'eglot-server-capable)
+                 (lambda (&rest _) (error "No current server"))))
+        (let ((flycheck-eglot-code-actions t))
+          (expect (flycheck-eglot--fix-provider) :to-be nil))))
 
     (it "resolves the preferred quickfix action into a fix"
       (flycheck-buttercup-with-temp-buffer

--- a/test/specs/test-lsp-integration.el
+++ b/test/specs/test-lsp-integration.el
@@ -1,0 +1,218 @@
+;;; test-lsp-integration.el --- Flycheck Specs: LSP end-to-end  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; End-to-end specs for the LSP bridges, against the scripted server in
+;; test/mock-lsp-server.py.  The unit specs in test-lsp.el and
+;; test-eglot.el simulate the reports the bridges receive; these run the
+;; real thing: a server process, the jsonrpc session, the asynchronous
+;; initialize handshake, and (through Eglot) whatever report cadence the
+;; running Emacs actually uses.  That cadence is the part that has
+;; drifted under us before: Emacs 31 answers one request for
+;; diagnostics with two reports where Emacs 30 sends one, which is how
+;; the re-check storms of #2262 and #2291 got past the unit specs.
+;;
+;; The server counts every method it receives into a stats file, so the
+;; specs can assert not only that diagnostics arrive but that a
+;; republishing or pull-model server is not asked again and again.
+
+;;; Code:
+
+(require 'flycheck-buttercup)
+(require 'test-helpers)
+
+;; Bound by eglot, which the spec that uses them loads first
+(defvar eglot-server-programs)
+(defvar eglot-sync-connect)
+
+(defconst test-lsp-integration/server
+  (expand-file-name "mock-lsp-server.py" flycheck-test-directory)
+  "Path to the scripted LSP server.")
+
+(defun test-lsp-integration/possible-p ()
+  "Whether this machine can run the end-to-end LSP specs at all."
+  (and (not (memq system-type '(windows-nt ms-dos cygwin)))
+       (executable-find "python3")))
+
+(defun test-lsp-integration/wait-until (pred timeout)
+  "Pump events until PRED returns non-nil or TIMEOUT seconds pass.
+
+Alternates process output with `sit-for', which is what runs the
+timers the bridges lean on (Eglot's settle timer, the handshake's
+timeout).  Return PRED's final answer."
+  (let ((deadline (+ (float-time) timeout)))
+    (while (and (not (funcall pred)) (< (float-time) deadline))
+      (accept-process-output nil 0.02)
+      (sit-for 0.02))
+    (funcall pred)))
+
+(defun test-lsp-integration/pump (seconds)
+  "Pump events for SECONDS, without waiting on anything in particular."
+  (test-lsp-integration/wait-until #'ignore seconds))
+
+(defvar test-lsp-integration/stats-file nil
+  "Where the current spec's server writes its method counts.")
+
+(defun test-lsp-integration/stats ()
+  "Return the mock server's method counts, as an alist of (METHOD . N)."
+  (when (file-exists-p test-lsp-integration/stats-file)
+    (mapcar (lambda (line)
+              (pcase-let ((`(,method ,n) (split-string line " ")))
+                (cons method (and n (string-to-number n)))))
+            (split-string (with-temp-buffer
+                            (insert-file-contents test-lsp-integration/stats-file)
+                            (buffer-string))
+                          "\n" t))))
+
+(defmacro test-lsp-integration/with-file-buffer (&rest body)
+  "Run BODY in a `makefile-gmake-mode' buffer visiting a fresh temp file.
+
+The buffer is shown in the selected window: a check in a buffer no
+window displays is deferred (`flycheck-must-defer-check'), and nothing
+in a batch session would ever run it.  The servers BODY starts inherit
+`test-lsp-integration/stats-file' through the environment, and are shut
+down before the temp directory goes away."
+  (declare (indent 0))
+  (let ((dir (make-symbol "dir"))
+        (file (make-symbol "file"))
+        (buffer (make-symbol "buffer")))
+    `(let* ((,dir (make-temp-file "flycheck-lsp-integration" 'dir))
+            (,file (expand-file-name "sample.mk" ,dir))
+            (test-lsp-integration/stats-file (expand-file-name "stats" ,dir))
+            (process-environment
+             (cons (concat "MOCK_LSP_STATS=" test-lsp-integration/stats-file)
+                   process-environment)))
+       (write-region "help:\n\techo hi\n" nil ,file nil 'quiet)
+       (let ((,buffer (find-file-noselect ,file)))
+         (unwind-protect
+             (save-window-excursion
+               (set-window-buffer (selected-window) ,buffer)
+               (with-current-buffer ,buffer
+                 (makefile-gmake-mode)
+                 ,@body))
+           (ignore-errors
+             (with-current-buffer ,buffer (flycheck-lsp-mode -1)))
+           (kill-buffer ,buffer)
+           ;; Before the directory disappears under the stats file
+           (flycheck-lsp--shutdown-all)
+           (delete-directory ,dir 'recursive))))))
+
+;; Enabling a bridge calls `flycheck-add-mode', which permanently grows
+;; the checker's global `modes' list; restore what the specs pollute
+(defmacro test-lsp-integration/preserving-checker (checker &rest body)
+  "Run BODY and restore CHECKER's `modes' and `next-checkers' after it."
+  (declare (indent 1))
+  `(let ((modes (flycheck-checker-get ,checker 'modes))
+         (next (flycheck-checker-get ,checker 'next-checkers)))
+     (unwind-protect
+         (progn ,@body)
+       (setf (flycheck-checker-get ,checker 'modes) modes)
+       (setf (flycheck-checker-get ,checker 'next-checkers) next))))
+
+(describe "The native lsp checker, end to end"
+
+  (it "reports the diagnostics a scripted server pushes"
+    (assume (test-lsp-integration/possible-p) "No python3, or Windows")
+    (test-lsp-integration/preserving-checker 'flycheck-lsp
+      (test-lsp-integration/with-file-buffer
+        (let ((flycheck-lsp-servers
+               `((makefile-gmake-mode . ("python3" ,test-lsp-integration/server
+                                         "change"))))
+              (flycheck-checkers '(flycheck-lsp)))
+          (flycheck-lsp-mode 1)
+          (flycheck-buffer)
+          (expect (test-lsp-integration/wait-until
+                   (lambda () (= 2 (length flycheck-current-errors))) 10)
+                  :to-be-truthy)
+          (let ((messages (mapcar #'flycheck-error-message flycheck-current-errors)))
+            (expect messages :to-have-same-items-as
+                    '("mock warning" "mock error")))
+          (expect (mapcar #'flycheck-error-level flycheck-current-errors)
+                  :to-have-same-items-as '(warning error))))))
+
+  (it "checks once for an indexing server's republish storm"
+    (assume (test-lsp-integration/possible-p) "No python3, or Windows")
+    (test-lsp-integration/preserving-checker 'flycheck-lsp
+      (test-lsp-integration/with-file-buffer
+        (let ((flycheck-lsp-servers
+               `((makefile-gmake-mode . ("python3" ,test-lsp-integration/server
+                                         "push"))))
+              (flycheck-checkers '(flycheck-lsp)))
+          (flycheck-lsp-mode 1)
+          (flycheck-buffer)
+          ;; All five identical pushes must arrive...
+          (expect (test-lsp-integration/wait-until
+                   (lambda () (>= flycheck-lsp--push-count 5)) 10)
+                  :to-be-truthy)
+          ;; ...and the diagnostic with them
+          (expect (test-lsp-integration/wait-until
+                   (lambda () flycheck-current-errors) 10)
+                  :to-be-truthy)
+          ;; but only the first, which changed something, cost a re-check
+          (expect flycheck-lsp--recheck-count :to-equal 1))))))
+
+(describe "The Eglot bridge, end to end"
+
+  (it "delivers the diagnostics without storming the server"
+    (assume (test-lsp-integration/possible-p) "No python3, or Windows")
+    (assume (require 'eglot nil 'noerror) "Eglot not available")
+    (assume (and (fboundp 'eglot--connect) (fboundp 'eglot--guess-contact)
+                 ;; A signature change would error out of `apply', not skip
+                 (equal (func-arity (symbol-function 'eglot--connect)) '(5 . 5)))
+            "Eglot's connect entry points moved")
+    (test-lsp-integration/preserving-checker 'eglot-check
+      (test-lsp-integration/with-file-buffer
+        (let ((eglot-server-programs
+               `((makefile-gmake-mode . ("python3" ,test-lsp-integration/server
+                                         "pull"))))
+              (eglot-sync-connect t)
+              (flycheck-checkers '(eglot-check))
+              (server nil))
+          (unwind-protect
+              (progn
+                (setq server (apply #'eglot--connect (eglot--guess-contact)))
+                (expect (eglot-managed-p) :to-be-truthy)
+                (flycheck-eglot-mode 1)
+                (flycheck-buffer)
+                ;; The server's answer reaches the buffer whichever cadence
+                ;; this Emacs uses: one pushed report (Emacs 30), or the
+                ;; pulled and the pushed halves of one answer (Emacs 31)
+                (expect (test-lsp-integration/wait-until
+                         (lambda ()
+                           (seq-some (lambda (err)
+                                       (equal (flycheck-error-message err)
+                                              "mock warning"))
+                                     flycheck-current-errors))
+                         10)
+                        :to-be-truthy)
+                ;; Give a feedback loop, which would ask hundreds of times a
+                ;; second (#2291), a full second to show itself
+                (test-lsp-integration/pump 1)
+                (let ((pulls (or (cdr (assoc "textDocument/diagnostic"
+                                             (test-lsp-integration/stats)))
+                                 0)))
+                  (expect pulls :to-be-less-than 10)))
+            (flycheck-eglot-mode -1)
+            (advice-remove 'flymake-diagnostics
+                           #'flycheck-eglot--flymake-diagnostics)
+            (when server
+              (ignore-errors (eglot-shutdown server)))))))))
+
+;;; test-lsp-integration.el ends here


### PR DESCRIPTION
The Eglot re-check storms (#2262, #2291) got past the unit specs because those simulate the report cadence, and the cadence itself is what changed under Emacs 31. This adds a scripted stdio LSP server (stdlib-only Python) and specs that run the native flycheck-lsp checker and a real Eglot session against it: diagnostics must arrive, a five-fold republish storm must cost exactly one re-check, and the pull model must not turn into a request storm. The harness also flushed out that the Eglot code-action probe could signal in unmanaged buffers, so it now asks only where a server can answer.