### PR TITLE
Pin textlint's quick fixes with a spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- [#2322](https://github.com/flycheck/flycheck/pull/2322): `textlint` carries the fixes its fixable rules emit, such as `common-misspellings`, so `C-c ! f` applies them; its eslint-compatible output had the fixes all along, and now a spec keeps it that way.
 - [#2319](https://github.com/flycheck/flycheck/pull/2319): `markdown-markdownlint-cli` now carries the fixes markdownlint suggests, so `C-c ! f` and `C-c ! F` apply them; the checker reads markdownlint's JSON output, and a rule configured with `severity: warning` now shows as a warning rather than an error.
 - [#2156](https://github.com/flycheck/flycheck/pull/2156): Add OCaml checkers. `ocaml-dune` checks a Dune project with `dune build @check`, so references to sibling modules and to the project's dependencies resolve, and `ocaml` checks a standalone file with `ocamlfind ocamlc`. Flycheck picks between them by whether the file belongs to a Dune project, since the compiler on its own would report every reference to a sibling module as an unbound module.
 - [#2157](https://github.com/flycheck/flycheck/pull/2157): Add a `swift` checker using `swiftc -parse`, which parses a file without type-checking it, so it is right for any Swift file whether or not it belongs to a package. Type errors need a language server that knows how the project is built, through `global-flycheck-eglot-mode` or `flycheck-lsp-mode`.

--- a/test/specs/languages/test-text.el
+++ b/test/specs/languages/test-text.el
@@ -42,7 +42,27 @@
 
     (flycheck-buttercup-def-parse-test textlint "language/text/text.txt"
       '(1 7 error "\"very\" is a weasel word and can weaken meaning"
-          :id "write-good")))
+          :id "write-good"))
+
+    (it "carries the fixes a fixable rule emits"
+      ;; textlint's JSON rides the eslint parser, whose fix extraction
+      ;; therefore works here too; this pins that compatibility, since
+      ;; nothing else exercises it.  The fix's range is a pair of
+      ;; absolute character offsets, wider here than the diagnostic's.
+      (flycheck-buttercup-with-temp-buffer
+        (insert "This is a occurence of a word.\n")
+        (let* ((output "[{\"messages\": [
+  {\"type\": \"lint\", \"ruleId\": \"common-misspellings\",
+   \"message\": \"This is a commonly misspelled word. Correct it to occurrence\",
+   \"line\": 1, \"column\": 11, \"range\": [10, 11], \"severity\": 2,
+   \"fix\": {\"range\": [10, 19], \"text\": \"occurrence\"}}],
+  \"filePath\": \"text.txt\"}]")
+               (errs (flycheck-parse-eslint output 'textlint (current-buffer)))
+               (fix (flycheck-error-fix (car errs))))
+          (expect fix :not :to-be nil)
+          (flycheck-apply-fix fix)
+          (expect (buffer-string)
+                  :to-equal "This is a occurrence of a word.\n")))))
 
   (describe "the textlint checker command"
     (it "appends flycheck-textlint-args before the source file"


### PR DESCRIPTION
textlint's eslint-compatible JSON meant the fix extraction from #2193 worked for it all along, unverified and undocumented. The applied fix byte-matches textlint --fix for a common-misspellings case; the new spec keeps the compatibility pinned since nothing else exercises it.