### PR TITLE
[#2345] Keep strict range edges in the flymake-diagnostics advice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugs fixed
 
+- [#2348](https://github.com/flycheck/flycheck/pull/2348): Range queries against the diagnostics of a `flycheck-eglot-mode` buffer now keep `overlays-in`'s strict edges, so a diagnostic merely touching a boundary is no longer served.
 - [#2347](https://github.com/flycheck/flycheck/pull/2347): A single-position `flymake-diagnostics` call in a `flycheck-eglot-mode` buffer no longer returns diagnostics from past the position ([#2345](https://github.com/flycheck/flycheck/issues/2345)).
 - [#2339](https://github.com/flycheck/flycheck/pull/2339): `perl-perlimports` quick fixes now notice when the buffer changed while the tool ran, instead of applying their edits to shifted positions.
 - [#2338](https://github.com/flycheck/flycheck/pull/2338): `emacs-lisp-checkdoc` no longer complains about missing file comments in buffers that have no backing file, such as org indirect edit buffers.

--- a/flycheck.el
+++ b/flycheck.el
@@ -12550,16 +12550,18 @@ ORIG is the advised function; BEG, END and ARGS are its arguments."
       (apply orig beg end args)
     ;; Mirror `flymake-diagnostics': a BEG-only call means the diagnostics
     ;; AT that position, spanning it the way `overlays-at' reads a span,
-    ;; right-open.  A range call returns the diagnostics that OVERLAP
-    ;; [BEG, END] (nil means unbounded), not just those contained in it, so
-    ;; callers like `eglot-code-actions' still see a wide diagnostic at point.
+    ;; right-open.  A range call returns the diagnostics that overlap
+    ;; BEG..END (nil means unbounded) with `overlays-in's strict edges: a
+    ;; diagnostic merely touching a boundary is not served, and a narrow
+    ;; query inside a wider diagnostic still finds it, so callers like
+    ;; `eglot-code-actions' see what Flymake itself would report.
     (seq-filter (lambda (d)
                   (let ((db (flymake-diagnostic-beg d))
                         (de (flymake-diagnostic-end d)))
                     (if (and beg (null end))
                         (and (<= db beg) (< beg de))
-                      (and (or (null end) (<= db end))
-                           (or (null beg) (<= beg de))))))
+                      (and (or (null end) (< db end))
+                           (or (null beg) (< beg de))))))
                 flycheck-eglot--diagnostics)))
 
 (defun flycheck-eglot--enable ()

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -353,6 +353,28 @@ TEST=1
           ;; the right-open end and beyond, as `overlays-at' reads a span
           (expect (flycheck-eglot--flymake-diagnostics #'ignore 17) :to-be nil)
           (expect (flycheck-eglot--flymake-diagnostics #'ignore 18) :to-be nil))))
+    (it "keeps the strict edges of a range query, as overlays-in does"
+      ;; A diagnostic merely touching a boundary is not in the range;
+      ;; the expectations mirror probed overlays-in behavior exactly
+      (flycheck-buttercup-with-temp-buffer
+        (insert "# comment\nTEST=1\nmore text\n")
+        (let* ((flycheck-eglot-mode t)
+               (diag (test-eglot--diag (current-buffer) 11 17 :warning "unused"))
+               (flycheck-eglot--diagnostics (list diag)))
+          ;; regions ending at the start or starting at the exclusive end
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 1 11) :to-be nil)
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 17 20) :to-be nil)
+          ;; overlapping and contained regions
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 16 20)
+                  :to-equal (list diag))
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 12 13)
+                  :to-equal (list diag))
+          ;; empty regions: nothing at the span's start, the span at a
+          ;; strictly inside position - eglot's code-action fallback asks
+          ;; for (point) (point)
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 11 11) :to-be nil)
+          (expect (flycheck-eglot--flymake-diagnostics #'ignore 16 16)
+                  :to-equal (list diag)))))
     (it "delegates to the original when the mode is off"
       (let ((flycheck-eglot-mode nil))
         (expect (flycheck-eglot--flymake-diagnostics


### PR DESCRIPTION
Follow-up to #2347: range queries compared both edges closed-interval, serving diagnostics that merely touch a boundary where Flymake itself returns nothing. Now both regimes of the advice mirror what they advise - `overlays-at` for a single position, `overlays-in` for a range - with the spec's expectations probed against the real functions case by case.