### PR TITLE
Read go-jsonnet's bare static errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- [#2331](https://github.com/flycheck/flycheck/pull/2331): Add `flycheck-jsonnet-ext-code-files` to bind external code files (`--ext-code-file`) for the `jsonnet` checker (originally proposed in [#1932](https://github.com/flycheck/flycheck/pull/1932)).
 - [#2329](https://github.com/flycheck/flycheck/pull/2329): Explain more checkers' diagnostics with `C-c ! e`: `yaml-yamllint`, `terraform-tflint`, `ruby-reek`, `markdown-pymarkdown` and `javascript-oxlint` now open the rule's documentation page.
 - [#2322](https://github.com/flycheck/flycheck/pull/2322): `textlint` carries the fixes its fixable rules emit, such as `common-misspellings`, so `C-c ! f` applies them; its eslint-compatible output had the fixes all along, and now a spec keeps it that way.
 - [#2319](https://github.com/flycheck/flycheck/pull/2319): `markdown-markdownlint-cli` now carries the fixes markdownlint suggests, so `C-c ! f` and `C-c ! F` apply them; the checker reads markdownlint's JSON output, and a rule configured with `severity: warning` now shows as a warning rather than an error.
@@ -39,6 +40,7 @@
 
 ### Bugs fixed
 
+- [#2331](https://github.com/flycheck/flycheck/pull/2331): Read go-jsonnet's static errors, which carry no `STATIC ERROR:` prefix and never matched the patterns written against the C++ binary, so the `jsonnet` checker reported nothing on the implementation flycheck's own documentation recommends.
 - [#2327](https://github.com/flycheck/flycheck/pull/2327): Read Scala 3's diagnostics. The compiler draws each of them in a box under a `-- [E008] Not Found Error: file:line:column` header, with unconditional coloring, so the `scala` checker has reported nothing on Scala 3 since dotty shipped. Scala 2's plain output is still read ([#2179](https://github.com/flycheck/flycheck/issues/2179)).
 - [#2325](https://github.com/flycheck/flycheck/pull/2325): Stop `org-lint` freezing Emacs on large Org setups ([#2161](https://github.com/flycheck/flycheck/issues/2161)): its `invalid-id-link` checker rescans every org-id file in the session on each check, so it sits in the new `flycheck-org-lint-disabled-checkers` by default; set that to nil to run everything org-lint has.
 - [#2324](https://github.com/flycheck/flycheck/pull/2324): Keep the errors earlier checkers in a chain reported when a later checker dies by a signal, and say what killed it, instead of clearing the buffer's whole result ([#1881](https://github.com/flycheck/flycheck/issues/1881)).

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -782,6 +782,12 @@ to view the docstring of the syntax checker.  Likewise, you may use
          binary via ``-J``. Relative paths are resolved relative to the path
          of the buffer being checked.
 
+      .. defcustom:: flycheck-jsonnet-ext-code-files
+
+         A list of strings of the form ``VAR=FILE``, each passed via
+         ``--ext-code-file`` so that ``std.extVar`` sees ``VAR`` bound to
+         the contents of ``FILE``.
+
 .. supported-language:: Less
 
    .. syntax-checker:: less

--- a/flycheck.el
+++ b/flycheck.el
@@ -15183,6 +15183,17 @@ string is a directory to add to the include path via `-J'."
 (flycheck-def-args-var flycheck-jsonnet-args jsonnet
   :package-version '(flycheck . "35.0"))
 
+(flycheck-def-option-var flycheck-jsonnet-ext-code-files nil jsonnet
+  "External code files for the jsonnet binary.
+
+The value of this variable is a list of strings of the form
+VAR=FILE, each passed via `--ext-code-file' so std.extVar sees VAR
+bound to FILE's contents (originally proposed in
+URL `https://github.com/flycheck/flycheck/pull/1932')."
+  :type '(repeat (string :tag "VAR=FILE"))
+  :safe #'flycheck-string-list-p
+  :package-version '(flycheck . "39"))
+
 (flycheck-define-checker jsonnet
   "A Jsonnet syntax checker using the jsonnet binary.
 
@@ -15190,14 +15201,23 @@ See URL `https://jsonnet.org'."
   :command
   ("jsonnet"
    (option-list "-J" flycheck-jsonnet-include-paths)
+   (option-list "--ext-code-file" flycheck-jsonnet-ext-code-files)
    (eval flycheck-jsonnet-args)
    source-inplace)
   :error-patterns
-  ((error line-start "STATIC ERROR: " (file-name) ":"
+  (;; C++ jsonnet prefixes static errors; go-jsonnet, the binary the
+   ;; docs point at, prints the bare position with a single space
+   ;; before the message
+   (error line-start "STATIC ERROR: " (file-name) ":"
           (or (seq line ":" column (zero-or-one (seq "-" end-column)))
               (seq "(" line ":" column ")" "-"
                    "(" end-line ":" end-column ")"))
           ": " (message) line-end)
+   (error line-start (file-name) ":"
+          (or (seq line ":" column (zero-or-one (seq "-" end-column)))
+              (seq "(" line ":" column ")" "-"
+                   "(" end-line ":" end-column ")"))
+          " " (message) line-end)
    (error line-start "RUNTIME ERROR: " (message) "\n"
           (? "\t" (file-name) ":" ;; first line of the backtrace
              (or (seq line ":" column (zero-or-one (seq "-" end-column)))

--- a/test/fixtures/jsonnet/language/jsonnet/static_error.jsonnet.txt
+++ b/test/fixtures/jsonnet/language/jsonnet/static_error.jsonnet.txt
@@ -1,0 +1,7 @@
+test/resources/language/jsonnet/flycheck_static_error.jsonnet:(1:8)-(3:4) Block string literals not allowed in imports
+
+import |||
+  xyz
+|||
+
+

--- a/test/specs/languages/test-jsonnet.el
+++ b/test/specs/languages/test-jsonnet.el
@@ -3,16 +3,103 @@
 (require 'flycheck-buttercup)
 (require 'test-helpers)
 
+(defun test-jsonnet/go-implementation-p ()
+  "Whether the jsonnet the checker would run is go-jsonnet."
+  (when-let* ((jsonnet (flycheck-find-checker-executable 'jsonnet)))
+    (with-temp-buffer
+      (call-process jsonnet nil t nil "--version")
+      (goto-char (point-min))
+      (search-forward "Go implementation" nil 'noerror))))
+
 (describe "Language Jsonnet"
+  ;; The two jsonnet implementations word their static errors
+  ;; differently, so each gets its own live check
   (flycheck-buttercup-def-checker-test jsonnet jsonnet static
+    (assume (test-jsonnet/go-implementation-p)
+            "The installed jsonnet is not go-jsonnet")
     (flycheck-buttercup-should-syntax-check
      "language/jsonnet/static_error.jsonnet" 'jsonnet-mode
-     '(1 23 "Not a unary operator: =" :checker jsonnet)))
+     '(1 8 error "Block string literals not allowed in imports"
+         :end-line 3 :end-column 4 :checker jsonnet)))
+
+  (flycheck-buttercup-def-checker-test jsonnet jsonnet static-cpp
+    (assume (not (test-jsonnet/go-implementation-p))
+            "The installed jsonnet is not the C++ implementation")
+    (flycheck-buttercup-should-syntax-check
+     "language/jsonnet/static_error.jsonnet" 'jsonnet-mode
+     '(1 8 error "Cannot use text blocks in import statements."
+         :end-line 3 :end-column 4 :checker jsonnet)))
 
   (flycheck-buttercup-def-checker-test jsonnet jsonnet runtime
     (flycheck-buttercup-should-syntax-check
      "language/jsonnet/runtime_error.jsonnet" 'jsonnet-mode
-     '(2 6 "Field does not exist: flat" :checker jsonnet
-         :end-line 2 :end-column 14))))
+     '(2 6 error "Field does not exist: flat" :checker jsonnet
+         :end-line 2 :end-column 14)))
+
+  (describe "the jsonnet checker command"
+    (it "passes the external code files before the extra arguments"
+      (flycheck-buttercup-with-temp-buffer
+        (let ((flycheck-jsonnet-include-paths nil)
+              (flycheck-jsonnet-ext-code-files '("config=cfg.jsonnet"))
+              (flycheck-jsonnet-args nil))
+          (let ((args (flycheck-checker-substituted-arguments 'jsonnet)))
+            (expect args :to-contain "--ext-code-file")
+            (expect args :to-contain "config=cfg.jsonnet"))))))
+
+  (describe "reading the tool's output"
+    ;; go-jsonnet has never printed the STATIC ERROR prefix the C++
+    ;; binary uses, so each format gets its own spec
+
+    (flycheck-buttercup-def-parse-test jsonnet "language/jsonnet/static_error.jsonnet"
+      '(1 8 error "Block string literals not allowed in imports"
+          :end-line 3 :end-column 4))
+
+    (it "reads go-jsonnet's bare static errors, span form"
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'jsonnet
+          "static_error.jsonnet:(1:8)-(3:4) Block string literals not allowed in imports
+
+import |||
+  xyz
+|||
+")
+         :to-be-equal-flycheck-errors
+         (list (flycheck-error-new-at
+                1 8 'error "Block string literals not allowed in imports"
+                :end-line 3 :end-column 4
+                :checker 'jsonnet :buffer (current-buffer)
+                :filename "static_error.jsonnet")))))
+
+    (it "reads go-jsonnet's bare static errors, single-position form"
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'jsonnet
+          "old_static.jsonnet:1:23-24 Not a unary operator: =
+
+local x = 1; x == = 2
+")
+         :to-be-equal-flycheck-errors
+         (list (flycheck-error-new-at
+                1 23 'error "Not a unary operator: ="
+                :end-line 1 :end-column 24
+                :checker 'jsonnet :buffer (current-buffer)
+                :filename "old_static.jsonnet")))))
+
+    (it "still reads the C++ binary's prefixed static errors"
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'jsonnet
+          "STATIC ERROR: static_error.jsonnet:(1:8)-(3:4): Cannot use text blocks in import statements.
+")
+         :to-be-equal-flycheck-errors
+         (list (flycheck-error-new-at
+                1 8 'error "Cannot use text blocks in import statements."
+                :end-line 3 :end-column 4
+                :checker 'jsonnet :buffer (current-buffer)
+                :filename "static_error.jsonnet")))))))
 
 ;;; test-jsonnet.el ends here


### PR DESCRIPTION
The jsonnet checker's static patterns require the STATIC ERROR prefix that only C++ jsonnet prints; go-jsonnet - the implementation our docs recommend and the checker image installs - never printed it, so its static errors have gone unread since 2019 (runtime errors worked by luck of a shared prefix). Verified against both binaries at v0.22; the fixture is recorded from go-jsonnet and the live specs assert each implementation's wording. Rides along: flycheck-jsonnet-ext-code-files for --ext-code-file, the surviving half of #1932 (the -J half landed earlier as include-paths), with credit to @runejuhl.