### PR TITLE
Keep org-lint's id-link checker out of the check by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Bugs fixed
 
+- [#2325](https://github.com/flycheck/flycheck/pull/2325): Stop `org-lint` freezing Emacs on large Org setups ([#2161](https://github.com/flycheck/flycheck/issues/2161)): its `invalid-id-link` checker rescans every org-id file in the session on each check, so it sits in the new `flycheck-org-lint-disabled-checkers` by default; set that to nil to run everything org-lint has.
 - [#2324](https://github.com/flycheck/flycheck/pull/2324): Keep the errors earlier checkers in a chain reported when a later checker dies by a signal, and say what killed it, instead of clearing the buffer's whole result ([#1881](https://github.com/flycheck/flycheck/issues/1881)).
 - [#2323](https://github.com/flycheck/flycheck/pull/2323): Fix `flycheck-next-error` cycling forever between two errors when one's region sits inside the other's, and `flycheck-previous-error` skipping the inner one ([#1781](https://github.com/flycheck/flycheck/issues/1781)). Language servers report overlapping regions routinely, so the 2020 bug bites much harder today.
 - [#2299](https://github.com/flycheck/flycheck/pull/2299): Show an annotation straight away when you jump to an error, rather than on the next thing you do ([#2293](https://github.com/flycheck/flycheck/issues/2293)). Annotations are built for the visible part of the buffer from `post-command-hook`, which runs before redisplay, so a jump that sends point off screen was building them while the window still described where it had been.

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -947,6 +947,16 @@ to view the docstring of the syntax checker.  Likewise, you may use
       The checker is enabled by default when ``org-lint`` is available (Org mode
       9.0 or later).
 
+      .. defcustom:: flycheck-org-lint-disabled-checkers
+
+         A list of org-lint checkers (symbols naming entries in
+         ``org-lint--checkers``) not to run.  By default the
+         ``invalid-id-link`` checker is disabled: it rescans every org-id
+         file Emacs knows about on each check, in the current Emacs
+         process, which freezes Emacs for tens of seconds per check on a
+         large Org setup such as org-roam.  Set to ``nil`` to run every
+         checker org-lint has.
+
       See the ``org-lint`` documentation in Org mode for details about the checks
       performed.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13859,6 +13859,22 @@ The checker runs `checkdoc-current-buffer'."
   (setf (car (flycheck-checker-get checker 'command))
         flycheck-this-emacs-executable))
 
+(declare-function org-lint-checker-name "org-lint")
+(defvar org-lint--checkers)
+
+(flycheck-def-option-var flycheck-org-lint-disabled-checkers
+    '(invalid-id-link) org-lint
+  "Org-lint checkers not to run.
+
+A list of symbols naming entries in `org-lint--checkers'.  The default
+keeps `invalid-id-link' out: it rescans every org-id file the session
+knows about on each invocation, in the main Emacs process, so with an
+org-roam-sized corpus a single check costs tens of seconds per idle
+pause.  Set this to nil to run everything org-lint has."
+  :type '(repeat symbol)
+  :safe #'flycheck-symbol-list-p
+  :package-version '(flycheck . "39"))
+
 (flycheck-define-generic-checker 'org-lint
   "An Org mode syntax checker using `org-lint'.
 
@@ -13866,25 +13882,42 @@ The checker runs `org-lint' in the current Emacs process, so it
 has access to all installed packages and user configuration."
   :start (lambda (checker callback)
            (condition-case err
-               (let ((errors
-                      (delq nil
-                            (mapcar
-                             (lambda (e)
-                               (pcase e
-                                 (`(,_n [,line ,_trust ,desc ,_checker])
-                                  (flycheck-error-new-at
-                                   (if (stringp line)
-                                       (string-to-number line)
-                                     line)
-                                   nil 'info desc
-                                   :checker checker))
-                                 (_
-                                  (flycheck-error-new-at
-                                   1 nil 'warning
-                                   (format "Unexpected org-lint format: %S" e)
-                                   :checker checker))))
-                             (org-lint)))))
-                 (funcall callback 'finished errors))
+               (progn
+                 ;; Loaded before the let binds its registry: were the
+                 ;; load to happen inside, the registrations would land
+                 ;; in the binding and unwind away with it.
+                 (require 'org-lint)
+                 ;; org-lint's list ARG is an allowlist, so a
+                 ;; denylist has to read the registry to compute the
+                 ;; complement anyway; binding it keeps one source of
+                 ;; truth and leaves the nil-ARG call path alone.
+                 (let* ((org-lint--checkers
+                         (if flycheck-org-lint-disabled-checkers
+                             (seq-remove
+                              (lambda (c)
+                                (memq (org-lint-checker-name c)
+                                      flycheck-org-lint-disabled-checkers))
+                              org-lint--checkers)
+                           org-lint--checkers))
+                        (errors
+                         (delq nil
+                               (mapcar
+                                (lambda (e)
+                                  (pcase e
+                                    (`(,_n [,line ,_trust ,desc ,_checker])
+                                     (flycheck-error-new-at
+                                      (if (stringp line)
+                                          (string-to-number line)
+                                        line)
+                                      nil 'info desc
+                                      :checker checker))
+                                    (_
+                                     (flycheck-error-new-at
+                                      1 nil 'warning
+                                      (format "Unexpected org-lint format: %S" e)
+                                      :checker checker))))
+                                (org-lint)))))
+                   (funcall callback 'finished errors)))
              (error (funcall callback 'errored
                              (error-message-string err)))))
   :modes '(org-mode)
@@ -13897,7 +13930,18 @@ has access to all installed packages and user configuration."
                      :message (if (fboundp 'org-lint)
                                   (format "yes (Org %s)" org-version)
                                 "no")
-                     :face (if (fboundp 'org-lint) 'success 'warning))))))
+                     :face (if (fboundp 'org-lint) 'success 'warning))
+                    ;; The answer to "where did my id-link warnings go?"
+                    (flycheck-verification-result-new
+                     :label "Disabled org-lint checkers"
+                     :message (if flycheck-org-lint-disabled-checkers
+                                  (format "%s (see %s)"
+                                          (mapconcat #'symbol-name
+                                                     flycheck-org-lint-disabled-checkers
+                                                     ", ")
+                                          "flycheck-org-lint-disabled-checkers")
+                                "none")
+                     :face 'success)))))
 
 (defun flycheck-ember-template--check-for-config (&rest _ignored)
   "Check the required config file is available up the file system."

--- a/test/specs/languages/test-org.el
+++ b/test/specs/languages/test-org.el
@@ -17,6 +17,43 @@
   (flycheck-buttercup-def-checker-test org-lint org valid
     (let ((inhibit-message t))
       (flycheck-buttercup-should-syntax-check
-       "language/org/valid.org" 'org-mode))))
+       "language/org/valid.org" 'org-mode)))
+
+  (describe "the org-lint checkers that run"
+    ;; invalid-id-link rescans every org-id file in the session on each
+    ;; invocation, in the main Emacs process; with an org-roam-sized
+    ;; corpus that is tens of seconds per idle pause.  See #2161.
+
+    (it "keeps the disabled checkers away from org-lint"
+      (require 'org-lint)
+      (let ((seen 'unset))
+        (cl-letf (((symbol-function 'org-lint)
+                   (lambda (&rest _) (setq seen org-lint--checkers) nil)))
+          (flycheck-buttercup-with-temp-buffer
+            (insert "* Heading\n")
+            (org-mode)
+            (funcall (flycheck-checker-get 'org-lint 'start)
+                     'org-lint #'ignore)))
+        (expect (seq-some (lambda (c)
+                            (eq (org-lint-checker-name c) 'invalid-id-link))
+                          seen)
+                :to-be nil)
+        ;; and it only removed, not replaced, the rest
+        (expect (length seen)
+                :to-equal (- (length org-lint--checkers)
+                             (length flycheck-org-lint-disabled-checkers)))))
+
+    (it "runs everything when nothing is disabled"
+      (require 'org-lint)
+      (let ((seen 'unset)
+            (flycheck-org-lint-disabled-checkers nil))
+        (cl-letf (((symbol-function 'org-lint)
+                   (lambda (&rest _) (setq seen org-lint--checkers) nil)))
+          (flycheck-buttercup-with-temp-buffer
+            (insert "* Heading\n")
+            (org-mode)
+            (funcall (flycheck-checker-get 'org-lint 'start)
+                     'org-lint #'ignore)))
+        (expect (length seen) :to-equal (length org-lint--checkers))))))
 
 ;;; test-org.el ends here


### PR DESCRIPTION
org-lint's invalid-id-link checker rescans every org-id file in the session on each invocation, in the main Emacs process - measured at 42 of a 45 second check with a thousand-file corpus, paid on every idle pause. The new flycheck-org-lint-disabled-checkers option excludes it by default (the other ~50 checks cost a fifth of a second); C-c ! v shows what's off, and nil runs everything. Fixes the remaining half of #2161.