### PR TITLE
Read Sphinx 8's warning-type tags as error ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugs fixed
 
+- [#2349](https://github.com/flycheck/flycheck/pull/2349): The `rst-sphinx` checker reads the warning-type tags Sphinx 8 appends (e.g. `[ref.envvar]`) as error identifiers instead of leaving them in the message.
 - [#2348](https://github.com/flycheck/flycheck/pull/2348): Range queries against the diagnostics of a `flycheck-eglot-mode` buffer now keep `overlays-in`'s strict edges, so a diagnostic merely touching a boundary is no longer served.
 - [#2347](https://github.com/flycheck/flycheck/pull/2347): A single-position `flymake-diagnostics` call in a `flycheck-eglot-mode` buffer no longer returns diagnostics from past the position ([#2345](https://github.com/flycheck/flycheck/issues/2345)).
 - [#2339](https://github.com/flycheck/flycheck/pull/2339): `perl-perlimports` quick fixes now notice when the buffer changed while the tool ran, instead of applying their edits to shifted positions.

--- a/flycheck.el
+++ b/flycheck.el
@@ -17597,11 +17597,18 @@ Requires Sphinx 1.2 or newer.  See URL `https://sphinx-doc.org'."
                                         ; directory
             source-original)            ; Sphinx needs the original document
   :error-patterns
-  ((warning line-start (file-name) ":" line ": WARNING: " (message) line-end)
+  ;; Sphinx 8 appends the warning's type, e.g. [ref.envvar], which is an
+  ;; error identifier rather than message text; older Sphinx has no tag.
+  ((warning line-start (file-name) ":" line ": WARNING: "
+            (message (minimal-match (one-or-more not-newline)))
+            (optional " [" (id (one-or-more (not (any "]")))) "]")
+            line-end)
    (error line-start
           (file-name) ":" line
           ": " (or "ERROR" "SEVERE") ": "
-          (message) line-end))
+          (message (minimal-match (one-or-more not-newline)))
+          (optional " [" (id (one-or-more (not (any "]")))) "]")
+          line-end))
   :modes rst-mode
   :predicate (lambda () (and (flycheck-buffer-saved-p)
                              (flycheck-locate-sphinx-source-directory)))

--- a/test/specs/languages/test-rst.el
+++ b/test/specs/languages/test-rst.el
@@ -3,6 +3,20 @@
 (require 'flycheck-buttercup)
 (require 'test-helpers)
 
+(defun test-rst/sphinx-warning-types-p ()
+  "Whether the installed sphinx-build tags diagnostics with their type.
+Sphinx 8 turned `show_warning_types' on by default, appending
+e.g. [ref.envvar], which the checker reads as the error's id."
+  (when-let* ((sphinx (flycheck-find-checker-executable 'rst-sphinx))
+              (version (with-temp-buffer
+                         (and (eq 0 (call-process sphinx nil t nil
+                                                  "--version"))
+                              (goto-char (point-min))
+                              (re-search-forward
+                               "sphinx-build \\([0-9.]+\\)" nil t)
+                              (match-string 1)))))
+    (version<= "8" version)))
+
 (describe "Language reStructuredText"
   (flycheck-buttercup-def-checker-test rst rst nil
     (flycheck-buttercup-should-syntax-check
@@ -15,12 +29,16 @@
      '(26 nil error "Unexpected section title." :checker rst)))
 
   (flycheck-buttercup-def-checker-test rst-sphinx rst nil
-    (flycheck-buttercup-should-syntax-check
-     "language/rst/sphinx/index.rst" 'rst-mode
-     '(2 nil warning "Title underline too short." :checker rst-sphinx)
-     '(9 nil error "Unknown target name: \"cool\". [docutils]" :checker rst-sphinx)
-     '(9 nil warning "'envvar' reference target not found: FOO [ref.envvar]"
-         :checker rst-sphinx)))
+    ;; Sphinx 8+ tags each diagnostic with its type, which becomes the id;
+    ;; the messages read the same on either side of that.
+    (let ((tagged (test-rst/sphinx-warning-types-p)))
+      (flycheck-buttercup-should-syntax-check
+       "language/rst/sphinx/index.rst" 'rst-mode
+       '(2 nil warning "Title underline too short." :checker rst-sphinx)
+       `(9 nil error "Unknown target name: \"cool\"."
+           :id ,(and tagged "docutils") :checker rst-sphinx)
+       `(9 nil warning "'envvar' reference target not found: FOO"
+           :id ,(and tagged "ref.envvar") :checker rst-sphinx))))
 
   (flycheck-buttercup-def-checker-test rst-sphinx rst not-outside-of-a-sphinx-project
     (flycheck-buttercup-with-resource-buffer "language/rst/errors.rst"
@@ -40,7 +58,8 @@
       '(21 nil error "Unknown target name: \"cool\"."))
     (flycheck-buttercup-def-parse-test rst-sphinx "language/rst/sphinx/index.rst"
       '(2 nil warning "Title underline too short.")
-      '(9 nil error "Unknown target name: \"cool\". [docutils]")
-      '(9 nil warning "'envvar' reference target not found: FOO [ref.envvar]"))))
+      '(9 nil error "Unknown target name: \"cool\"." :id "docutils")
+      '(9 nil warning "'envvar' reference target not found: FOO"
+          :id "ref.envvar"))))
 
 ;;; test-rst.el ends here


### PR DESCRIPTION
Follow-up to #2342: the `[docutils]` / `[ref.envvar]` suffixes Sphinx 8 appends are identifiers, not message text, so the `rst-sphinx` patterns now capture them as the error's id - same treatment actionlint and puppet-lint got. Messages read identically on either side of Sphinx 8, and the live spec branches its id expectations on the installed version (verified against real 7.4.7 and 9.1.0).