### PR TITLE
Read Scala 3's boxed diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Bugs fixed
 
+- [#2327](https://github.com/flycheck/flycheck/pull/2327): Read Scala 3's diagnostics. The compiler draws each of them in a box under a `-- [E008] Not Found Error: file:line:column` header, with unconditional coloring, so the `scala` checker has reported nothing on Scala 3 since dotty shipped. Scala 2's plain output is still read ([#2179](https://github.com/flycheck/flycheck/issues/2179)).
 - [#2325](https://github.com/flycheck/flycheck/pull/2325): Stop `org-lint` freezing Emacs on large Org setups ([#2161](https://github.com/flycheck/flycheck/issues/2161)): its `invalid-id-link` checker rescans every org-id file in the session on each check, so it sits in the new `flycheck-org-lint-disabled-checkers` by default; set that to nil to run everything org-lint has.
 - [#2324](https://github.com/flycheck/flycheck/pull/2324): Keep the errors earlier checkers in a chain reported when a later checker dies by a signal, and say what killed it, instead of clearing the buffer's whole result ([#1881](https://github.com/flycheck/flycheck/issues/1881)).
 - [#2323](https://github.com/flycheck/flycheck/pull/2323): Fix `flycheck-next-error` cycling forever between two errors when one's region sits inside the other's, and `flycheck-previous-error` skipping the inner one ([#1781](https://github.com/flycheck/flycheck/issues/1781)). Language servers report overlapping regions routinely, so the 2020 bug bites much harder today.

--- a/flycheck.el
+++ b/flycheck.el
@@ -17768,14 +17768,109 @@ CHECKER and BUFFER are used to construct the error objects."
                 errors))
     (json-parse-error nil)))
 
