### PR TITLE
Read GHC 9.10's JSON diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [#2357](https://github.com/flycheck/flycheck/pull/2357): `haskell-ghc` reads GHC 9.10's JSON diagnostics when the compiler has them (probed per binary): errors carry precise spans and GHC-NNNNN ids that `C-c ! e` explains via the Haskell error index, and JSON-reading checkers in general no longer choke on text lines that merely start with a bracket, like GHC's compilation progress.
 - [#2356](https://github.com/flycheck/flycheck/pull/2356): `haskell-hlint` reads hlint's JSON ideas: hint names become error ids, spans get right-open end columns, and an idea with a replacement carries a machine-applicable fix, applied with `C-c ! f`.
 - [#2355](https://github.com/flycheck/flycheck/pull/2355): `go-vet` reads `go vet -json`: analyzer findings carry the analyzer's name as their id and byte-precise positions with end columns, and a compile error that stops the analyzers is reported at its real position as an error rather than a warning.
 - [#2354](https://github.com/flycheck/flycheck/pull/2354): `c/c++-gcc` reads GCC's SARIF output when the compiler supports it well (probed per binary, GCC 15 or newer - the SARIF of 13 and 14 can lose diagnostics - with the text patterns still covering older GCC and the Clang that answers to gcc on macOS): errors carry precise spans, warnings keep their flag ids, and GCC's notes become the error's related locations; the shared SARIF parser now maps related locations for every SARIF checker.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10884,7 +10884,12 @@ lines, and returns the parsed JSON lines in a list."
       (goto-char (point-min))
       (while (not (eobp))
         (when (memq (char-after) '(?\{ ?\[))
-          (push (funcall flycheck--json-parser) objects))
+          (condition-case nil
+              (push (funcall flycheck--json-parser) objects)
+            ;; A plain-text line that merely starts with a brace or
+            ;; bracket - a compiler's [1 of 2] progress line, say -
+            ;; is not an object; skip just that line
+            (json-parse-error nil)))
         (forward-line)))
     (nreverse objects)))
 
