### PR TITLE
Add a Luau checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- [#2334](https://github.com/flycheck/flycheck/pull/2334): Add a `luau-analyze` checker for the Luau language, using the analyzer that ships with Luau (originally proposed in [#2167](https://github.com/flycheck/flycheck/pull/2167)). It runs in the Lua major modes but only on `.luau` files, since the analyzer rejects plain Lua constructs like `goto`, and it checks the buffer through a copy next to the original, so the project's `.luaurc` applies to unsaved contents.
 - [#2331](https://github.com/flycheck/flycheck/pull/2331): Add `flycheck-jsonnet-ext-code-files` to bind external code files (`--ext-code-file`) for the `jsonnet` checker (originally proposed in [#1932](https://github.com/flycheck/flycheck/pull/1932)).
 - [#2329](https://github.com/flycheck/flycheck/pull/2329): Explain more checkers' diagnostics with `C-c ! e`: `yaml-yamllint`, `terraform-tflint`, `ruby-reek`, `markdown-pymarkdown` and `javascript-oxlint` now open the rule's documentation page.
 - [#2322](https://github.com/flycheck/flycheck/pull/2322): `textlint` carries the fixes its fixable rules emit, such as `common-misspellings`, so `C-c ! f` applies them; its eslint-compatible output had the fixes all along, and now a spec keeps it that way.

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -845,6 +845,27 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       Check syntax with the `Lua compiler <https://www.lua.org/>`_.
 
+.. supported-language:: Luau
+
+   .. syntax-checker:: luau-analyze
+
+      Check syntax and types with the analyzer that ships with `Luau
+      <https://luau.org/>`_, Roblox's typed dialect of Lua.
+
+      Luau buffers run one of the Lua major modes, since there is no dedicated
+      Luau mode, but the analyzer rejects constructs that Luau dropped from
+      Lua, such as ``goto``, so this checker keeps to buffers visiting
+      ``.luau`` files and leaves plain Lua to the Lua checkers.
+
+      How strictly the analyzer type-checks follows the file's ``--!strict``
+      pragma and the nearest ``.luaurc``, which it finds by walking up from the
+      file, so the buffer is checked through a copy in its own directory and
+      the project configuration applies to unsaved contents.
+
+      .. defcustom:: flycheck-luau-analyze-args
+
+         A list of additional arguments passed to ``luau-analyze``.
+
 .. supported-language:: Markdown
 
    Flycheck checks Markdown with `markdownlint-cli`, `markdownlint-cli2`,

--- a/flycheck.el
+++ b/flycheck.el
@@ -175,6 +175,9 @@
     less
     less-stylelint
     llvm-llc
+    ;; Ahead of the Lua checkers, whose modes it shares, so that it wins in
+    ;; buffers visiting .luau files (see its predicate).
+    luau-analyze
     lua-luacheck
     lua
     markdown-markdownlint-cli2
@@ -15385,6 +15388,45 @@ See URL `https://www.lua.org/'."
           (minimal-match (zero-or-more not-newline))
           ": stdin:" line ": " (message) line-end))
   :modes (lua-mode lua-ts-mode))
+
+(flycheck-def-args-var flycheck-luau-analyze-args luau-analyze
+  :package-version '(flycheck . "39"))
+
+(defun flycheck-luau--file-p ()
+  "Whether the current buffer visits a Luau file."
+  (and buffer-file-name
+       (string= (file-name-extension buffer-file-name) "luau")))
+
+(flycheck-define-checker luau-analyze
+  "A Luau syntax and type checker using the Luau analyzer.
+
+Luau is a typed dialect of Lua, and `luau-analyze' is the analyzer
+that ships with it.  It reports syntax errors, type errors and
+lint warnings.  How strictly it type-checks follows the file's
+`--!strict' pragma and the nearest `.luaurc', which it finds by
+walking up from the file it is given, so the buffer is checked
+through a copy in its own directory and the project configuration
+applies to contents that are not saved yet.
+
+The analyzer rejects constructs that Luau dropped from Lua, such
+as `goto', so this checker keeps to buffers visiting .luau files
+and leaves plain Lua to the Lua checkers.  It is registered ahead
+of them, so that it wins in those buffers, where luacheck would
+report Luau's own syntax as errors.
+
+See URL `https://luau.org/'."
+  :command ("luau-analyze"
+            (eval flycheck-luau-analyze-args)
+            source-inplace)
+  :error-patterns
+  ((error line-start (file-name) "(" line "," column "): "
+          (id (or "SyntaxError" "TypeError")) ": " (message) line-end)
+   ;; Everything else is a lint warning named after its rule, such as
+   ;; FunctionUnused
+   (warning line-start (file-name) "(" line "," column "): "
+            (id (one-or-more alnum)) ": " (message) line-end))
+  :modes (lua-mode lua-ts-mode)
+  :predicate flycheck-luau--file-p)
 
 (flycheck-define-checker opam
   "An Opam syntax and style checker using opam lint.

--- a/test/fixtures/luau-analyze/language/luau/syntax-error.luau.txt
+++ b/test/fixtures/luau-analyze/language/luau/syntax-error.luau.txt
@@ -1,0 +1,1 @@
+language/luau/flycheck_syntax-error.luau(7,1): SyntaxError: Expected 'end' (to close 'then' at line 5), got <eof>

--- a/test/fixtures/luau-analyze/language/luau/type-error.luau.txt
+++ b/test/fixtures/luau-analyze/language/luau/type-error.luau.txt
@@ -1,0 +1,1 @@
+language/luau/flycheck_type-error.luau(6,19): TypeError: Expected this to be 'number', but got 'string'

--- a/test/fixtures/luau-analyze/language/luau/warnings.luau.txt
+++ b/test/fixtures/luau-analyze/language/luau/warnings.luau.txt
@@ -1,0 +1,2 @@
+language/luau/flycheck_warnings.luau(5,16): FunctionUnused: Function 'unused' is never used; prefix with '_' to silence
+language/luau/flycheck_warnings.luau(9,7): LocalUnused: Variable 'value' is never used; prefix with '_' to silence

--- a/test/resources/language/luau/syntax-error.luau
+++ b/test/resources/language/luau/syntax-error.luau
@@ -1,0 +1,6 @@
+-- A syntax error caused by a missing end
+--
+-- Checkers: luau-analyze
+
+if true then
+  print("hi")

--- a/test/resources/language/luau/type-error.luau
+++ b/test/resources/language/luau/type-error.luau
@@ -1,0 +1,7 @@
+-- A type error caught in strict mode
+--
+-- Checkers: luau-analyze
+--!strict
+
+local x: number = "not a number"
+print(x)

--- a/test/resources/language/luau/warnings.luau
+++ b/test/resources/language/luau/warnings.luau
@@ -1,0 +1,11 @@
+-- Lint warnings about unused things
+--
+-- Checkers: luau-analyze
+
+local function unused()
+  return 1
+end
+
+local value = 42
+
+print("hello")

--- a/test/specs/languages/test-luau.el
+++ b/test/specs/languages/test-luau.el
@@ -1,0 +1,67 @@
+;;; test-luau.el --- Flycheck Specs: Luau -*- lexical-binding: t; -*-
+;;; Code:
+(require 'flycheck-buttercup)
+(require 'test-helpers)
+
+(describe "Language Luau"
+  (flycheck-buttercup-def-checker-test luau-analyze luau syntax-error
+    (flycheck-buttercup-should-syntax-check
+     "language/luau/syntax-error.luau" 'lua-mode
+     '(7 1 error "Expected 'end' (to close 'then' at line 5), got <eof>"
+         :id "SyntaxError" :checker luau-analyze)))
+
+  (flycheck-buttercup-def-checker-test luau-analyze luau type-error
+    (flycheck-buttercup-should-syntax-check
+     "language/luau/type-error.luau" 'lua-mode
+     '(6 19 error "Expected this to be 'number', but got 'string'"
+         :id "TypeError" :checker luau-analyze)))
+
+  (flycheck-buttercup-def-checker-test luau-analyze luau warnings
+    (flycheck-buttercup-should-syntax-check
+     "language/luau/warnings.luau" 'lua-mode
+     '(5 16 warning "Function 'unused' is never used; prefix with '_' to silence"
+         :id "FunctionUnused" :checker luau-analyze)
+     '(9 7 warning "Variable 'value' is never used; prefix with '_' to silence"
+         :id "LocalUnused" :checker luau-analyze)))
+
+  (describe "checker selection"
+
+    (it "runs in a buffer visiting a .luau file"
+      (flycheck-buttercup-with-resource-buffer "language/luau/warnings.luau"
+        (expect (funcall (flycheck-checker-get 'luau-analyze 'predicate))
+                :to-be-truthy)))
+
+    (it "leaves a plain Lua buffer to the Lua checkers"
+      ;; The analyzer rejects valid Lua, such as goto and labels, so it
+      ;; must not hijack buffers that merely share the major mode
+      (flycheck-buttercup-with-resource-buffer "language/lua/syntax-error.lua"
+        (expect (funcall (flycheck-checker-get 'luau-analyze 'predicate))
+                :not :to-be-truthy))))
+
+  (describe "the luau-analyze checker command"
+    (it "appends flycheck-luau-analyze-args before the source file"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name (make-temp-file "flycheck-luau" nil ".luau"))
+        (let ((flycheck-luau-analyze-args '("--mode=strict")))
+          (expect (flycheck-checker-substituted-arguments 'luau-analyze)
+                  :to-contain "--mode=strict")))))
+
+  (describe "reading the tool's output"
+    ;; Read from output recorded earlier, so this runs whether or
+    ;; not the tool is installed here
+
+    (flycheck-buttercup-def-parse-test luau-analyze "language/luau/syntax-error.luau"
+      '(7 1 error "Expected 'end' (to close 'then' at line 5), got <eof>"
+          :id "SyntaxError"))
+
+    (flycheck-buttercup-def-parse-test luau-analyze "language/luau/type-error.luau"
+      '(6 19 error "Expected this to be 'number', but got 'string'"
+          :id "TypeError"))
+
+    (flycheck-buttercup-def-parse-test luau-analyze "language/luau/warnings.luau"
+      '(5 16 warning "Function 'unused' is never used; prefix with '_' to silence"
+          :id "FunctionUnused")
+      '(9 7 warning "Variable 'value' is never used; prefix with '_' to silence"
+          :id "LocalUnused"))))
+
+;;; test-luau.el ends here


### PR DESCRIPTION
A fresh take on #2167: a luau-analyze checker using the analyzer's default output format (the plain formatter hardcodes W0 on every diagnostic, so severities and rule ids only exist in the default one). SyntaxError/TypeError parse as errors, lint rules as warnings with the rule name as the id; a predicate keeps it to .luau files since the analyzer rejects valid Lua 5.4, and source-inplace keeps the project's .luaurc applying to unsaved buffer contents. Live specs run against luau 0.733, parse specs read recorded output everywhere. Credit to @redguardtoo for the original proposal.