### PR TITLE
Keep #pragma once quiet when the buffer is a header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Bugs fixed
 
+- [#2332](https://github.com/flycheck/flycheck/pull/2332): Stop the C/C++ checkers warning about `#pragma once` in every standalone header ([#2178](https://github.com/flycheck/flycheck/issues/2178)): the buffer is always the compiler's main file, so the warning fired on the very idiom headers are supposed to use. In a source file it still fires, as intended.
 - [#2327](https://github.com/flycheck/flycheck/pull/2327): Read Scala 3's diagnostics. The compiler draws each of them in a box under a `-- [E008] Not Found Error: file:line:column` header, with unconditional coloring, so the `scala` checker has reported nothing on Scala 3 since dotty shipped. Scala 2's plain output is still read ([#2179](https://github.com/flycheck/flycheck/issues/2179)).
 - [#2325](https://github.com/flycheck/flycheck/pull/2325): Stop `org-lint` freezing Emacs on large Org setups ([#2161](https://github.com/flycheck/flycheck/issues/2161)): its `invalid-id-link` checker rescans every org-id file in the session on each check, so it sits in the new `flycheck-org-lint-disabled-checkers` by default; set that to nil to run everything org-lint has.
 - [#2324](https://github.com/flycheck/flycheck/pull/2324): Keep the errors earlier checkers in a chain reported when a later checker dies by a signal, and say what killed it, instead of clearing the buffer's whole result ([#1881](https://github.com/flycheck/flycheck/issues/1881)).

--- a/flycheck.el
+++ b/flycheck.el
@@ -12608,6 +12608,30 @@ See URL `https://github.com/bazelbuild/buildtools/blob/master/buildifier'."
             line-end))
   :modes bazel-workspace-mode)
 
+(defconst flycheck--c/c++-header-suffixes
+  '(".h" ".hh" ".H" ".hp" ".hxx" ".hpp" ".HPP" ".h++" ".tcc")
+  "File suffixes GCC itself treats as C or C++ headers.")
+
+(defun flycheck--c/c++-discard-pragma-once-in-header (errors)
+  "Drop the pragma-once-in-main-file warning from ERRORS in a header buffer.
+
+The C and C++ checkers hand the compiler the buffer on standard input,
+so a header is always the main file and the warning would fire on
+every header using the idiom (#2178).  In a source file it stays:
+`#pragma once' outside a header is what the warning is for.  Matched
+on the message as well as the id, because the flag id only exists
+since GCC 15 and the quoting differs by locale."
+  (if (not (and buffer-file-name
+                (member (concat "." (or (file-name-extension buffer-file-name) ""))
+                        flycheck--c/c++-header-suffixes)))
+      errors
+    (seq-remove
+     (lambda (err)
+       (or (equal (flycheck-error-id err) "-Wpragma-once-outside-header")
+           (string-match-p "#pragma once['\u2019]? in main file"
+                           (or (flycheck-error-message err) ""))))
+     errors)))
+
 (flycheck-def-args-var flycheck-clang-args c/c++-clang
   :package-version '(flycheck . "0.22"))
 
@@ -12805,7 +12829,7 @@ See URL `https://clang.llvm.org/'."
         ;; them past our error filtering
         (setf (flycheck-error-message err)
               (or (flycheck-error-message err) "no message")))
-      errors))
+      (flycheck--c/c++-discard-pragma-once-in-header errors)))
   :modes (c-mode c++-mode c-ts-mode c++-ts-mode)
   :next-checkers ((warning . c/c++-cppcheck)))
 
@@ -12957,6 +12981,10 @@ Requires GCC 4.4 or newer.  See URL `https://gcc.gnu.org/'."
    (error line-start (or "<stdin>" (file-name))
           ":" line (optional ":" column)
           ": " (or "fatal error" "error") ": " (message) line-end))
+  :error-filter
+  (lambda (errors)
+    (flycheck--c/c++-discard-pragma-once-in-header
+     (flycheck-sanitize-errors errors)))
   :modes (c-mode c++-mode c-ts-mode c++-ts-mode)
   :next-checkers ((warning . c/c++-cppcheck)))
 

--- a/test/fixtures/c_c++-clang/language/c_c++/header.h.txt
+++ b/test/fixtures/c_c++-clang/language/c_c++/header.h.txt
@@ -1,0 +1,3 @@
+<stdin>:1:9: warning: #pragma once in main file
+<stdin>:4:12: warning: comparison of integers of different signs: 'int' and 'unsigned int'
+<stdin>:3:19: warning: unused function 'flycheck_cmp'

--- a/test/fixtures/c_c++-gcc/language/c_c++/header.h.txt
+++ b/test/fixtures/c_c++-gcc/language/c_c++/header.h.txt
@@ -1,0 +1,3 @@
+<stdin>:1:9: warning: ‘#pragma once’ in main file [-Wpragma-once-outside-header]
+<stdin>: In function ‘flycheck_cmp’:
+<stdin>:4:12: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]

--- a/test/resources/language/c_c++/header.h
+++ b/test/resources/language/c_c++/header.h
@@ -1,0 +1,5 @@
+#pragma once
+
+static inline int flycheck_cmp(int a, unsigned b) {
+  return a < b;
+}

--- a/test/specs/languages/test-c_c++.el
+++ b/test/specs/languages/test-c_c++.el
@@ -293,13 +293,63 @@ against a integer value that is neither 1 nor 0.\">
          '(12 nil warning "Parameter 'foo' is passed by value. It could be passed as a const reference which is usually faster and recommended in C++."
               :id "passedByValue" :checker c/c++-cppcheck)))))
 
