### PR TITLE
Match a Scala 3 header too long for padding dashes

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -17776,7 +17776,10 @@ CHECKER and BUFFER are used to construct the error objects."
       (group (or "Error" "Warning")) ": "
       (group (one-or-more (not (any "\n"))))
       ":" (group (one-or-more digit)) ":" (group (one-or-more digit))
-      " " (one-or-more "-") "\n"
+      ;; The dashes pad the header out to the terminal width, so a path
+      ;; long enough to fill the line on its own, such as the temporary
+      ;; copy Flycheck checks, leaves a bare position, or a lone space
+      (zero-or-more (any " -")) "\n"
       ;; The gutter under the header, holding the echoed source, the
       ;; caret marks and the message
       (group (zero-or-more (zero-or-more (any " " digit)) "|"

--- a/test/specs/languages/test-scala.el
+++ b/test/specs/languages/test-scala.el
@@ -73,6 +73,25 @@ one error found
               :id "E008" :checker 'scala :buffer (current-buffer)
               :filename "/home/cpc/scala3-ansi-colors/src/main/scala/Main.scala"))))
 
+    (it "reads a header too long for any padding dashes"
+      ;; The dashes pad the header to the terminal width, so the long
+      ;; temporary path of a real check leaves none, and every live
+      ;; check parsed nothing while the short sample paths passed.
+      (expect
+       (flycheck-buttercup-parse
+        'scala
+        "-- [E019] Syntax Error: /var/folders/1l/xqbgb73s21vd3wrrp_tyxmy00000gn/T/flycheckB2ap0M/averyveryverylongdirectoryname/anotherlongsubdirectoryname/scala-test.scala:3:17
+3 |  implicit def mi
+  |                 ^
+  |                 Missing return type
+1 error found
+")
+       :to-be-equal-flycheck-errors
+       (list (flycheck-error-new-at
+              3 18 'error "Missing return type"
+              :id "E019" :checker 'scala :buffer (current-buffer)
+              :filename "/var/folders/1l/xqbgb73s21vd3wrrp_tyxmy00000gn/T/flycheckB2ap0M/averyveryverylongdirectoryname/anotherlongsubdirectoryname/scala-test.scala"))))
+
     (it "skips the caret line and the hint about -explain"
       (expect
        (flycheck-buttercup-parse


### PR DESCRIPTION
Follow-up to #2327, found by live-testing against an installed scalac 3.8.4: the box header's padding dashes disappear when the path fills the terminal width on its own, which the long temporary path of a real check always does, so live checks parsed nothing while the specs' short sample paths passed. The dash tail is optional now and the checker reports end to end against 3.8.4.