### PR TITLE
[Fix #2343] Add a flycheck-fix-edit-new-at-pos constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- [#2344](https://github.com/flycheck/flycheck/pull/2344): New `flycheck-fix-edit-new-at-pos` constructor building a fix edit from buffer positions, as `flycheck-error-new-at-pos` does for errors ([#2343](https://github.com/flycheck/flycheck/issues/2343)).
 - [#2341](https://github.com/flycheck/flycheck/pull/2341): The error list's project scope now shows the diagnostics a language server pushed for files that are not open in any buffer, with both the Eglot bridge and the native `flycheck-lsp` checker ([#2340](https://github.com/flycheck/flycheck/issues/2340)).
 
 ### Bugs fixed

--- a/doc/developer/developing.rst
+++ b/doc/developer/developing.rst
@@ -363,6 +363,12 @@ empty replacement):
                         :replacement ""))
           :tick (buffer-chars-modified-tick)))
 
+When you have buffer positions rather than lines and columns -- from a regexp
+match or an overlay, say -- build the edit with ``flycheck-fix-edit-new-at-pos``
+instead, the counterpart of ``flycheck-error-new-at-pos``: it takes the start
+position, the (exclusive) end position and the replacement, and converts them
+in the current buffer.
+
 Set ``:tick`` to the buffer's ``buffer-chars-modified-tick`` when you build the
 fix: ``flycheck-apply-fix`` refuses to apply a fix if the buffer changed since,
 so stale positions can never silently corrupt the buffer.

--- a/flycheck.el
+++ b/flycheck.el
@@ -4613,14 +4613,30 @@ out to be available."
   (let ((fix (flycheck-error-fix err)))
     (if (functionp fix) (funcall fix err) fix)))
 
-(cl-defstruct (flycheck-fix-edit (:constructor flycheck-fix-edit-new))
+(cl-defstruct (flycheck-fix-edit
+               (:constructor flycheck-fix-edit-new)
+               (:constructor
+                flycheck-fix-edit-new-at-pos
+                (pos end-pos replacement
+                 &aux
+                 ((line . column) (flycheck-line-column-at-pos pos))
+                 ((end-line . end-column)
+                  (flycheck-line-column-at-pos end-pos)))))
   "A single text edit of a `flycheck-fix'.
 
 Replace the region from LINE, COLUMN to END-LINE, END-COLUMN with
 REPLACEMENT.  Positions are one-based, as in `flycheck-error'; an
 edit that only inserts text has END-LINE, END-COLUMN equal to
 LINE, COLUMN, and an edit that only deletes has an empty
-REPLACEMENT."
+REPLACEMENT.
+
+`flycheck-fix-edit-new-at-pos' builds an edit from buffer
+positions instead, as `flycheck-error-new-at-pos' does for
+errors: POS and END-POS are positions in the current buffer,
+converted at construction time.  A buffer region excludes the
+character at its end, which is exactly the right-open span the
+edit wants, so no adjustment is needed.  POS must not exceed
+END-POS; a reversed region is refused when the fix is applied."
   line column end-line end-column replacement)
 
 (cl-defstruct (flycheck-fix (:constructor flycheck-fix-new))

--- a/test/specs/test-quick-fixes.el
+++ b/test/specs/test-quick-fixes.el
@@ -53,6 +53,44 @@
       (let ((err (flycheck-error-new-at 1 1 'error "e" :fix (lambda (_) nil))))
         (expect (flycheck-error-resolve-fix err) :to-be nil))))
 
+  (describe "flycheck-fix-edit-new-at-pos"
+    (it "converts buffer positions to one-based lines and columns"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "first line\nsecond line\n")
+        ;; "second" is positions 12-18: line 2, columns 1-7 right-open
+        (let ((edit (flycheck-fix-edit-new-at-pos 12 18 "next")))
+          (expect (flycheck-fix-edit-line edit) :to-equal 2)
+          (expect (flycheck-fix-edit-column edit) :to-equal 1)
+          (expect (flycheck-fix-edit-end-line edit) :to-equal 2)
+          (expect (flycheck-fix-edit-end-column edit) :to-equal 7)
+          (expect (flycheck-fix-edit-replacement edit) :to-equal "next"))))
+
+    (it "builds an insertion from an empty region"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "ab\n")
+        (let ((edit (flycheck-fix-edit-new-at-pos 2 2 "x")))
+          (expect (flycheck-fix-edit-line edit) :to-equal 1)
+          (expect (flycheck-fix-edit-column edit) :to-equal 2)
+          (expect (flycheck-fix-edit-end-line edit) :to-equal 1)
+          (expect (flycheck-fix-edit-end-column edit) :to-equal 2))))
+
+    (it "builds the same edit flycheck-fix-edit-new would"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "first line\nsecond line\n")
+        (expect (flycheck-fix-edit-new-at-pos 12 18 "next")
+                :to-equal (flycheck-fix-edit-new
+                           :line 2 :column 1 :end-line 2 :end-column 7
+                           :replacement "next"))))
+
+    (it "applies like any other edit"
+      (flycheck-buttercup-with-temp-buffer
+        (insert "first line\nsecond line\n")
+        (let ((fix (flycheck-fix-new
+                    :edits (list (flycheck-fix-edit-new-at-pos 12 18 "next"))
+                    :tick (buffer-chars-modified-tick))))
+          (flycheck-apply-fix fix)
+          (expect (buffer-string) :to-equal "first line\nnext line\n")))))
+
   (describe "flycheck-error-known-fix-p"
     (it "is true for a stored fix"
       (let* ((fix (flycheck-test--edit 1 1 1 2 "x"))


### PR DESCRIPTION
Builds a fix edit from buffer positions, the way `flycheck-error-new-at-pos` builds an error. Checker authors with a regexp match or an overlay in hand no longer need to convert to lines and columns themselves, and the exclusive end of a buffer region maps onto the edit's right-open end column with no adjustment.

Fixes #2343.