### PR TITLE
[Fix #2345] Serve only the diagnostics at the queried position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugs fixed
 
+- [#2347](https://github.com/flycheck/flycheck/pull/2347): A single-position `flymake-diagnostics` call in a `flycheck-eglot-mode` buffer no longer returns diagnostics from past the position ([#2345](https://github.com/flycheck/flycheck/issues/2345)).
 - [#2339](https://github.com/flycheck/flycheck/pull/2339): `perl-perlimports` quick fixes now notice when the buffer changed while the tool ran, instead of applying their edits to shifted positions.
 - [#2338](https://github.com/flycheck/flycheck/pull/2338): `emacs-lisp-checkdoc` no longer complains about missing file comments in buffers that have no backing file, such as org indirect edit buffers.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -12548,14 +12548,18 @@ leave `flymake-diagnostics' (used e.g. by `eglot-code-actions') empty.
 ORIG is the advised function; BEG, END and ARGS are its arguments."
   (if (not (bound-and-true-p flycheck-eglot-mode))
       (apply orig beg end args)
-    ;; Mirror `flymake-diagnostics': return the diagnostics that OVERLAP
+    ;; Mirror `flymake-diagnostics': a BEG-only call means the diagnostics
+    ;; AT that position, spanning it the way `overlays-at' reads a span,
+    ;; right-open.  A range call returns the diagnostics that OVERLAP
     ;; [BEG, END] (nil means unbounded), not just those contained in it, so
     ;; callers like `eglot-code-actions' still see a wide diagnostic at point.
     (seq-filter (lambda (d)
                   (let ((db (flymake-diagnostic-beg d))
                         (de (flymake-diagnostic-end d)))
-                    (and (or (null end) (<= db end))
-                         (or (null beg) (<= beg de)))))
+                    (if (and beg (null end))
+                        (and (<= db beg) (< beg de))
+                      (and (or (null end) (<= db end))
+                           (or (null beg) (<= beg de))))))
                 flycheck-eglot--diagnostics)))
 
 (defun flycheck-eglot--enable ()

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -331,6 +331,28 @@ half-assembled answer and passes for the wrong reason."
           ;; a narrow query inside a wider diagnostic must still find it
           (expect (flycheck-eglot--flymake-diagnostics #'ignore 3 4)
                   :to-equal (list wide)))))
+    (it "serves only the diagnostics AT a single position"
+      ;; Flymake promises that BEG alone means the diagnostics at BEG; the
+      ;; filter used to keep everything ending at or after it, handing
+      ;; "diagnostic at point" callers errors from lines below (#2345)
+      (flycheck-buttercup-with-temp-buffer
+        (insert "# comment
+TEST=1
+")
+        (let* ((flycheck-eglot-mode t)
+               (diag (test-eglot--diag (current-buffer) 11 17 :warning "unused"))
+               (flycheck-eglot--diagnostics (list diag)))
+          ;; before the span, as anywhere on line 1
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 1) :to-be nil)
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 10) :to-be nil)
+          ;; inside the span, both edges
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 11)
+                  :to-equal (list diag))
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 16)
+                  :to-equal (list diag))
+          ;; the right-open end and beyond, as `overlays-at' reads a span
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 17) :to-be nil)
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 18) :to-be nil))))
     (it "delegates to the original when the mode is off"
       (let ((flycheck-eglot-mode nil))
         (expect (flycheck-eglot--flymake-diagnostics


### PR DESCRIPTION
The eglot bridge's `flymake-diagnostics` advice treated a single-position call as an unbounded range, so asking for the diagnostics at point returned everything from point downward. That broke third-party diagnostic-at-point consumers, and eglot's own `eglot--code-action-bounds` is a single-position caller too. A lone BEG now matches spans the way `overlays-at` does, right-open at the end; range calls are unchanged.

Fixes #2345.