### PR TITLE
Fix problems caused by emacs-lisp-checkdoc buffer name handling.

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -13788,6 +13788,7 @@ See Info Node `(elisp)Byte Compilation'."
     (require 'checkdoc)
 
     (let ((source (car command-line-args-left))
+          (source-original (cadr command-line-args-left))
           ;; Remember the default directory of the process
           (process-default-directory default-directory))
       ;; Note that we deliberately use our custom approach even despite of
@@ -13796,7 +13797,8 @@ See Info Node `(elisp)Byte Compilation'."
       ;; for us.
       (with-temp-buffer
         (insert-file-contents source 'visit)
-        (setq buffer-file-name source)
+        (setq buffer-file-name
+              (unless (string-empty-p source-original) source-original))
         ;; And change back to the process default directory to make file-name
         ;; back-substitution work
         (setq default-directory process-default-directory)
@@ -13849,9 +13851,9 @@ The checker runs `checkdoc-current-buffer'."
             "--eval" (eval (flycheck-sexp-to-string
                             (flycheck-emacs-lisp-checkdoc-variables-form)))
             "--eval" (eval flycheck-emacs-lisp-checkdoc-form)
-            "--" source)
+            "--" source source-original)
   :error-patterns
-  ((info line-start (file-name) ":" line ": " (message) line-end))
+  ((info line-start (or "#<buffer  *temp*>" (file-name)) ":" line ": " (message) line-end))
   :modes (emacs-lisp-mode)
   :enabled flycheck--emacs-lisp-checkdoc-enabled-p)
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13797,8 +13797,12 @@ See Info Node `(elisp)Byte Compilation'."
       ;; for us.
       (with-temp-buffer
         (insert-file-contents source 'visit)
+        ;; Keep the buffer file-less when the checked buffer has no file, so
+        ;; that checkdoc skips the file-comment checks that make no sense for
+        ;; it.  `string-empty-p' would be cleaner, but subr-x is not preloaded
+        ;; in the batch Emacs before 29.
         (setq buffer-file-name
-              (unless (string-empty-p source-original) source-original))
+              (unless (equal source-original "") source-original))
         ;; And change back to the process default directory to make file-name
         ;; back-substitution work
         (setq default-directory process-default-directory)


### PR DESCRIPTION
checkdoc use buffer-file-name to decide whether or not checking file comments, this check should not be applied to temporary buffers. However, flycheck always use a temporary file, so file comment check is always applied, and the buffer file name in check message is set to the name of temporary file, which can be confusing.

To fix this problem, add source-original to the checker command list. If it is nil or empty string, we don't set buffer-file-name to indicate checkdoc. Otherwise we set buffer-file-name to it, so that file comment check produce messages with correct file name.