+(defconst flycheck-scala--diagnostic-rx
+  (rx line-start "-- "
+      ;; The bracketed id is usually there, but plain `-- Warning:' exists
+      (optional "[" (group (one-or-more (any "A-Z" "0-9"))) "] ")
+      (zero-or-more (not (any ":" "\n")))
+      (group (or "Error" "Warning")) ": "
+      (group (one-or-more (not (any "\n"))))
+      ":" (group (one-or-more digit)) ":" (group (one-or-more digit))
+      " " (one-or-more "-") "\n"
+      ;; The gutter under the header, holding the echoed source, the
+      ;; caret marks and the message
+      (group (zero-or-more (zero-or-more (any " " digit)) "|"
+                           (zero-or-more (not (any "\n"))) "\n")))
+  "Matches one diagnostic in the box format Scala 3 introduced.")
+
+(defconst flycheck-scala--gutter-rx
+  (rx string-start (group (zero-or-more (any " " digit))) "|"
+      (group (zero-or-more not-newline)))
+  "Splits one gutter line into its prefix and its content.
+
+The prefix spells out the source's line number when the line
+echoes source, and holds only padding otherwise.")
+
+(defun flycheck-scala--message-line (line)
+  "Return the text gutter LINE contributes to the message, or nil.
+
+The echoed source keeps its line number in the gutter, which is
+what tells it apart from the message; the caret marks under it
+and the hint about `-explain' carry no message text either.  The
+content keeps its indentation, so a message spanning lines can be
+dedented as a whole."
+  (when (string-match flycheck-scala--gutter-rx line)
+    (let ((prefix (match-string 1 line))
+          (content (match-string 2 line)))
+      (unless (or (string-match-p (rx digit) prefix)
+                  (string-match-p (rx string-start (zero-or-more " ")
+                                      (one-or-more "^")
+                                      (zero-or-more " ") string-end)
+                                  content)
+                  (string-match-p (rx string-start (zero-or-more " ")
+                                      "longer explanation available")
+                                  content))
+        content))))
+
+(defun flycheck-parse-scala--boxed (output checker buffer)
+  "Parse the diagnostics Scala 3 draws in a box out of OUTPUT.
+
+CHECKER and BUFFER are as in `flycheck-parse-output'.
+
+The header names the position, so the caret under the echoed
+source is only decoration here.  Scala counts columns from zero
+and Emacs from one.  The message ends at the blank separator
+line, after which only trailers like the hint about `-explain'
+follow."
+  (let (errors (start 0))
+    (while (string-match flycheck-scala--diagnostic-rx output start)
+      (setq start (match-end 0))
+      (let ((id (match-string 1 output))
+            (level (match-string 2 output))
+            (file (match-string 3 output))
+            (line (string-to-number (match-string 4 output)))
+            (column (string-to-number (match-string 5 output)))
+            (gutter (split-string (match-string 6 output) "\n" t)))
+        (push (flycheck-error-new-at
+               line (1+ column)
+               (if (string= level "Warning") 'warning 'error)
+               (string-join
+                (seq-take-while
+                 (lambda (content) (not (string-blank-p content)))
+                 (delq nil (mapcar #'flycheck-scala--message-line gutter)))
+                "\n")
+               :id id :checker checker :buffer buffer :filename file)
+              errors)))
+    (nreverse errors)))
+
+(defun flycheck-parse-scala (output checker buffer)
+  "Parse scalac's OUTPUT, in either of the two shapes it comes in.
+
+CHECKER and BUFFER are as in `flycheck-parse-output'.
+
+Scala 3 draws each diagnostic in a box and colors it whether or
+not anyone is watching; the compiler has no flag both major
+versions accept to turn that off.  Scala 2 still prints the plain
+`file:line: error: message' form, so the patterns still read the
+output when no box is found."
+  (let ((plain (ansi-color-filter-apply output)))
+    (or (flycheck-parse-scala--boxed plain checker buffer)
+        (flycheck-parse-with-patterns plain checker buffer))))
+
 (flycheck-define-checker scala
   "A Scala syntax checker using the Scala compiler.
 
 See URL `https://www.scala-lang.org/'."
   :command ("scalac" "-Ystop-after:parser" source)
+  :error-parser flycheck-parse-scala
   :error-patterns
   ((error line-start (file-name) ":" line ": error: " (message) line-end)
    (warning line-start (file-name) ":" line ": warning: " (message) line-end))
+  ;; Dedenting keeps the alignment inside a boxed message, such as a
+  ;; type Scala 3 wraps over several lines
+  :error-filter
+  (lambda (errors)
+    (flycheck-sanitize-errors (flycheck-dedent-error-messages errors)))
   :modes (scala-mode scala-ts-mode)
   :next-checkers ((warning . scala-scalastyle)))
 

--- a/test/specs/languages/test-scala.el
+++ b/test/specs/languages/test-scala.el
@@ -51,6 +51,140 @@
       (let ((flycheck-scalastyle-config nil)
             (flycheck-scalastyle-args '("--quiet" "true")))
         (expect (flycheck-checker-substituted-arguments 'scala-scalastyle)
-                :to-contain "--quiet")))))
+                :to-contain "--quiet"))))
+
+  (describe "reading scalac's output"
+    ;; The E008 and E019 samples are verbatim from the reports in
+    ;; https://github.com/flycheck/flycheck/pull/2106
+
+    (it "reads a Scala 3 box"
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        "-- [E008] Not Found Error: /home/cpc/scala3-ansi-colors/src/main/scala/Main.scala:5:43 --------------------------
+5 |def msg =  \"I was compiled by Scala 3. :)\" / 2
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |           value / is not a member of String
+one error found
+")
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              5 44 'error "value / is not a member of String"
+              :id "E008" :checker 'scala :buffer (current-buffer)
+              :filename "/home/cpc/scala3-ansi-colors/src/main/scala/Main.scala"))))
+
+    (it "skips the caret line and the hint about -explain"
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        "-- [E019] Syntax Error: /tmp/flycheckVLFiiu/foo.scala:2:15 ---------------------
+2 |implicit def mi
+  |               ^
+  |               Missing return type
+  |
+  | longer explanation available when compiling with `-explain`
+1 error found
+")
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              2 16 'error "Missing return type"
+              :id "E019" :checker 'scala :buffer (current-buffer)
+              :filename "/tmp/flycheckVLFiiu/foo.scala"))))
+
+    (it "reads through the colors Scala 3 always prints"
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        (concat
+         "\e[31m\e[31m-- [E019] Syntax Error: /tmp/flycheckVLFiiu/foo.scala"
+         ":2:15 ---------------------\e[0m\e[0m\n"
+         "\e[31m2 |\e[0m\e[33mimplicit\e[0m \e[33mdef\e[0m \e[36mmi\e[0m\n"
+         "\e[31m\e[31m  |\e[0m               ^\e[0m\n"
+         "\e[31m  |\e[0m               Missing return type\n"
+         "\e[31m  |\e[0m\n"
+         "\e[31m  |\e[0m longer explanation available when compiling"
+         " with ‘-explain’\n"
+         "1 error found\n"))
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              2 16 'error "Missing return type"
+              :id "E019" :checker 'scala :buffer (current-buffer)
+              :filename "/tmp/flycheckVLFiiu/foo.scala"))))
+
+    (it "reads a header without an id"
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        "-- Warning: /tmp/flycheckVLFiiu/foo.scala:3:8 ----------------------------------
+3 |@nowarn(\"id\")
+  |        ^^^^
+  |        Invalid message filter
+1 warning found
+")
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              3 9 'warning "Invalid message filter"
+              :checker 'scala :buffer (current-buffer)
+              :filename "/tmp/flycheckVLFiiu/foo.scala"))))
+
+    (it "reads every box, keeping a message's lines together"
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        "-- [E007] Type Mismatch Error: /tmp/flycheckVLFiiu/foo.scala:3:13 --------------
+3 |val i: Int = \"42\"
+  |             ^^^^
+  |             Found:    (\"42\" : String)
+  |             Required: Int
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E198] Unused Symbol Warning: /tmp/flycheckVLFiiu/foo.scala:1:7 -------------
+1 |import scala.util.Try
+  |       ^^^^^^^^^^^^^^
+  |       unused import
+1 warning found
+1 error found
+")
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              3 14 'error "Found:    (\"42\" : String)\nRequired: Int"
+              :id "E007" :checker 'scala :buffer (current-buffer)
+              :filename "/tmp/flycheckVLFiiu/foo.scala")
+             (flycheck-error-new-at
+              1 8 'warning "unused import"
+              :id "E198" :checker 'scala :buffer (current-buffer)
+              :filename "/tmp/flycheckVLFiiu/foo.scala"))))
+
+    (it "skips indented source and keeps a wrapped message aligned"
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        "-- [E007] Type Mismatch Error: /tmp/flycheckVLFiiu/foo.scala:4:2 ---------------
+4 |  foo(bar)
+  |  ^^^^^^^^
+  |  Found:    List[
+  |              Int]
+  |  Required: Int
+1 error found
+")
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              4 3 'error "Found:    List[\n            Int]\nRequired: Int"
+              :id "E007" :checker 'scala :buffer (current-buffer)
+              :filename "/tmp/flycheckVLFiiu/foo.scala"))))
+
+    (it "falls back to the plain form Scala 2 prints"
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        "/tmp/flycheckVLFiiu/foo.scala:3: error: identifier expected but '{' found.
+object {
+       ^
+")
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              3 nil 'error "identifier expected but '{' found."
+              :checker 'scala :buffer (current-buffer)
+              :filename "/tmp/flycheckVLFiiu/foo.scala"))))))
 
 ;;; test-scala.el ends here


### PR DESCRIPTION
Scala 3 draws each diagnostic in a box under a '-- [E008] Not Found Error: file:line:col' header with unconditional coloring, none of which the Scala 2 patterns match, so the scala checker has reported nothing on Scala 3 since dotty shipped. This parses the boxes the way the rebar3 checker reads its boxed format (headers are authoritative for positions; dotty counts columns from zero) and falls back to the existing patterns when no box is found, so Scala 2 keeps working. Specs run the verbatim samples from #2106, including an ANSI-colored capture; live verification needs a Scala 3 install, which neither this machine nor the checker image has, so confirmation from a Scala 3 user on the issue would be welcome. Fixes #2179.

(Supersedes #2326, whose pull_request CI events never fired; the identical commit passed the full matrix via workflow dispatch, run 31177891795.)