### PR TITLE
Carry markdownlint's fixes via its JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- [#2319](https://github.com/flycheck/flycheck/pull/2319): `markdown-markdownlint-cli` now carries the fixes markdownlint suggests, so `C-c ! f` and `C-c ! F` apply them; the checker reads markdownlint's JSON output, and a rule configured with `severity: warning` now shows as a warning rather than an error.
 - [#2156](https://github.com/flycheck/flycheck/pull/2156): Add OCaml checkers. `ocaml-dune` checks a Dune project with `dune build @check`, so references to sibling modules and to the project's dependencies resolve, and `ocaml` checks a standalone file with `ocamlfind ocamlc`. Flycheck picks between them by whether the file belongs to a Dune project, since the compiler on its own would report every reference to a sibling module as an unbound module.
 - [#2157](https://github.com/flycheck/flycheck/pull/2157): Add a `swift` checker using `swiftc -parse`, which parses a file without type-checking it, so it is right for any Swift file whether or not it belongs to a package. Type errors need a language server that knows how the project is built, through `global-flycheck-eglot-mode` or `flycheck-lsp-mode`.
 - [#2286](https://github.com/flycheck/flycheck/pull/2286): Make `tcl-nagelfar` configurable: `flycheck-tcl-nagelfar-syntax-databases` lists the databases to load with `-s`, so a project whose procedures span several files stops reporting them as unknown commands, and `flycheck-tcl-nagelfar-args` passes arbitrary arguments (originally proposed in [#1906](https://github.com/flycheck/flycheck/pull/1906)).

--- a/flycheck.el
+++ b/flycheck.el
@@ -16699,30 +16699,108 @@ See URL `https://github.com/rpm-software-management/rpmlint'."
    (lambda (id) (substring id 0 5)))
   "Browse the markdownlint rule documentation for the error at point.")
 
+(defun flycheck-parse-markdownlint--column (line index buffer)
+  "Convert markdownlint's 1-based UTF-16 INDEX on LINE of BUFFER to a column.
+
+markdownlint counts JS string indices, which are UTF-16 code units, so
+a character outside the Basic Multilingual Plane counts twice and an
+edit to the right of one lands a column short, inside text it should
+leave alone.  Walk LINE's text consuming INDEX's units; the characters
+walked are the column.  Units left past the line's end, or the whole
+INDEX when BUFFER no longer has the line, count one column each, which
+keeps an edit appending at the end of a line intact."
+  (with-current-buffer buffer
+    (save-excursion
+      (save-restriction
+        (widen)
+        (goto-char (point-min))
+        (forward-line (1- line))
+        (let ((text (buffer-substring-no-properties
+                     (point) (line-end-position)))
+              (units (1- index))
+              (chars 0))
+          (while (and (> units 0) (< chars (length text)))
+            (cl-decf units (if (> (aref text chars) #xFFFF) 2 1))
+            (cl-incf chars))
+          (+ 1 chars (max 0 units)))))))
+
+(defun flycheck-parse-markdownlint--fix (info line description buffer)
+  "Build a `flycheck-fix' for BUFFER from markdownlint's fixInfo INFO.
+
+INFO edits one line, LINE unless it names another: it deletes
+`deleteCount' characters at `editColumn' and puts `insertText' there.
+A `deleteCount' of -1 deletes the whole line, newline included.
+DESCRIPTION describes the fix to the user."
+  (let-alist info
+    (let ((fline (or .lineNumber line)))
+      (flycheck--make-fix
+       buffer description
+       (list (if (eql .deleteCount -1)
+                 (flycheck-fix-edit-new
+                  :line fline :column 1
+                  :end-line (1+ fline) :end-column 1
+                  :replacement "")
+               ;; Both endpoints go through the UTF-16 conversion; the
+               ;; deleted span may itself contain astral characters, so
+               ;; converting deleteCount alone would not do.
+               (let ((start (or .editColumn 1)))
+                 (flycheck-fix-edit-new
+                  :line fline
+                  :column (flycheck-parse-markdownlint--column
+                           fline start buffer)
+                  :end-line fline
+                  :end-column (flycheck-parse-markdownlint--column
+                               fline (+ start (or .deleteCount 0)) buffer)
+                  :replacement (or .insertText "")))))))))
+
+(defun flycheck-parse-markdownlint (output checker buffer)
+  "Parse markdownlint JSON OUTPUT into Flycheck errors.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and the
+BUFFER that was checked respectively.  OUTPUT is what `--json' prints:
+one array of findings, each carrying the rule's names, an optional
+1-based `errorRange', and, for the auto-fixable findings, a `fixInfo'.
+A clean file prints nothing at all.
+
+See URL `https://github.com/DavidAnson/markdownlint' for more
+information."
+  (seq-map
+   (lambda (finding)
+     (let-alist finding
+       ;; The message mirrors the text output: the rule's description
+       ;; with the detail and the offending context bracketed after it.
+       ;; Only the start column is set, as the text output had it, so
+       ;; the highlighting does not change; the fix carries its own
+       ;; coordinates.
+       (flycheck-error-new-at
+        .lineNumber
+        (and .errorRange (elt .errorRange 0))
+        (if (equal .severity "warning") 'warning 'error)
+        (concat .ruleDescription
+                (when .errorDetail (format " [%s]" .errorDetail))
+                (when .errorContext (format " [Context: \"%s\"]" .errorContext)))
+        :id (string-join .ruleNames "/")
+        :checker checker
+        :buffer buffer
+        :filename .fileName
+        :fix (and .fixInfo
+                  (flycheck-parse-markdownlint--fix
+                   .fixInfo .lineNumber .ruleDescription buffer)))))
+   (car (flycheck-parse-json output))))
+
 (flycheck-define-checker markdown-markdownlint-cli
   "Markdown checker using markdownlint-cli.
 
 See URL `https://github.com/igorshubovych/markdownlint-cli'."
   :command ("markdownlint"
+            "--json"
             (config-file "--config" flycheck-markdown-markdownlint-cli-config)
             (option-list "--disable" flycheck-markdown-markdownlint-cli-disabled-rules)
             (option-list "--enable" flycheck-markdown-markdownlint-cli-enabled-rules)
             (eval flycheck-markdown-markdownlint-cli-args)
             "--"
             source)
-  :error-patterns
-  (;; markdownlint-cli v0.42+/cli2 v0.14+ include a severity word
-   (error line-start
-          (file-name) ":" line
-          (? ":" column) " "
-          (or "error" "warning") " "
-          (id (one-or-more (not (any space))))
-          " " (message) line-end)
-   ;; older versions without severity word
-   (error line-start
-          (file-name) ":" line
-          (? ":" column) " " (id (one-or-more (not (any space))))
-          " " (message) line-end))
+  :error-parser flycheck-parse-markdownlint
   :error-filter flycheck-markdownlint-error-filter
   :modes (markdown-mode gfm-mode)
   :error-explainer flycheck-markdownlint-error-explainer

--- a/test/fixtures/markdown-markdownlint-cli/language/markdown.md.txt
+++ b/test/fixtures/markdown-markdownlint-cli/language/markdown.md.txt
@@ -1,3 +1,56 @@
-markdown.md:1 error MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "## Second Header First"]
-markdown.md:3 error MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
-markdown.md:4:15 error MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 7]
+[
+  {
+    "fileName": "markdown.md",
+    "lineNumber": 1,
+    "ruleNames": [
+      "MD041",
+      "first-line-heading",
+      "first-line-h1"
+    ],
+    "ruleDescription": "First line in a file should be a top-level heading",
+    "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md041.md",
+    "errorDetail": null,
+    "errorContext": "## Second Header First",
+    "errorRange": null,
+    "fixInfo": null,
+    "severity": "error"
+  },
+  {
+    "fileName": "markdown.md",
+    "lineNumber": 3,
+    "ruleNames": [
+      "MD012",
+      "no-multiple-blanks"
+    ],
+    "ruleDescription": "Multiple consecutive blank lines",
+    "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md012.md",
+    "errorDetail": "Expected: 1; Actual: 2",
+    "errorContext": null,
+    "errorRange": null,
+    "fixInfo": {
+      "deleteCount": -1
+    },
+    "severity": "error"
+  },
+  {
+    "fileName": "markdown.md",
+    "lineNumber": 4,
+    "ruleNames": [
+      "MD009",
+      "no-trailing-spaces"
+    ],
+    "ruleDescription": "Trailing spaces",
+    "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md009.md",
+    "errorDetail": "Expected: 0 or 2; Actual: 7",
+    "errorContext": null,
+    "errorRange": [
+      15,
+      7
+    ],
+    "fixInfo": {
+      "editColumn": 15,
+      "deleteCount": 7
+    },
+    "severity": "error"
+  }
+]

--- a/test/specs/languages/test-markdown.el
+++ b/test/specs/languages/test-markdown.el
@@ -69,6 +69,80 @@
                        'markdown-markdownlint-cli2)))
             (expect args :to-contain "--no-globs"))))))
 
