### PR TITLE
Harden CI against supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# The workflows pin every action to a commit, so a compromised tag or
+# branch cannot reach CI; this keeps the pins from fossilizing by
+# offering the new commit as a reviewable PR instead.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         # Match the version Read the Docs builds with, so the manual is
         # checked against the Sphinx that actually publishes it

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -18,6 +18,9 @@ on:
       - 'test/fixtures/**'
       - 'test/record-fixture.el'
 
+permissions:
+  contents: read
+
 jobs:
   # On a pull request, against whatever the runner can be given quickly.
   # This is for telling someone their recording is wrong while they are
@@ -27,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@54b61ac9c1d7011a54d2b6d66dedbcddf20e2fb9 # master, 2026-08-06
       with:
         version: 30.2
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@5e7d164250e4b5e438fb02a21b57d001a3b189b2 # master, 2026-08-06
       with:
         version: 'snapshot'
 
@@ -43,7 +46,7 @@ jobs:
         sudo apt-get install --yes --no-install-recommends \
           cppcheck gawk tidy lua5.4 shellcheck libxml2-utils
         pip install --quiet flake8 pylint
-        npm install --global --silent stylelint stylelint-config-standard \
+        npm install --global --silent --ignore-scripts stylelint stylelint-config-standard \
           markdownlint-cli markdownlint-cli2 oxlint
 
     - run: make init
@@ -60,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
     # The image is large, and a runner arrives with tens of gigabytes of
     # toolchains this job has no use for.

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create GitHub Release with Auto-Generated Notes
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           tag: ${{ github.ref_name }}
           name: Flycheck ${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,20 +39,20 @@ jobs:
             experimental: true
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@54b61ac9c1d7011a54d2b6d66dedbcddf20e2fb9 # master, 2026-08-06
       with:
         version: ${{ matrix.emacs-version }}
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@5e7d164250e4b5e438fb02a21b57d001a3b189b2 # master, 2026-08-06
       with:
         version: 'snapshot'
 
     # `make init' installs a few dozen major-mode packages so the specs
     # have modes to run in, which is most of a job's time and does not
     # change between runs
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: .eask
         key: eask-${{ matrix.os }}-${{ matrix.emacs-version }}-${{ hashFiles('Eask') }}

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -35,8 +35,10 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
       dash zsh \
     && rm -rf /var/lib/apt/lists/*
 
-# The Node checkers.  --no-fund and --no-audit keep the log readable.
-RUN npm install --global --no-fund --no-audit \
+# The Node checkers.  --no-fund and --no-audit keep the log readable;
+# --ignore-scripts keeps install hooks from running, which none of these
+# packages need and which is the way the npm worms spread.
+RUN npm install --global --no-fund --no-audit --ignore-scripts \
       coffeescript \
       ember-template-lint \
       eslint \


### PR DESCRIPTION
Follow-up to #2301: every action the workflows run is now pinned to a commit rather than a mutable tag or branch (with Dependabot offering bumps as PRs), the workflow token is read-only everywhere nothing writes, and the npm linters the checker image and the fixtures job install run with --ignore-scripts, which none of them need and which is how the current worm campaign spreads.