### PR TITLE
Compose Eglot diagnostic messages from Emacs 32's split Flymake fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugs fixed
 
+- [#2350](https://github.com/flycheck/flycheck/pull/2350): The Eglot bridge composes diagnostic messages from Emacs 32's split Flymake fields itself, so they read identically across Emacs versions instead of picking up stray separators.
 - [#2349](https://github.com/flycheck/flycheck/pull/2349): The `rst-sphinx` checker reads the warning-type tags Sphinx 8 appends (e.g. `[ref.envvar]`) as error identifiers instead of leaving them in the message.
 - [#2348](https://github.com/flycheck/flycheck/pull/2348): Range queries against the diagnostics of a `flycheck-eglot-mode` buffer now keep `overlays-in`'s strict edges, so a diagnostic merely touching a boundary is no longer served.
 - [#2347](https://github.com/flycheck/flycheck/pull/2347): A single-position `flymake-diagnostics` call in a `flycheck-eglot-mode` buffer no longer returns diagnostics from past the position ([#2345](https://github.com/flycheck/flycheck/issues/2345)).

--- a/flycheck.el
+++ b/flycheck.el
@@ -12217,6 +12217,9 @@ For a full language server, prefer Eglot and `flycheck-eglot-mode'."
 (declare-function flymake-diagnostic-type "flymake" (diag))
 (declare-function flymake-diagnostic-text "flymake" (diag))
 (declare-function flymake-diagnostic-data "flymake" (diag))
+(declare-function flymake-diagnostic-message "flymake" (diag))
+(declare-function flymake-diagnostic-origin "flymake" (diag))
+(declare-function flymake-diagnostic-code "flymake" (diag))
 (declare-function eglot-code-actions "eglot" (beg &optional end action-kind interactive))
 (declare-function eglot-server-capable "eglot" (&rest feats))
 (declare-function eglot-uri-to-path "eglot" (uri))
@@ -12338,6 +12341,26 @@ is never selected unless the mode opted in."
   (and (bound-and-true-p flycheck-eglot-mode)
        (flycheck-eglot--available-p)))
 
+(defun flycheck-eglot--diag-message (diag)
+  "Return the message text of the Flymake diagnostic DIAG.
+
+Emacs 32's Flymake splits a diagnostic's text into origin, code and
+message, and its `flymake-diagnostic-text' composes them back with
+decoration (and stray separators around absent parts).  Compose the raw
+fields here instead, in the shape Eglot used to bake into the text -
+ORIGIN [CODE]: MESSAGE - so the same diagnostic reads identically on
+either side of the split.  A diagnostic without an origin drops old
+Eglot's stray leading separators rather than reproducing them."
+  (if (fboundp 'flymake-diagnostic-message)
+      (let ((origin (flymake-diagnostic-origin diag))
+            (code (flymake-diagnostic-code diag))
+            (message (or (flymake-diagnostic-message diag) "")))
+        (cond ((and origin code) (format "%s [%s]: %s" origin code message))
+              (origin (format "%s: %s" origin message))
+              (code (format "[%s]: %s" code message))
+              (t (format "%s" message))))
+    (format "%s" (flymake-diagnostic-text diag))))
+
 (defun flycheck-eglot--type-level (type)
   "Map an Eglot Flymake diagnostic TYPE to a Flycheck error level."
   (pcase type
@@ -12361,7 +12384,7 @@ as a fallback."
        (flycheck-eglot--type-level (flymake-diagnostic-type diag)))
      (if lsp
          (plist-get lsp :message)
-       (format "%s" (flymake-diagnostic-text diag)))
+       (flycheck-eglot--diag-message diag))
      :end-pos (flymake-diagnostic-end diag)
      :id (and lsp (flycheck-lsp--diagnostic-id lsp))
      :relations (and lsp (flycheck-lsp--related-locations lsp))
@@ -12410,7 +12433,7 @@ position.  Returns nil when the position cannot be read."
     (flycheck-error-new-at
      (car beg) (cdr beg)
      (flycheck-eglot--type-level (flymake-diagnostic-type diag))
-     (format "%s" (flymake-diagnostic-text diag))
+     (flycheck-eglot--diag-message diag)
      :checker 'eglot-check
      :filename file
      :buffer nil)))

--- a/test/specs/test-eglot.el
+++ b/test/specs/test-eglot.el
@@ -69,6 +69,20 @@ half-assembled answer and passes for the wrong reason."
           (expect (flycheck-error-message err) :to-equal "raw")
           (expect (flycheck-error-id err) :to-be nil))))
 
+    (it "composes the split fields the way older Eglot baked into the text"
+      ;; Emacs 32's Flymake carries origin, code and message separately;
+      ;; the composed message must read identically to released Emacsen
+      (assume (fboundp 'flymake-diagnostic-message)
+              "Requires the split diagnostic fields of Emacs 32's Flymake")
+      (flycheck-buttercup-with-temp-buffer
+        (insert "line one here\n")
+        (let* ((diag (flymake-make-diagnostic
+                      (current-buffer) 1 5 :error
+                      (list "compiler" "UndeclaredName" "undefined: a")))
+               (err (flycheck-eglot--convert-diagnostic diag)))
+          (expect (flycheck-error-message err)
+                  :to-equal "compiler [UndeclaredName]: undefined: a"))))
+
     (it "maps the diagnostic's relatedInformation to related locations"
       (flycheck-buttercup-with-temp-buffer
         (insert "line one here\n")


### PR DESCRIPTION
The Emacs 32 snapshots split Flymake's diagnostic text into origin/code/message, and `flymake-diagnostic-text` now composes them with stray separators when parts are absent - which is why the two snapshot CI jobs went red on the eglot bridge specs. The bridge now composes the raw fields itself, matching byte-for-byte what released Eglot bakes into the text, verified by running the eglot specs against the snapshot flymake.el loaded into Emacs 30.2 (both generations green).