### PR TITLE
Keep a chain's earlier errors when a checker dies by signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Bugs fixed
 
+- [#2324](https://github.com/flycheck/flycheck/pull/2324): Keep the errors earlier checkers in a chain reported when a later checker dies by a signal, and say what killed it, instead of clearing the buffer's whole result ([#1881](https://github.com/flycheck/flycheck/issues/1881)).
 - [#2323](https://github.com/flycheck/flycheck/pull/2323): Fix `flycheck-next-error` cycling forever between two errors when one's region sits inside the other's, and `flycheck-previous-error` skipping the inner one ([#1781](https://github.com/flycheck/flycheck/issues/1781)). Language servers report overlapping regions routinely, so the 2020 bug bites much harder today.
 - [#2299](https://github.com/flycheck/flycheck/pull/2299): Show an annotation straight away when you jump to an error, rather than on the next thing you do ([#2293](https://github.com/flycheck/flycheck/issues/2293)). Annotations are built for the visible part of the buffer from `post-command-hook`, which runs before redisplay, so a jump that sends point off screen was building them while the window still described where it had been.
 - [#2299](https://github.com/flycheck/flycheck/pull/2299): Keep a `sideline` annotation off the column the continuation glyph needs, so a message that fits stops spilling onto the next line by one character ([#2292](https://github.com/flycheck/flycheck/issues/2292)). Without a right fringe to draw that glyph in, as on a terminal, the rightmost column is not text's to use.

--- a/flycheck.el
+++ b/flycheck.el
@@ -9763,10 +9763,11 @@ CHECKER."
     (let ((pending-output (process-get process 'flycheck-pending-output)))
       (apply #'concat (nreverse pending-output)))))
 
-(defun flycheck-handle-signal (process _event)
+(defun flycheck-handle-signal (process event)
   "Handle a signal from the syntax checking PROCESS.
 
-_EVENT is ignored."
+EVENT describes how the process died and stands in for the exit
+status when a signal killed it."
   (when (memq (process-status process) '(signal exit))
     (let ((files (process-get process 'flycheck-temporaries))
           (buffer (process-get process 'flycheck-buffer))
@@ -9778,15 +9779,21 @@ _EVENT is ignored."
       (when (buffer-live-p buffer)
         (with-current-buffer buffer
           (condition-case err
-              (pcase (process-status process)
-                (`signal
-                 (funcall callback 'interrupted))
-                (`exit
-                 (flycheck-finish-checker-process
-                  (process-get process 'flycheck-checker)
-                  (or err (process-exit-status process))
-                  files
-                  (flycheck-get-output process) callback cwd)))
+              (flycheck-finish-checker-process
+               (process-get process 'flycheck-checker)
+               ;; A checker killed by a signal is a crashed checker, not
+               ;; an interruption Flycheck asked for: deliberate kills
+               ;; discard their syntax check before killing, so their
+               ;; report never lands anywhere.  Finishing like a
+               ;; non-zero exit keeps what earlier checkers in the chain
+               ;; already reported, where the `interrupted' status threw
+               ;; the whole chain's work away (#1881).
+               (or err
+                   (if (eq (process-status process) 'signal)
+                       (string-trim (or event "killed"))
+                     (process-exit-status process)))
+               files
+               (flycheck-get-output process) callback cwd)
             ((debug error)
              (funcall callback 'errored (error-message-string err)))))))))
 
@@ -9830,9 +9837,14 @@ Resolve all errors in OUTPUT using CWD as working directory."
             ;; (e.g. includes) even if there are no errors in the file being
             ;; checked.
             (funcall callback 'suspicious
-                     (format "Exited with status %S, printing output that \
+                     (format "%s, printing output that \
 contained no errors Flycheck could read:\n\n%s"
-                             exit-status output))))))
+                             ;; A string names the signal that killed the
+                             ;; process; "exited" would misdescribe it
+                             (if (stringp exit-status)
+                                 (format "Died (%s)" exit-status)
+                               (format "Exited with status %S" exit-status))
+                             output))))))
       (unless self-disabled
         (funcall callback 'finished
                  ;; Fix error file names, by substituting them backwards

--- a/test/specs/test-command-checker.el
+++ b/test/specs/test-command-checker.el
@@ -162,6 +162,27 @@ afterwards."
           (expect (shut-up (flycheck-buttercup-should-syntax-check-in-buffer))
                   :to-throw 'flycheck-buttercup-suspicious-checker))))
 
+    (it "keeps earlier chain output when a later checker dies by signal"
+      ;; A crashed checker used to report `interrupted', which cleared
+      ;; everything the checkers before it in the chain had found.  See
+      ;; #1881.
+      (assume (not (memq system-type '(windows-nt ms-dos cygwin)))
+              "Signals work differently on Windows")
+      (assume (executable-find "sh") "No sh to kill")
+      (assume (or (executable-find "python3") (executable-find "python")))
+      (cl-letf* ((flycheck-checkers '(chain-first chain-killed))
+                 (flycheck-checker 'chain-first)
+                 ((symbol-plist 'chain-first) flycheck-test--chain-first)
+                 ((symbol-plist 'chain-killed) flycheck-test--chain-killed))
+        (flycheck-buttercup-with-temp-buffer
+          (chain-crash-mode)
+          (insert "hello\n")
+          (shut-up (flycheck-buttercup-buffer-sync))
+          (expect (mapcar #'flycheck-error-message flycheck-current-errors)
+                  :to-equal '("first checker finding"))
+          (expect (mapcar #'flycheck-error-checker flycheck-current-errors)
+                  :to-equal '(chain-first)))))
+
     (it "reports errors returned by the :handle-suspicious function"
       (assume (or (executable-find "python3") (executable-find "python")))
       (cl-letf* ((flycheck-checker 'suspicious-exit)

--- a/test/specs/test-helpers.el
+++ b/test/specs/test-helpers.el
@@ -351,6 +351,37 @@ The manifest path is relative to
   "Saved plist for the suspicious-exit checker.")
 
 (setf (symbol-plist 'suspicious-exit) nil)
+
+;;; Chain-crash test helpers (for the mid-chain crash tests)
+
+(define-derived-mode chain-crash-mode prog-mode "chain-crash")
+
+(flycheck-define-command-checker 'chain-first
+  "Report one warning, then hand over to a checker that dies."
+  :command `(,(or (executable-find "python3") "python")
+             "-c" "print('finding:1:first checker finding')")
+  :error-patterns '((warning bol "finding:" line ":" (message) eol))
+  :modes '(chain-crash-mode)
+  :next-checkers '(chain-killed))
+
+(flycheck-define-command-checker 'chain-killed
+  "Die by a signal instead of exiting."
+  :command '("sh" "-c" "kill -9 $$")
+  :error-patterns '((error bol "never-matches:" line ":" (message)))
+  :modes '(chain-crash-mode))
+
+(defconst flycheck-test--chain-first
+  (symbol-plist 'chain-first)
+  "Saved plist for the chain-first checker.")
+
+(defconst flycheck-test--chain-killed
+  (symbol-plist 'chain-killed)
+  "Saved plist for the chain-killed checker.")
+
+(setf (symbol-plist 'chain-first) nil)
+(setf (symbol-plist 'chain-killed) nil)
+
+
 ;;; Excessive-errors test helpers (for error-threshold tests)
 
 (define-derived-mode many-errors-mode prog-mode "many")


### PR DESCRIPTION
A checker in a :next-checkers chain dying by a signal reported interrupted, which wiped everything earlier checkers had already found - the issue's C++ repro loses all of checker A's errors when checker B aborts. Deliberate interruptions discard the check before killing, so a signal report that lands is a genuine crash; it now finishes through the suspicious machinery with the signal named in the message, and the chain's earlier output survives. One deliberate trade: whatever the crashed checker printed before dying gets parsed now instead of thrown away, so a finding clipped mid-line can surface where before nothing did. Fixes #1881.