@@ -15329,11 +15334,70 @@ See URL `https://github.com/commercialhaskell/stack'."
                 :message (or stack "Not found")
                 :face (if stack 'success '(bold error)))))))
 
+(defvar flycheck--ghc-json-support (make-hash-table :test 'equal)
+  "Whether a GHC binary supports JSON diagnostics, keyed by path.")
+
+(defun flycheck--ghc-json-flag ()
+  "Return GHC's JSON diagnostics flag when this buffer's GHC has it.
+
+Probed once per binary by evaluating a constant with the flag - GHC
+before 9.10 rejects it as unrecognised - through the checker's process
+machinery, so a remote buffer probes the remote host's compiler.  The
+answer is cached for the session: a compiler swapped in behind the
+same path, as ghcup set does, keeps its old answer until Emacs
+restarts."
+  (when-let* ((ghc (flycheck-find-checker-executable 'haskell-ghc)))
+    (let* ((key (cons (file-remote-p default-directory) ghc))
+           (cached (gethash key flycheck--ghc-json-support 'unknown)))
+      (when (eq cached 'unknown)
+        (setq cached
+              (eq 0 (ignore-errors
+                      (flycheck-call-checker-process
+                       'haskell-ghc nil nil nil
+                       "-fdiagnostics-as-json" "-e" "0"))))
+        (puthash key cached flycheck--ghc-json-support))
+      (when cached '("-fdiagnostics-as-json")))))
+
+(defun flycheck-parse-ghc (output checker buffer)
+  "Parse GHC diagnostics from OUTPUT, JSON lines or plain text.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and the
+BUFFER that was checked, respectively.  GHC 9.10's JSON diagnostics come
+one object per line between the plain-text progress lines; the numeric
+code becomes a GHC-NNNNN id, which the Haskell error index explains.  A
+diagnostic without a span - a driver error, say - lands on line one.
+Output of an older GHC without JSON falls through to the checker's
+patterns, which also ignore the progress lines."
+  (nconc
+   (mapcar
+    (lambda (diag)
+      (let-alist diag
+        (flycheck-error-new-at
+         (or .span.start.line 1) .span.start.column
+         (pcase .severity
+           ("Warning" 'warning)
+           (_ 'error))
+         (concat (string-join .message "\n")
+                 (mapconcat (lambda (hint)
+                              (format "\nSuggested fix: %s" hint))
+                            .hints ""))
+         :id (and .code (format "GHC-%d" .code))
+         :end-line .span.end.line
+         :end-column .span.end.column
+         :checker checker
+         :buffer buffer
+         :filename .span.file)))
+    (seq-filter (lambda (value) (alist-get 'ghcVersion value))
+                (flycheck-parse-json output)))
+   (flycheck-parse-with-patterns output checker buffer)))
+
 (flycheck-define-checker haskell-ghc
   "A Haskell syntax and type checker using ghc.
 
+Rich diagnostics with ids from the Haskell error index need GHC 9.10.
 See URL `https://www.haskell.org/ghc/'."
   :command ("ghc" "-Wall" "-no-link"
+            (eval (flycheck--ghc-json-flag))
             "-outputdir" (eval (file-local-name
                                 (flycheck-haskell-ghc-cache-directory)))
             (option-flag "-no-user-package-db"
@@ -15374,9 +15438,13 @@ See URL `https://www.haskell.org/ghc/'."
                                   (one-or-more " ")
                                   (one-or-more (not (any ?\n ?|)))))))
           line-end))
+  :error-parser flycheck-parse-ghc
   :error-filter
   (lambda (errors)
     (flycheck-sanitize-errors (flycheck-dedent-error-messages errors)))
+  :error-explainer
+  (flycheck-error-explainer-from-url
+   "https://errors.haskell.org/messages/%s/")
   :modes (haskell-mode haskell-literate-mode haskell-ts-mode)
   :next-checkers ((warning . haskell-hlint))
   :working-directory flycheck-haskell--ghc-find-default-directory)

--- a/test/fixtures/haskell-ghc/language/haskell/SyntaxError.hs.txt
+++ b/test/fixtures/haskell-ghc/language/haskell/SyntaxError.hs.txt
@@ -1,7 +1,2 @@
 [1 of 1] Compiling Main             ( SyntaxError.hs, Main.o )
-SyntaxError.hs:3:1: error: [GHC-58481]
-    parse error on input ‘module’
-  |
-3 | module Haskell.SyntaxError where
-  | ^^^^^^
-
+{"version":"1.1","ghcVersion":"ghc-9.14.1","span":{"file":"SyntaxError.hs","start":{"line":3,"column":1},"end":{"line":3,"column":7}},"severity":"Error","code":58481,"message":["parse error on input \u2018module\u2019"],"hints":[]}

--- a/test/specs/languages/test-haskell.el
+++ b/test/specs/languages/test-haskell.el
@@ -186,7 +186,82 @@ Perhaps:
     ;; not the tool is installed here
 
     (flycheck-buttercup-def-parse-test haskell-ghc "language/haskell/SyntaxError.hs"
-      '(3 1 error "parse error on input ‘module’" :id "GHC-58481"))))
+      ;; Recorded from a local GHC 9.14, which emits JSON diagnostics
+      '(3 1 error "parse error on input ‘module’"
+          :id "GHC-58481" :end-line 3 :end-column 7))))
+
+  (describe "reading ghc's output"
+    ;; GHC is not in the checker image; the JSON lines are captured
+    ;; from ghc 9.10.3, and the recording below comes from a local GHC
+
+    (it "reads JSON diagnostics with ids from the error index"
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'haskell-ghc
+          (concat
+           "[1 of 1] Compiling Haskell.Warnings ( Warnings.hs, nothing )\n"
+           "{\"version\":\"1.0\",\"ghcVersion\":\"ghc-9.10.3\","
+           "\"span\":{\"file\":\"Warnings.hs\","
+           "\"start\":{\"line\":4,\"column\":1},"
+           "\"end\":{\"line\":4,\"column\":5}},"
+           "\"severity\":\"Warning\",\"code\":38417,"
+           "\"message\":[\"Top-level binding with no type signature:\\n  spam :: [String] -> [[String]]\"],"
+           "\"hints\":[]}\n"))
+         :to-be-equal-flycheck-errors
+         (list (flycheck-error-new-at
+                4 1 'warning
+                "Top-level binding with no type signature:\n  spam :: [String] -> [[String]]"
+                :id "GHC-38417" :end-line 4 :end-column 5
+                :checker 'haskell-ghc :buffer (current-buffer)
+                :filename "Warnings.hs")))))
+
+    (it "keeps a hint as a suggested fix line and a parse error's id"
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'haskell-ghc
+          (concat
+           "{\"version\":\"1.0\",\"ghcVersion\":\"ghc-9.10.3\","
+           "\"span\":{\"file\":\"SyntaxError.hs\","
+           "\"start\":{\"line\":3,\"column\":1},"
+           "\"end\":{\"line\":3,\"column\":7}},"
+           "\"severity\":\"Error\",\"code\":58481,"
+           "\"message\":[\"parse error on input \`module'\"],"
+           "\"hints\":[\"Perhaps you intended to use TemplateHaskell\"]}\n"))
+         :to-be-equal-flycheck-errors
+         (list (flycheck-error-new-at
+                3 1 'error
+                "parse error on input \`module'\nSuggested fix: Perhaps you intended to use TemplateHaskell"
+                :id "GHC-58481" :end-line 3 :end-column 7
+                :checker 'haskell-ghc :buffer (current-buffer)
+                :filename "SyntaxError.hs")))))
+
+    (it "pins a diagnostic without a span to the first line"
+      (flycheck-buttercup-with-temp-buffer
+        (let ((errors (flycheck-buttercup-parse
+                       'haskell-ghc
+                       (concat
+                        "{\"version\":\"1.0\",\"ghcVersion\":\"ghc-9.10.3\","
+                        "\"span\":null,\"severity\":\"Error\",\"code\":39999,"
+                        "\"message\":[\"driver trouble\"],\"hints\":[]}\n"))))
+          (expect (flycheck-error-line (car errors)) :to-equal 1)
+          (expect (flycheck-error-message (car errors))
+                  :to-equal "driver trouble"))))
+
+    (it "still reads an old GHC's plain text through the patterns"
+      (flycheck-buttercup-with-temp-buffer
+        (expect
+         (flycheck-buttercup-parse
+          'haskell-ghc
+          "Warnings.hs:4:1: warning: [-Wmissing-signatures]\n    Top-level binding with no type signature:\n      spam :: [String] -> [[String]]\n")
+         :to-be-equal-flycheck-errors
+         (list (flycheck-error-new-at
+                4 1 'warning
+                "Top-level binding with no type signature:\n  spam :: [String] -> [[String]]"
+                :id "-Wmissing-signatures"
+                :checker 'haskell-ghc :buffer (current-buffer)
+                :filename "Warnings.hs"))))))
 
   (describe "reading hlint's output"
 

--- a/test/specs/test-error-parsers.el
+++ b/test/specs/test-error-parsers.el
@@ -26,6 +26,13 @@
 (require 'flycheck-buttercup)
 
 (describe "Error parsers"
+  (describe "flycheck-parse-json"
+    (it "skips a text line that merely starts with a bracket"
+      ;; GHC prints [1 of 2] progress lines; Bundler prints [DEPRECATED]
+      (expect (flycheck-parse-json
+               "[1 of 1] Compiling M ( M.hs, nothing )\n{\"a\": 1}\n")
+              :to-equal '(((a . 1))))))
+
   (describe "The SARIF parser"
     (it "parses results with locations and rule metadata"
       (let ((sarif "{\"version\":\"2.1.0\",\"runs\":[{\"tool\":{\"driver\":\


### PR DESCRIPTION
Batch two's closing slice: `haskell-ghc` reads `-fdiagnostics-as-json` (GHC 9.10+, probed per binary), gaining precise spans and GHC-NNNNN ids that `C-c ! e` explains via errors.haskell.org. Old GHC keeps the text patterns through the same hybrid fallthrough the other slices use.

The shared win: `flycheck-parse-json` no longer signals on text lines that merely start with a bracket - GHC's `[1 of 2] Compiling` lines hit exactly the hazard an earlier review flagged for Bundler's `[DEPRECATED]` noise, and every JSON checker is now immune, with a unit spec pinning it.