### PR TITLE
Skip annotate rebuilds over clean lines, add a benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ specs: compile
 # branch against master on the same machine.
 .PHONY: bench
 bench:
-	$(EASK) exec emacs --batch -L . -l test/benchmark.el \
+	$(EASK) exec emacs --batch -L . -l test/flycheck-benchmark.el \
 		-f flycheck-benchmark-batch
 
 DOCKER ?= docker

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,13 @@ compile:
 specs: compile
 	$(EASK) exec buttercup -L . -L test -L test/specs test/specs
 
+# Times the hot paths; nothing asserts, the numbers are for comparing a
+# branch against master on the same machine.
+.PHONY: bench
+bench:
+	$(EASK) exec emacs --batch -L . -l test/benchmark.el \
+		-f flycheck-benchmark-batch
+
 DOCKER ?= docker
 CHECKER_IMAGE ?= flycheck-checkers
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -8519,20 +8519,53 @@ anything."
                                            flycheck-annotate-style-functions))))
               (funcall render errors anchor focused))))))))
 
+(defun flycheck-annotate--line-clean-p (pos)
+  "Whether the line around POS carries no Flycheck error overlays.
+
+The scan runs through the newline: an error reported past the last
+character, such as a missing semicolon, gets an overlay starting
+exactly at the line's end, and it anchors an annotation on this line
+all the same."
+  (save-excursion
+    (goto-char pos)
+    (not (flycheck-overlays-in (line-beginning-position)
+                               (min (point-max)
+                                    (1+ (line-end-position)))))))
+
 (defun flycheck-annotate--post-command ()
   "Rebuild the inline overlays if point, the window or the buffer changed.
 
-Skips the rebuild only when nothing that affects the annotations happened:
-point stayed on its line, the window did not scroll, and the buffer was not
-edited.  The buffer-change check catches edits that leave point on its line
-\(such as `open-line'), which the line and window checks alone would miss,
-and keeps a `below'-style connector aligned as the code under it changes.
-The check runs once per command, so a bulk edit rebuilds once rather than
-once per change."
-  (unless (and (eql (line-beginning-position) flycheck-annotate--last-line-start)
-               (eql (window-start) flycheck-annotate--last-window-start)
-               (eql (buffer-chars-modified-tick) flycheck-annotate--last-tick))
-    (flycheck-annotate--refresh)))
+Skips the rebuild when nothing that affects the annotations happened:
+point stayed on its line, the window did not scroll, and the buffer was
+not edited.  The buffer-change check catches edits that leave point on
+its line \(such as `open-line'), which the line and window checks alone
+would miss, and keeps a `below'-style connector aligned as the code
+under it changes.  The check runs once per command, so a bulk edit
+rebuilds once rather than once per change.
+
+Crossing between two lines that carry no errors is also a skip: which
+line has point only tells on the rendering through the current-line
+tier, and a line without errors renders nothing under any tier.  Most
+navigation is over clean lines, and every skipped rebuild is a screen's
+worth of overlays not rebuilt mid-keystroke."
+  (let ((same-window-and-text
+         (and (eql (window-start) flycheck-annotate--last-window-start)
+              (eql (buffer-chars-modified-tick) flycheck-annotate--last-tick))))
+    (unless (and same-window-and-text
+                 (or (eql (line-beginning-position)
+                          flycheck-annotate--last-line-start)
+                     ;; The recorded line is a live position: the text is
+                     ;; unedited under this guard, so it has not shifted.
+                     ;; Narrowing does not bump the tick, though, so the
+                     ;; position must still be accessible to be inspected.
+                     (and flycheck-annotate--last-line-start
+                          (<= (point-min)
+                              flycheck-annotate--last-line-start
+                              (point-max))
+                          (flycheck-annotate--line-clean-p (point))
+                          (flycheck-annotate--line-clean-p
+                           flycheck-annotate--last-line-start))))
+      (flycheck-annotate--refresh))))
 
 (defvar-local flycheck-annotate--rebuilding nil
   "Whether a rebuild is already under way in this buffer.")

--- a/test/flycheck-benchmark.el
+++ b/test/flycheck-benchmark.el
@@ -1,0 +1,102 @@
+;;; benchmark.el --- How long Flycheck's hot paths take  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Flycheck contributors
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Times the paths a keystroke or a finished check pays for: overlay
+;; creation, error-list rendering, the inline-annotation rebuild, and
+;; the post-command guard that decides whether to rebuild at all.  Run
+;; with `make bench'.
+;;
+;; The numbers mean nothing across machines and everything across
+;; branches: run on master, run on the branch, compare.  A timing
+;; assertion in CI would flake, so nothing here asserts.
+
+;;; Code:
+
+(require 'flycheck)
+
+(defconst flycheck-benchmark-lines 2000
+  "Lines in the benchmark buffer.")
+
+(defconst flycheck-benchmark-errors 1000
+  "Errors spread over the benchmark buffer, one every other line.")
+
+(defun flycheck-benchmark--buffer ()
+  "Return a fresh benchmark buffer with errors on every other line."
+  (let ((buffer (generate-new-buffer "*flycheck-benchmark*")))
+    (with-current-buffer buffer
+      (dotimes (i flycheck-benchmark-lines)
+        (insert (format "line %d of unremarkable code\n" i)))
+      (setq-local flycheck-mode t)
+      (setq flycheck-current-errors
+            (let (errors)
+              (dotimes (i flycheck-benchmark-errors)
+                (push (flycheck-error-new-at
+                       (1+ (* 2 i)) 6 (if (zerop (mod i 10)) 'error 'warning)
+                       (format "benchmark error %d with a message of usual length" i)
+                       :id (format "B%03d" (mod i 100))
+                       :checker 'emacs-lisp
+                       :buffer buffer)
+                      errors))
+              (nreverse errors))))
+    buffer))
+
+(defmacro flycheck-benchmark--report (label repetitions &rest body)
+  "Time BODY run REPETITIONS times and print it under LABEL."
+  (declare (indent 2))
+  `(let ((timing (benchmark-run ,repetitions ,@body)))
+     (message "  %-42s %8.2f ms  (%d gcs)"
+              ,label (/ (* 1000 (car timing)) ,repetitions) (nth 1 timing))))
+
+(defun flycheck-benchmark-run ()
+  "Run the benchmarks and print one line per path."
+  (message "%d lines, %d errors; per-iteration times:"
+           flycheck-benchmark-lines flycheck-benchmark-errors)
+  ;; Overlay creation, what publishing a finished check pays
+  (with-current-buffer (flycheck-benchmark--buffer)
+    (flycheck-benchmark--report "add-overlay for every error" 5
+      (mapc #'flycheck-add-overlay flycheck-current-errors)
+      (flycheck-delete-all-overlays)))
+  ;; The error list's rows, what the list pays to (re)display
+  (with-current-buffer (flycheck-benchmark--buffer)
+    (let ((flycheck-error-list-source-buffer (current-buffer)))
+      (flycheck-benchmark--report "error-list entries" 5
+        (flycheck-error-list-entries))))
+  ;; The inline-annotation rebuild, what a command that moves onto an
+  ;; annotated line pays with the mode on
+  (with-current-buffer (flycheck-benchmark--buffer)
+    (set-window-buffer (selected-window) (current-buffer))
+    (mapc #'flycheck-add-overlay flycheck-current-errors)
+    (goto-char (point-min))
+    (let ((flycheck-annotate-mode t))
+      (flycheck-benchmark--report "annotate refresh of the visible region" 20
+        (flycheck-annotate--refresh)))
+    ;; The guard for a command that only moved point between clean lines
+    (let ((flycheck-annotate-mode t))
+      (flycheck-annotate--refresh)
+      (flycheck-benchmark--report "post-command guard, clean-line crossing" 200
+        (flycheck-annotate--post-command)))))
+
+(defun flycheck-benchmark-batch ()
+  "Entry point for `make bench'."
+  (flycheck-benchmark-run))
+
+(provide 'flycheck-benchmark)
+;;; benchmark.el ends here

--- a/test/flycheck-benchmark.el
+++ b/test/flycheck-benchmark.el
@@ -1,4 +1,4 @@
-;;; benchmark.el --- How long Flycheck's hot paths take  -*- lexical-binding: t; -*-
+;;; flycheck-benchmark.el --- How long Flycheck's hot paths take  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2026 Flycheck contributors
 
@@ -88,10 +88,16 @@
     (let ((flycheck-annotate-mode t))
       (flycheck-benchmark--report "annotate refresh of the visible region" 20
         (flycheck-annotate--refresh)))
-    ;; The guard for a command that only moved point between clean lines
-    (let ((flycheck-annotate-mode t))
+    ;; The guard for a command that moved point between two clean lines,
+    ;; which is the skip the guard exists to make cheap; ping-pong so
+    ;; every iteration really crosses
+    (let ((flycheck-annotate-mode t)
+          (here (point-min))
+          (there (save-excursion (goto-char (point-min))
+                                 (forward-line 2) (point))))
       (flycheck-annotate--refresh)
       (flycheck-benchmark--report "post-command guard, clean-line crossing" 200
+        (goto-char (if (eql (point) here) there here))
         (flycheck-annotate--post-command)))))
 
 (defun flycheck-benchmark-batch ()
@@ -99,4 +105,4 @@
   (flycheck-benchmark-run))
 
 (provide 'flycheck-benchmark)
-;;; benchmark.el ends here
+;;; flycheck-benchmark.el ends here

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -754,6 +754,68 @@ a newline, so key it back under the code line."
               (expect flycheck-annotate--last-tick
                       :to-equal (buffer-chars-modified-tick))))))))
 
