### PR TITLE
Read puppet-lint's and actionlint's JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [#2353](https://github.com/flycheck/flycheck/pull/2353): `puppet-lint` and `actionlint` read their tools' JSON output, giving puppet-lint problems the columns the old patterns never captured and actionlint errors precise end positions.
 - [#2352](https://github.com/flycheck/flycheck/pull/2352): `python-mypy` reads mypy's JSON output (requiring mypy 1.11 or newer): errors carry precise end positions (with mypy 1.20+), stub-install hints stay attached to their error, and messages lose the stray leading space the old patterns captured.
 - [#2351](https://github.com/flycheck/flycheck/pull/2351): The RuboCop family (`rubocop`, `standardrb`, `cookstyle`) reads the tools' JSON output: ids are bare cop names without the `[Correctable] ` marker (which un-breaks explanations for correctable offenses), errors carry precise end positions, and refactor/info severities are no longer dropped.
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -14662,18 +14662,38 @@ Uses GCC's Fortran compiler gfortran.  See URL
 (flycheck-def-args-var flycheck-yaml-actionlint-args yaml-actionlint
   :package-version '(flycheck . "39"))
 
+(defun flycheck-parse-actionlint (output checker buffer)
+  "Parse actionlint JSON errors from OUTPUT.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and the
+BUFFER that was checked, respectively.  The kind of the check becomes
+the error's id, as the oneline format's [kind] suffix used to; the end
+column is inclusive and becomes Flycheck's right-open one.  Requires
+actionlint 1.6 or newer; end positions need 1.6.20.
+
+See URL `https://github.com/rhysd/actionlint/' for more information."
+  (mapcar
+   (lambda (err)
+     (let-alist err
+       (flycheck-error-new-at
+        .line .column 'error .message
+        :id .kind
+        :end-line (and .end_column .line)
+        :end-column (and .end_column (1+ .end_column))
+        :checker checker
+        :buffer buffer
+        :filename .filepath)))
+   (car (flycheck-parse-json output))))
+
 (flycheck-define-checker yaml-actionlint
   "A YAML syntax checker using actionlint.
 
 See URL https://github.com/rhysd/actionlint/."
-  :command ("actionlint" "-oneline"
+  :command ("actionlint" "-format" "{{json .}}"
             (config-file "-config-file" flycheck-yaml-actionlint-config)
             (eval flycheck-yaml-actionlint-args)
             source)
-  :error-patterns
-  ((error line-start (file-name) ":" line ":" column ": "
-          (message (minimal-match (one-or-more not-newline)))
-          " [" (id (one-or-more (not (any "]")))) "]" line-end))
+  :error-parser flycheck-parse-actionlint
   :modes (yaml-mode yaml-ts-mode)
   :predicate (lambda ()
                (and buffer-file-name
@@ -16472,6 +16492,39 @@ and their names."
 (flycheck-def-args-var flycheck-puppet-lint-args puppet-lint
   :package-version '(flycheck . "39"))
 
+(defun flycheck-parse-puppet-lint (output checker buffer)
+  "Parse puppet-lint JSON problems from OUTPUT.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and the
+BUFFER that was checked, respectively.  The JSON is one outer array
+holding an array of problems per checked file, and it carries a column
+for every problem, which the old patterns never captured.
+
+See URL `https://puppet-lint.com/' for more information."
+  (let ((errors nil))
+    (seq-do
+     (lambda (file-problems)
+       (seq-do
+        (lambda (problem)
+          (let-alist problem
+            (push (flycheck-error-new-at
+                   .line .column
+                   (pcase .kind
+                     ("error" 'error)
+                     (_ 'warning))
+                   .message
+                   :id .check
+                   :checker checker
+                   :buffer buffer
+                   :filename .path)
+                  errors)))
+        file-problems))
+     ;; Stderr noise ahead of the report could parse as JSON too; take
+     ;; the value shaped like the report, a list of lists
+     (seq-find (lambda (value) (and (consp value) (listp (car value))))
+               (flycheck-parse-json output)))
+    (nreverse errors)))
+
 (flycheck-define-checker puppet-lint
   "A Puppet DSL style checker using puppet-lint.
 
@@ -16483,19 +16536,12 @@ See URL `https://puppet-lint.com/'."
   ;; temporary file will cause an error.
   :command ("puppet-lint"
             (config-file "--config" flycheck-puppet-lint-config)
-            "--log-format"
-            "%{path}:%{line}:%{kind}: %{message} (%{check})"
+            "--json"
             (option-list "" flycheck-puppet-lint-disabled-checks concat
                          flycheck-puppet-lint-disabled-arg-name)
             (eval flycheck-puppet-lint-args)
             source-original)
-  :error-patterns
-  ((warning line-start (file-name) ":" line ":warning: "
-            (message (minimal-match (one-or-more not-newline)))
-            " (" (id (one-or-more (not (any ")")))) ")" line-end)
-   (error line-start (file-name) ":" line ":error: "
-          (message (minimal-match (one-or-more not-newline)))
-          " (" (id (one-or-more (not (any ")")))) ")" line-end))
+  :error-parser flycheck-parse-puppet-lint
   :modes (puppet-mode puppet-ts-mode)
   ;; Since we check the original file, we can only use this syntax checker if
   ;; the buffer is actually linked to a file, and if it is not modified.

--- a/test/fixtures/puppet-lint/language/puppet/warnings.pp.txt
+++ b/test/fixtures/puppet-lint/language/puppet/warnings.pp.txt
@@ -1,3 +1,39 @@
-test/resources/language/puppet/warnings.pp:2:error: foo::bar not in autoload module layout (autoloader_layout)
-test/resources/language/puppet/warnings.pp:3:warning: case statement without a default case (case_without_default)
-test/resources/language/puppet/warnings.pp:3:warning: legacy fact 'operatingsystem' (legacy_facts)
+[
+  [
+    {
+      "message": "foo::bar not in autoload module layout",
+      "line": 2,
+      "column": 7,
+      "kind": "error",
+      "check": "autoloader_layout",
+      "fullpath": "test/resources/language/puppet/warnings.pp",
+      "path": "test/resources/language/puppet/warnings.pp",
+      "filename": "warnings.pp",
+      "KIND": "ERROR"
+    },
+    {
+      "message": "case statement without a default case",
+      "line": 3,
+      "column": 3,
+      "kind": "warning",
+      "check": "case_without_default",
+      "fullpath": "test/resources/language/puppet/warnings.pp",
+      "path": "test/resources/language/puppet/warnings.pp",
+      "filename": "warnings.pp",
+      "KIND": "WARNING"
+    },
+    {
+      "message": "legacy fact 'operatingsystem'",
+      "line": 3,
+      "column": 8,
+      "token": "#<PuppetLint::Lexer::Token:0x0000ffff94b6c3a0>",
+      "fact_name": "operatingsystem",
+      "kind": "warning",
+      "check": "legacy_facts",
+      "fullpath": "test/resources/language/puppet/warnings.pp",
+      "path": "test/resources/language/puppet/warnings.pp",
+      "filename": "warnings.pp",
+      "KIND": "WARNING"
+    }
+  ]
+]

--- a/test/fixtures/yaml-actionlint/language/.github/workflows/test-action.yml.txt
+++ b/test/fixtures/yaml-actionlint/language/.github/workflows/test-action.yml.txt
@@ -1,1 +1,1 @@
-test-action.yml:6:23: property "foo" is not defined in object type {} [expression]
+[{"message":"property \"foo\" is not defined in object type {}","filepath":"test-action.yml","line":6,"column":23,"kind":"expression","snippet":"      - run: echo ${{ inputs.foo }}\n                      ^~~~~~~~~~","end_column":32}]

--- a/test/specs/languages/test-actionlint.el
+++ b/test/specs/languages/test-actionlint.el
@@ -8,14 +8,16 @@
     (flycheck-buttercup-should-syntax-check
      "language/.github/workflows/test-action.yml" 'yaml-mode
      '(6 23 error "property \"foo\" is not defined in object type {}"
-         :id "expression" :checker yaml-actionlint)))
+         :id "expression" :end-line 6 :end-column 33
+         :checker yaml-actionlint)))
 
   (describe "reading the tool's output"
     ;; Read from output recorded earlier, so this runs whether or
     ;; not the tool is installed here
 
     (flycheck-buttercup-def-parse-test yaml-actionlint "language/.github/workflows/test-action.yml"
+      ;; The JSON carries an inclusive end column the oneline format lacked
       '(6 23 error "property \"foo\" is not defined in object type {}"
-          :id "expression"))))
+          :id "expression" :end-line 6 :end-column 33))))
 
 ;;; test-actionlint.el ends here

--- a/test/specs/languages/test-puppet.el
+++ b/test/specs/languages/test-puppet.el
@@ -26,10 +26,12 @@
   (flycheck-buttercup-def-checker-test puppet-lint puppet nil
     (flycheck-buttercup-should-syntax-check
      "language/puppet/warnings.pp" 'puppet-mode
-     '(2 nil error "foo::bar not in autoload module layout"
+     '(2 7 error "foo::bar not in autoload module layout"
          :id "autoloader_layout" :checker puppet-lint)
-     '(3 nil warning "case statement without a default case"
-         :id "case_without_default" :checker puppet-lint)))
+     '(3 3 warning "case statement without a default case"
+         :id "case_without_default" :checker puppet-lint)
+     '(3 8 warning "legacy fact 'operatingsystem'"
+         :id "legacy_facts" :checker puppet-lint)))
 
   (describe "the puppet-lint checker command"
     (it "appends flycheck-puppet-lint-args before the source file"
@@ -48,8 +50,9 @@
     (flycheck-buttercup-def-parse-test puppet-parser "language/puppet/parser-error.pp"
       '(3 9 error "Syntax error at '>'"))
     (flycheck-buttercup-def-parse-test puppet-lint "language/puppet/warnings.pp"
-      '(2 nil error "foo::bar not in autoload module layout" :id "autoloader_layout")
-      '(3 nil warning "case statement without a default case" :id "case_without_default")
-      '(3 nil warning "legacy fact 'operatingsystem'" :id "legacy_facts"))))
+      ;; The JSON carries columns, which the old patterns never captured
+      '(2 7 error "foo::bar not in autoload module layout" :id "autoloader_layout")
+      '(3 3 warning "case statement without a default case" :id "case_without_default")
+      '(3 8 warning "legacy fact 'operatingsystem'" :id "legacy_facts"))))
 
 ;;; test-puppet.el ends here


### PR DESCRIPTION
Batch-one closeout for the structured-output sweep: `puppet-lint` moves off its custom log format (whose flycheck-side pattern never captured a column - the JSON has one for every problem) and `actionlint` moves off `-oneline`, with check kinds as ids and inclusive end columns converted to right-open spans (actionlint 1.6+; end positions from 1.6.20).

Both verified against the checker image with re-recorded fixtures; the live actionlint spec also runs against the real tool there. The live puppet spec gains the `legacy_facts` problem the old expectations were already missing against the current recording.