### PR TITLE
Read go vet's JSON findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [#2355](https://github.com/flycheck/flycheck/pull/2355): `go-vet` reads `go vet -json`: analyzer findings carry the analyzer's name as their id and byte-precise positions with end columns, and a compile error that stops the analyzers is reported at its real position as an error rather than a warning.
 - [#2354](https://github.com/flycheck/flycheck/pull/2354): `c/c++-gcc` reads GCC's SARIF output when the compiler supports it well (probed per binary, GCC 15 or newer - the SARIF of 13 and 14 can lose diagnostics - with the text patterns still covering older GCC and the Clang that answers to gcc on macOS): errors carry precise spans, warnings keep their flag ids, and GCC's notes become the error's related locations; the shared SARIF parser now maps related locations for every SARIF checker.
 - [#2353](https://github.com/flycheck/flycheck/pull/2353): `puppet-lint` and `actionlint` read their tools' JSON output, giving puppet-lint problems the columns the old patterns never captured and actionlint errors precise end positions.
 - [#2352](https://github.com/flycheck/flycheck/pull/2352): `python-mypy` reads mypy's JSON output (requiring mypy 1.11 or newer): errors carry precise end positions (with mypy 1.20+), stub-install hints stay attached to their error, and messages lose the stray leading space the old patterns captured.

--- a/flycheck.el
+++ b/flycheck.el
@@ -14844,18 +14844,73 @@ See URL `https://go.dev/cmd/gofmt/'."
 (flycheck-def-args-var flycheck-go-vet-args go-vet
   :package-version '(flycheck . "39"))
 
+(defun flycheck--go-vet-parse-position (position)
+  "Parse POSITION, a go/token file:line:column string, into a list.
+
+Returns (FILENAME LINE COLUMN), or nil when POSITION has no such
+shape."
+  (when (stringp position)
+    (cond
+     ((string-match "\\`\\(.+\\):\\([0-9]+\\):\\([0-9]+\\)\\'" position)
+      (list (match-string 1 position)
+            (string-to-number (match-string 2 position))
+            (string-to-number (match-string 3 position))))
+     ;; go/token omits a zero column, printing just file:line
+     ((string-match "\\`\\(.+\\):\\([0-9]+\\)\\'" position)
+      (list (match-string 1 position)
+            (string-to-number (match-string 2 position))
+            nil)))))
+
+(defun flycheck-parse-go-vet (output checker buffer)
+  "Parse `go vet -json' findings from OUTPUT.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and the
+BUFFER that was checked, respectively.  The findings arrive as one JSON
+document keyed by package and then by analyzer, whose name becomes the
+error's id; positions count bytes, with go/token's right-open end
+mapping straight onto Flycheck's.  A compile error that stops the
+analyzers prints as a text line beside the document and is read by the
+checker's pattern."
+  (let ((errors nil))
+    (dolist (package (apply #'append (flycheck-parse-json output)))
+      (pcase-dolist (`(,analyzer . ,findings) (cdr package))
+        (seq-do
+         (lambda (finding)
+           (let-alist finding
+             (pcase-let ((`(,file ,line ,column)
+                          (flycheck--go-vet-parse-position .posn))
+                         (`(,_ ,end-line ,end-column)
+                          (flycheck--go-vet-parse-position .end)))
+               (when line
+                 (push (flycheck-error-new-at
+                        line column 'warning .message
+                        :id (symbol-name analyzer)
+                        :end-line end-line
+                        :end-column end-column
+                        :checker checker
+                        :buffer buffer
+                        :filename file)
+                       errors)))))
+         findings)))
+    (nconc (nreverse errors)
+           (flycheck-parse-with-patterns output checker buffer))))
+
 (flycheck-define-checker go-vet
   "A Go syntax checker using the `go vet' command.
 
 See URL `https://go.dev/cmd/go/' and URL
 `https://pkg.go.dev/cmd/vet/'."
-  :command ("go" "vet"
+  :command ("go" "vet" "-json"
             (option "-tags=" flycheck-go-build-tags concat
                     flycheck-option-comma-separated-list)
             (eval flycheck-go-vet-args)
             (source ".go"))
+  :error-parser flycheck-parse-go-vet
   :error-patterns
-  ((warning line-start (file-name) ":" line ": " (message) line-end))
+  ;; A compile error that stops the analyzers prints as text beside the
+  ;; JSON document; the parser reads it with this pattern
+  ((error line-start "vet: " (file-name) ":" line ":" column ": "
+          (message) line-end))
   :modes (go-mode go-ts-mode)
   :next-checkers (go-build
                   go-test

--- a/test/fixtures/go-vet/language/go/printf/printf.go.txt
+++ b/test/fixtures/go-vet/language/go/printf/printf.go.txt
@@ -1,0 +1,11 @@
+{
+	"command-line-arguments": {
+		"printf": [
+			{
+				"posn": "printf.go:6:14",
+				"end": "printf.go:6:16",
+				"message": "fmt.Printf format %d has arg \"s\" of wrong type string"
+			}
+		]
+	}
+}

--- a/test/resources/language/go/printf/printf.go
+++ b/test/resources/language/go/printf/printf.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("%d", "s")
+}

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -92,11 +92,14 @@
           `(("GOPATH" . ,(flycheck-buttercup-resource-filename "language/go")))
         (flycheck-buttercup-should-syntax-check
          "language/go/src/warnings.go" 'go-mode
-         '(4 2 error "imported and not used: \"fmt\"" :checker go-build)
+         ;; Wordings follow modern Go; go-vet reads the compile error
+         ;; that stops its analyzers since it moved to -json output
+         '(4 2 error "\"fmt\" imported and not used" :checker go-build)
          '(8 2 error "undefined: fmt" :checker go-build)
+         '(8 2 error "undefined: fmt" :checker go-vet)
          '(12 2 error "undefined: fmt" :checker go-build)
          '(17 2 error "undefined: fmt" :checker go-build)
-         '(19 13 error "cannot use 1 (type untyped int) as type string in argument to Warnf"
+         '(19 13 error "cannot use 1 (untyped int constant) as string value in argument to Warnf"
               :checker go-build))))
 
     (flycheck-buttercup-def-checker-test go-build go handles-packages
@@ -160,6 +163,12 @@
       '(5 9 error "expected '(', found ta")
       '(6 1 error "expected ')', found '}'"))
     (flycheck-buttercup-def-parse-test go-vet "language/go/src/warnings.go"
-      '(2 nil warning "undefined: fmt"))))
+      ;; A compile error that stops the analyzers, via the vet: pattern
+      '(8 2 error "undefined: fmt"))
+    (flycheck-buttercup-def-parse-test go-vet "language/go/printf/printf.go"
+      ;; An analyzer finding from the JSON document; the analyzer names
+      ;; the id, and go/token's right-open end maps straight through
+      '(6 14 warning "fmt.Printf format %d has arg \"s\" of wrong type string"
+          :id "printf" :end-line 6 :end-column 16))))
 
 ;;; test-go.el ends here


### PR DESCRIPTION
Next slice of the structured-output sweep: `go-vet` reads `go vet -json`. Analyzer names become error ids, positions gain byte-precise end columns mapped straight from go/token's right-open ends, and compile errors surface at their real position as errors - the review turned up that modern vet's `vet:` prefix has been defeating the old pattern, so those errors were silently dropped for some time. The dormant live chain spec also gets modern Go wordings.

Both output modes are pinned by recordings: a compile error through the text pattern, a printf finding through the JSON document.