+  (describe "the pragma-once filter"
+    ;; Checking a standalone header compiles it as the main file, so the
+    ;; compiler warns about #pragma once on every header that uses the
+    ;; idiom.  See #2178.
+
+    (defun test-c/pragma-errors ()
+      "One pragma-once warning in each observed wording, plus a real one."
+      (list
+       ;; clang, and GCC before 15
+       (flycheck-error-new-at 1 9 'warning "#pragma once in main file")
+       ;; GCC 15 under the C locale
+       (flycheck-error-new-at 1 nil 'warning
+                              "'#pragma once' in main file"
+                              :id "-Wpragma-once-outside-header")
+       ;; GCC 15 under a UTF-8 locale
+       (flycheck-error-new-at 1 nil 'warning
+                              "‘#pragma once’ in main file")
+       (flycheck-error-new-at 4 3 'warning
+                              "comparison of integers of different signs")))
+
+    (it "drops the warning in all its wordings when checking a header"
+      (flycheck-buttercup-with-resource-buffer "language/c_c++/header.h"
+        (let ((kept (flycheck--c/c++-discard-pragma-once-in-header
+                     (test-c/pragma-errors))))
+          (expect (mapcar #'flycheck-error-message kept)
+                  :to-equal '("comparison of integers of different signs")))))
+
+    (it "keeps the warning in a source file, where it means something"
+      (flycheck-buttercup-with-resource-buffer "language/c_c++/error.cpp"
+        (expect (length (flycheck--c/c++-discard-pragma-once-in-header
+                         (test-c/pragma-errors)))
+                :to-equal 4))))
+
   (describe "reading the compiler's output"
     ;; Recorded from Clang, which is what answers to the name gcc on
     ;; macOS.  GNU GCC words these differently, which is exactly the sort
     ;; of divergence a live check cannot pin down on one machine.
     (flycheck-buttercup-def-parse-test c/c++-gcc "language/c_c++/error.cpp"
       '(8 nil warning "ignoring ‘#pragma nope ’" :id "-Wunknown-pragmas")
-      '(2 20 error "‘struct A’ has no member named ‘bar’")))
+      '(2 20 error "‘struct A’ has no member named ‘bar’"))
+
+    ;; Plain `it' forms: the pragma-once filter reads the buffer's file
+    ;; name, so these must parse inside the header's own buffer
+    (it "reads gcc's output over header.h without the pragma warning"
+      (flycheck-buttercup-with-resource-buffer "language/c_c++/header.h"
+        (flycheck-buttercup-should-parse
+         'c/c++-gcc "language/c_c++/header.h"
+         '(4 12 warning "comparison of integer expressions of different \
+signedness: ‘int’ and ‘unsigned int’" :id "-Wsign-compare"))))
+
+    (it "reads clang's output over header.h without the pragma warning"
+      (flycheck-buttercup-with-resource-buffer "language/c_c++/header.h"
+        (flycheck-buttercup-should-parse
+         'c/c++-clang "language/c_c++/header.h"
+         '(4 12 warning "comparison of integers of different signs: \
+'int' and 'unsigned int'")
+         '(3 19 warning "unused function 'flycheck_cmp'")))))
 
   (describe "reading the tool's output"
     ;; Read from output recorded earlier, so this runs whether or


### PR DESCRIPTION
Checking a standalone header compiles it as the compiler's main file, so clang and gcc warn about #pragma once on the exact idiom headers should use. A shared error-filter now drops that warning when the buffer visits a header (GCC's own suffix list) and keeps it in source files, matched on message and id since the flag id only exists from GCC 15 and quoting differs by locale - verified against clang 18/21 and gcc 13/15, where the alternative flags either don't exist or gcc refuses them on stdin. Recorded header fixtures for both checkers. Fixes #2178.