### PR TITLE
Read mypy's JSON diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [#2352](https://github.com/flycheck/flycheck/pull/2352): `python-mypy` reads mypy's JSON output (requiring mypy 1.11 or newer): errors carry precise end positions (with mypy 1.20+), stub-install hints stay attached to their error, and messages lose the stray leading space the old patterns captured.
 - [#2351](https://github.com/flycheck/flycheck/pull/2351): The RuboCop family (`rubocop`, `standardrb`, `cookstyle`) reads the tools' JSON output: ids are bare cop names without the `[Correctable] ` marker (which un-breaks explanations for correctable offenses), errors carry precise end positions, and refactor/info severities are no longer dropped.
 
 ### New Features

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1306,7 +1306,7 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. note::
 
-         This syntax checker requires mypy 0.730 or newer.
+         This syntax checker requires mypy 1.11 or newer; precise end positions need mypy 1.20.
 
       .. syntax-checker-config-file:: flycheck-python-mypy-config
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -17023,34 +17023,57 @@ See URL `https://github.com/microsoft/pyright'."
 (flycheck-def-args-var flycheck-python-mypy-args python-mypy
   :package-version '(flycheck . "39"))
 
+(defun flycheck-parse-mypy (output checker buffer)
+  "Parse mypy JSON diagnostics from OUTPUT.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and the
+BUFFER that was checked, respectively.  Mypy prints one JSON object per
+line; its columns are zero-based with a right-open end, converted here
+to Flycheck's one-based ones.
+
+See URL `https://mypy.readthedocs.io/en/stable/command_line.html' for
+more information."
+  (mapcar
+   (lambda (diag)
+     (let-alist diag
+       (flycheck-error-new-at
+        ;; -1 is mypy's unknown-position sentinel; an error without a
+        ;; line is discarded as irrelevant, like the old patterns never
+        ;; matching one
+        (and (natnump .line) (> .line 0) .line)
+        (and (natnump .column) (1+ .column))
+        (pcase .severity
+          ("note" 'info)
+          ("warning" 'warning)
+          (_ 'error))
+        ;; A note sharing an error's exact location arrives folded into
+        ;; its hint rather than as a diagnostic of its own
+        (if (stringp .hint)
+            (format "%s\n%s" .message .hint)
+          .message)
+        :id .code
+        :end-line (and (natnump .end_line) (> .end_line 0) .end_line)
+        ;; End positions arrived in mypy 1.20's JSON; older versions
+        ;; simply omit them
+        :end-column (and (natnump .end_column) (1+ .end_column))
+        :checker checker
+        :buffer buffer
+        :filename .file)))
+   (flycheck-parse-json output)))
+
 (flycheck-define-checker python-mypy
-  "Mypy syntax and type checker.  Requires mypy>=0.730.
+  "Mypy syntax and type checker.  Requires mypy 1.11 or newer;
+end positions need mypy 1.20.
 
 See URL `https://mypy-lang.org/'."
   :command ("mypy"
-            "--show-column-numbers"
-            "--show-error-codes"
-            "--no-pretty"
+            "--output" "json"
             (config-file "--config-file" flycheck-python-mypy-config)
             (option "--cache-dir" flycheck-python-mypy-cache-dir)
             (option "--python-executable" flycheck-python-mypy-python-executable)
             (eval flycheck-python-mypy-args)
             source-original)
-  :error-patterns
-  ((error line-start (file-name) ":" line (optional ":" column)
-          ": error:" (message) line-end)
-   (warning line-start (file-name) ":" line (optional ":" column)
-            ": warning:" (message) line-end)
-   (info line-start (file-name) ":" line (optional ":" column)
-         ": note:" (message) line-end))
-  :error-filter
-  (lambda (errors)
-    (dolist (err errors)
-      (let ((msg (flycheck-error-message err)))
-        (when (and msg (string-match "\\(.*?\\)  \\[\\([^]]+\\)\\]\\'" msg))
-          (setf (flycheck-error-message err) (match-string 1 msg))
-          (setf (flycheck-error-id err) (match-string 2 msg)))))
-    errors)
+  :error-parser flycheck-parse-mypy
   :working-directory flycheck-python-find-project-root
   :error-explainer
   (flycheck-error-explainer-from-url

--- a/test/fixtures/python-mypy/language/python/invalid_type.py.txt
+++ b/test/fixtures/python-mypy/language/python/invalid_type.py.txt
@@ -1,2 +1,1 @@
-python/invalid_type.py:2:12: error: Incompatible return value type (got "str", expected "int")  [return-value]
-Found 1 error in 1 file (checked 1 source file)
+{"file": "python/invalid_type.py", "line": 2, "column": 11, "end_line": 2, "end_column": 12, "message": "Incompatible return value type (got \"str\", expected \"int\")", "hint": null, "code": "return-value", "severity": "error"}

--- a/test/specs/languages/test-python.el
+++ b/test/specs/languages/test-python.el
@@ -359,8 +359,45 @@ ModuleNotFoundError: No module named 'pycodestyle'")
       '(1 1 info "Invalid module name: 'syntax-error'" :id "N999")
       '(3 7 error "Expected an identifier, but found a keyword `import` that cannot be used here")
       '(3 14 error "Simple statements must be separated by newlines or semicolons"))
+    (it "keeps mypy's folded hint attached to its error"
+      ;; A note at an error's exact location arrives as the error's hint
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'python-mypy
+          (concat "{\"file\": \"m.py\", \"line\": 1, \"column\": 7,"
+                  " \"end_line\": null, \"end_column\": null,"
+                  " \"message\": \"Library stubs not installed\","
+                  " \"hint\": \"Hint: pip install types-requests\","
+                  " \"code\": \"import-untyped\","
+                  " \"severity\": \"error\"}\n"))
+         :to-be-equal-flycheck-errors
+         (list (flycheck-error-new-at
+                1 8 'error "Library stubs not installed\nHint: pip install types-requests"
+                :id "import-untyped" :checker 'python-mypy
+                :buffer (current-buffer) :filename "m.py")))))
+
+    (it "drops mypy's unknown-position sentinels rather than pinning them"
+      ;; -1 means unknown; a context note with it must not land on line 1
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'python-mypy
+          (concat "{\"file\": \"m.py\", \"line\": -1, \"column\": -1,"
+                  " \"end_line\": -1, \"end_column\": -1,"
+                  " \"message\": \"At top level:\", \"hint\": null,"
+                  " \"code\": null, \"severity\": \"note\"}\n"))
+         :to-equal
+         (list (flycheck-error-new-at
+                nil nil 'info "At top level:"
+                :checker 'python-mypy
+                :buffer (current-buffer) :filename "m.py")))))
+
     (flycheck-buttercup-def-parse-test python-mypy "language/python/invalid_type.py"
-      '(2 12 error " Incompatible return value type (got \"str\", expected \"int\")" :id "return-value"))
+      ;; The old patterns captured the space after "error:" into the
+      ;; message; the JSON messages are clean
+      '(2 12 error "Incompatible return value type (got \"str\", expected \"int\")"
+          :id "return-value" :end-line 2 :end-column 13))
     (flycheck-buttercup-def-parse-test python-pyright "language/python/invalid_type.py"
       '(2 12 error "Type \"str\" is not assignable to return type \"int\"\n  \"str\" is not assignable to \"int\"" :id "reportReturnType" :end-line 2 :end-column 13))))
 


### PR DESCRIPTION
Second slice of the structured-output sweep: `python-mypy` reads `--output json` (mypy 1.11+, so the checker docstring and manual now say so) instead of text patterns plus a message-scraping filter. Error codes arrive as ids, end positions come along on mypy 1.20+, and notes that mypy folds into an error's `hint` stay attached to the message - the old patterns showed them, so dropping them would have been a quiet regression. Mypy's `-1` unknown-position sentinels map to nil instead of pinning phantom diagnostics at line 1.

Verified against mypy 2.3 in the checker image (re-recorded fixture) plus source-level checks of the JSON formatter across 1.11-1.20 for the field history.