+    (it "does not rebuild crossing between two clean lines"
+      ;; Which line has point only matters through the current-line tier,
+      ;; and a line without errors renders nothing under any tier.
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)          ; errors on lines 2 and 4
+          (goto-char (point-min))        ; line 1, clean
+          (flycheck-annotate-mode 1)
+          (spy-on 'flycheck-annotate--refresh)
+          (goto-char (point-max))        ; past line 4, clean line 5
+          (flycheck-annotate--post-command)
+          (expect 'flycheck-annotate--refresh :not :to-have-been-called))))
+
+    (it "rebuilds crossing from a clean line onto an error line"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)          ; errors on lines 2 and 4
+          (goto-char (point-min))        ; line 1, clean
+          (flycheck-annotate-mode 1)
+          (spy-on 'flycheck-annotate--refresh)
+          (goto-char (point-min))
+          (forward-line 1)               ; line 2 carries an error
+          (flycheck-annotate--post-command)
+          (expect 'flycheck-annotate--refresh :to-have-been-called))))
+
+    (it "rebuilds leaving an error line for a clean one"
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (test-annotate/setup)          ; errors on lines 2 and 4
+          (goto-char (point-min))
+          (forward-line 1)               ; line 2 carries an error
+          (flycheck-annotate-mode 1)
+          (spy-on 'flycheck-annotate--refresh)
+          (goto-char (point-min))        ; back to clean line 1
+          (flycheck-annotate--post-command)
+          (expect 'flycheck-annotate--refresh :to-have-been-called))))
+
+    (it "counts an error anchored at the line's very end as the line's"
+      ;; A missing-semicolon style error is reported past the last
+      ;; character, so its overlay starts exactly at eol; the line must
+      ;; not pass for clean, or the annotation sticks in the wrong tier.
+      (flycheck-buttercup-with-temp-buffer
+        (save-window-excursion
+          (set-window-buffer (selected-window) (current-buffer))
+          (insert "ab\ncd\n")
+          (setq-local flycheck-mode t)
+          (let ((e (flycheck-error-new-at 1 3 'error "missing ;"
+                                          :buffer (current-buffer)
+                                          :checker 'emacs-lisp)))
+            (setq flycheck-current-errors (list e))
+            (mapc #'flycheck-add-overlay flycheck-current-errors))
+          (goto-char (point-min))
+          (forward-line 1)               ; line 2, clean
+          (flycheck-annotate-mode 1)
+          (spy-on 'flycheck-annotate--refresh)
+          (goto-char (point-min))        ; onto the annotated line 1
+          (flycheck-annotate--post-command)
+          (expect 'flycheck-annotate--refresh :to-have-been-called))))
+
   (describe "the background tint"
     (it "adds no tint when disabled"
       (flycheck-buttercup-with-temp-buffer


### PR DESCRIPTION
flycheck-annotate-mode rebuilt every visible annotation on any command that moved point to another line, but point's line only affects the rendering through the current-line tier, so crossing between two lines without errors changes nothing and now skips the rebuild. Also adds make bench, which times the hot paths for comparing a branch against master.