### PR TITLE
Explain five more checkers' diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- [#2329](https://github.com/flycheck/flycheck/pull/2329): Explain more checkers' diagnostics with `C-c ! e`: `yaml-yamllint`, `terraform-tflint`, `ruby-reek`, `markdown-pymarkdown` and `javascript-oxlint` now open the rule's documentation page.
 - [#2322](https://github.com/flycheck/flycheck/pull/2322): `textlint` carries the fixes its fixable rules emit, such as `common-misspellings`, so `C-c ! f` applies them; its eslint-compatible output had the fixes all along, and now a spec keeps it that way.
 - [#2319](https://github.com/flycheck/flycheck/pull/2319): `markdown-markdownlint-cli` now carries the fixes markdownlint suggests, so `C-c ! f` and `C-c ! F` apply them; the checker reads markdownlint's JSON output, and a rule configured with `severity: warning` now shows as a warning rather than an error.
 - [#2156](https://github.com/flycheck/flycheck/pull/2156): Add OCaml checkers. `ocaml-dune` checks a Dune project with `dune build @check`, so references to sibling modules and to the project's dependencies resolve, and `ocaml` checks a standalone file with `ocamlfind ocamlc`. Flycheck picks between them by whether the file belongs to a Dune project, since the compiler on its own would report every reference to a sibling module as an unbound module.

--- a/flycheck.el
+++ b/flycheck.el
@@ -15095,7 +15095,19 @@ See URL `https://oxc.rs/'."
     (flycheck-sanitize-errors
      (flycheck-dequalify-error-ids errors)))
   :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode rjsx-mode
-                  typescript-mode js-ts-mode typescript-ts-mode tsx-ts-mode))
+                  typescript-mode js-ts-mode typescript-ts-mode tsx-ts-mode)
+  :error-explainer
+  ;; Ids come as plugin(rule), and the docs nest each rule's page
+  ;; under its plugin
+  (flycheck-error-explainer-from-url
+   "https://oxc.rs/docs/guide/usage/linter/rules/%s.html"
+   (lambda (id)
+     (when (string-match (rx string-start
+                             (group (one-or-more (not (any "("))))
+                             "(" (group (one-or-more (not (any ")")))) ")"
+                             string-end)
+                         id)
+       (concat (match-string 1 id) "/" (match-string 2 id))))))
 
 (flycheck-def-args-var flycheck-javascript-standard-args javascript-standard
   :package-version '(flycheck . "39"))
@@ -17013,7 +17025,11 @@ See URL `https://pypi.org/project/pymarkdownlnt/'."
     (flycheck-sanitize-errors
      (flycheck-remove-error-file-names "(string)" errors)))
   :modes (markdown-mode gfm-mode)
-  :next-checkers ((warning . proselint)))
+  :next-checkers ((warning . proselint))
+  :error-explainer
+  (flycheck-error-explainer-from-url
+   "https://github.com/jackdewinter/pymarkdown/blob/main/docs/rules/rule_%s.md"
+   #'downcase))
 
 (flycheck-define-checker nix
   "Nix checker using nix-instantiate.
@@ -17343,7 +17359,16 @@ See URL `https://github.com/troessner/reek'."
             (config-file "--config" flycheck-reek-config)
             source)
   :error-parser flycheck-parse-reek
-  :modes (enh-ruby-mode ruby-mode ruby-ts-mode))
+  :modes (enh-ruby-mode ruby-mode ruby-ts-mode)
+  :error-explainer
+  ;; The docs hyphenate the smell's CamelCase name:
+  ;; InstanceVariableAssumption -> Instance-Variable-Assumption.md
+  (flycheck-error-explainer-from-url
+   "https://github.com/troessner/reek/blob/master/docs/%s.md"
+   (lambda (id)
+     ;; Folded search would let [a-z] take the capitals too
+     (let ((case-fold-search nil))
+       (replace-regexp-in-string "\\([a-z]\\)\\([A-Z]\\)" "\\1-\\2" id t)))))
 
 (flycheck-define-checker ruby
   "A Ruby syntax checker using the standard Ruby interpreter.
@@ -18458,7 +18483,13 @@ See URL `https://github.com/terraform-linters/tflint'."
             (eval flycheck-tflint-args))
   :error-parser flycheck-parse-tflint-linter
   :predicate flycheck-buffer-saved-p
-  :modes (terraform-mode terraform-ts-mode))
+  :modes (terraform-mode terraform-ts-mode)
+  :error-explainer
+  ;; Rules come from per-provider rulesets; only the terraform ruleset
+  ;; keeps a documentation file per rule, so the rest are skipped
+  (flycheck-error-explainer-from-url
+   "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/%s.md"
+   (lambda (id) (and (string-prefix-p "terraform_" id) id))))
 
 (flycheck-def-option-var flycheck-chktex-extra-flags nil tex-chktex
   "A list of extra arguments to give to chktex.
@@ -18759,7 +18790,13 @@ See URL `https://github.com/adrienverge/yamllint'."
             "stdin:" line ":" column ": [warning] "
             (message) line-end))
   :modes (yaml-mode yaml-ts-mode)
-  :next-checkers ((warning . cwl)))
+  :next-checkers ((warning . cwl))
+  :error-explainer
+  ;; The rule pages anchor on the module name, which spells the rule
+  ;; with underscores where the reported id has hyphens
+  (flycheck-error-explainer-from-url
+   "https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.%s"
+   (lambda (id) (string-replace "-" "_" id))))
 
 (provide 'flycheck)
 

--- a/test/specs/test-error-explainers.el
+++ b/test/specs/test-error-explainers.el
@@ -74,6 +74,36 @@
       (expect (test-explainer/explain 'javascript-eslint "no-eval")
               :to-equal '(url . "https://eslint.org/docs/rules/no-eval"))
       (expect (test-explainer/explain 'javascript-eslint "react/jsx-key")
+              :to-be nil))
+
+    (it "links yamllint rules through their underscored anchors"
+      (expect (test-explainer/explain 'yaml-yamllint "document-start")
+              :to-equal
+              '(url . "https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.document_start")))
+
+    (it "links tflint's terraform rules but skips provider rules"
+      (expect (test-explainer/explain 'terraform-tflint "terraform_deprecated_interpolation")
+              :to-equal
+              '(url . "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md"))
+      ;; The provider rulesets keep no documentation file per rule
+      (expect (test-explainer/explain 'terraform-tflint "aws_instance_invalid_type")
+              :to-be nil))
+
+    (it "links reek smells through their hyphenated names"
+      (expect (test-explainer/explain 'ruby-reek "InstanceVariableAssumption")
+              :to-equal
+              '(url . "https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md")))
+
+    (it "links pymarkdown rules through their lowercased files"
+      (expect (test-explainer/explain 'markdown-pymarkdown "MD022")
+              :to-equal
+              '(url . "https://github.com/jackdewinter/pymarkdown/blob/main/docs/rules/rule_md022.md")))
+
+    (it "links oxlint rules under their plugin, skipping bare ids"
+      (expect (test-explainer/explain 'javascript-oxlint "eslint(no-unused-vars)")
+              :to-equal
+              '(url . "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html"))
+      (expect (test-explainer/explain 'javascript-oxlint "no-unused-vars")
               :to-be nil)))
 
   (describe "flycheck-dockerfile-hadolint-error-explainer"


### PR DESCRIPTION
yamllint, tflint, reek, pymarkdown and oxlint document their rules online keyed by the ids their checkers already report, so C-c ! e now opens the right page - each URL scheme verified against the live site, including the quirks (yamllint anchors spell rules with underscores, reek hyphenates the CamelCase smell name, oxlint nests rules under their plugin, and tflint's provider rulesets have no per-rule docs so only terraform_* rules answer). Takes explainer coverage from 30 to 35 checkers.