+  (describe "the fixes markdownlint suggests"
+    (it "converts each shape of fixInfo to an edit"
+      (flycheck-buttercup-with-temp-buffer
+        (let* ((output "[
+  {\"fileName\": \"doc.md\", \"lineNumber\": 3,
+   \"ruleNames\": [\"MD009\", \"no-trailing-spaces\"],
+   \"ruleDescription\": \"Trailing spaces\", \"severity\": \"error\",
+   \"fixInfo\": {\"editColumn\": 15, \"deleteCount\": 7}},
+  {\"fileName\": \"doc.md\", \"lineNumber\": 5,
+   \"ruleNames\": [\"MD012\", \"no-multiple-blanks\"],
+   \"ruleDescription\": \"Multiple consecutive blank lines\", \"severity\": \"error\",
+   \"fixInfo\": {\"deleteCount\": -1}},
+  {\"fileName\": \"doc.md\", \"lineNumber\": 7,
+   \"ruleNames\": [\"MD047\", \"single-trailing-newline\"],
+   \"ruleDescription\": \"Files should end with a single newline character\",
+   \"severity\": \"error\",
+   \"fixInfo\": {\"editColumn\": 10, \"insertText\": \"NL\"}},
+  {\"fileName\": \"doc.md\", \"lineNumber\": 9,
+   \"ruleNames\": [\"MD041\", \"first-line-heading\"],
+   \"ruleDescription\": \"First line should be a heading\",
+   \"severity\": \"error\", \"fixInfo\": null}]")
+               (parsed (flycheck-buttercup-parse
+                        'markdown-markdownlint-cli output))
+               (edit (lambda (err)
+                       (car (flycheck-fix-edits (flycheck-error-fix err))))))
+          ;; delete a character range on the line
+          (let ((e (funcall edit (nth 0 parsed))))
+            (expect (flycheck-fix-edit-line e) :to-equal 3)
+            (expect (flycheck-fix-edit-column e) :to-equal 15)
+            (expect (flycheck-fix-edit-end-line e) :to-equal 3)
+            (expect (flycheck-fix-edit-end-column e) :to-equal 22)
+            (expect (flycheck-fix-edit-replacement e) :to-equal ""))
+          ;; -1 deletes the whole line, newline included
+          (let ((e (funcall edit (nth 1 parsed))))
+            (expect (flycheck-fix-edit-line e) :to-equal 5)
+            (expect (flycheck-fix-edit-column e) :to-equal 1)
+            (expect (flycheck-fix-edit-end-line e) :to-equal 6)
+            (expect (flycheck-fix-edit-end-column e) :to-equal 1)
+            (expect (flycheck-fix-edit-replacement e) :to-equal ""))
+          ;; a pure insertion deletes nothing
+          (let ((e (funcall edit (nth 2 parsed))))
+            (expect (flycheck-fix-edit-column e) :to-equal 10)
+            (expect (flycheck-fix-edit-end-column e) :to-equal 10)
+            (expect (flycheck-fix-edit-replacement e) :to-equal "NL"))
+          ;; no fixInfo, no fix
+          (expect (flycheck-error-fix (nth 3 parsed)) :to-be nil))))
+
+    (it "converts markdownlint's UTF-16 indices to character columns"
+      ;; markdownlint counts JS string indices, where a character outside
+      ;; the BMP counts twice; applied as Emacs columns unconverted, the
+      ;; edit lands one column short and corrupts the line.
+      (flycheck-buttercup-with-temp-buffer
+        (insert "🎉 see (docs)[https://example.com] here\n")
+        (let* ((output "[
+  {\"fileName\": \"doc.md\", \"lineNumber\": 1,
+   \"ruleNames\": [\"MD011\", \"no-reversed-links\"],
+   \"ruleDescription\": \"Reversed link syntax\", \"severity\": \"error\",
+   \"fixInfo\": {\"editColumn\": 8, \"deleteCount\": 27,
+                 \"insertText\": \"[docs](https://example.com)\"}}]")
+               (parsed (flycheck-buttercup-parse
+                        'markdown-markdownlint-cli output))
+               (edit (car (flycheck-fix-edits
+                           (flycheck-error-fix (car parsed))))))
+          (expect (flycheck-fix-edit-column edit) :to-equal 7)
+          (expect (flycheck-fix-edit-end-column edit) :to-equal 34)
+          (flycheck-apply-fix (flycheck-error-fix (car parsed)))
+          (expect (buffer-string)
+                  :to-equal "🎉 see [docs](https://example.com) here\n"))))
+
+    (it "reads a clean file's empty output as no errors"
+      (flycheck-buttercup-with-temp-buffer
+        (expect (flycheck-buttercup-parse 'markdown-markdownlint-cli "")
+                :to-be nil))))
+
   (describe "reading the tool's output"
     ;; Read from output recorded earlier, so this runs whether or
     ;; not the tool is installed here


### PR DESCRIPTION
markdownlint computes machine-applicable fixes for its auto-fixable rules, and the text output the checker parsed just dropped them. Reading --json instead turns them into quick fixes for C-c ! f and C-c ! F, with markdownlint's UTF-16 column indices converted to character columns so an edit to the right of an emoji doesn't corrupt the line. Messages, ids and columns are unchanged, and applying the fixes byte-matches markdownlint --fix.