### PR TITLE
[#2360] Add project checkers, starting with terraform-validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### New Features
 
+- [#2360](https://github.com/flycheck/flycheck/pull/2360): New command `flycheck-check-project` (`C-c ! P`) runs project checkers - tools that check a whole project at once for the cross-file problems buffer checks cannot see - starting with `terraform-validate`; their diagnostics join the error list's project scope and the mode line's project counts.
 - [#2358](https://github.com/flycheck/flycheck/pull/2358): New `flycheck-navigation-scope` option: with `project`, `flycheck-next-error` continues into the project's other diagnostics when the buffer runs out of errors, opening the next file at its first error.
 - [#2346](https://github.com/flycheck/flycheck/pull/2346): New `flycheck-mode-line-scope` option to make the mode-line counter show the project-wide diagnostics instead of the current buffer's ([#2340](https://github.com/flycheck/flycheck/issues/2340)).
 - [#2344](https://github.com/flycheck/flycheck/pull/2344): New `flycheck-fix-edit-new-at-pos` constructor building a fix edit from buffer positions, as `flycheck-error-new-at-pos` does for errors ([#2343](https://github.com/flycheck/flycheck/issues/2343)).

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -180,6 +180,33 @@ You can also start a syntax check explicitly with `C-c ! c`:
 
    Check syntax in the current buffer.
 
+.. _flycheck-project-checks:
+
+Check whole projects
+====================
+
+Some problems live between files, where no single buffer's check can see
+them: a Terraform output referencing a variable no file declares, say.  A
+*project checker* runs its tool once over the whole project, on demand:
+
+.. define-key:: C-c ! P
+                M-x flycheck-check-project
+
+   Run every applicable project checker over the current project.  The
+   diagnostics show alongside the recorded buffer checks in the
+   :ref:`error list's <flycheck-error-list>` project scope and in the
+   mode line's project counts (see `flycheck-mode-line-scope`).
+
+   The results reflect the project as of the run and stay until the next
+   run there; with a prefix argument the results are dropped instead.
+
+Project checkers never run automatically and take no part in buffer
+checks.  The first one is ``terraform-validate``, which validates the
+root module of a Terraform project with ``terraform validate``; a
+configuration using providers or modules needs ``terraform init`` run in
+the project first.  New ones can be defined with
+``flycheck-define-project-checker``.
+
 
 LSP diagnostics via Eglot
 =========================

--- a/flycheck.el
+++ b/flycheck.el
@@ -1325,6 +1325,7 @@ Eglot renders the same LSP tag."
     (define-key map "c"         #'flycheck-buffer)
     (define-key map "C"         #'flycheck-clear)
     (define-key map (kbd "C-c") #'flycheck-compile)
+    (define-key map "P"         #'flycheck-check-project)
     (define-key map "n"         #'flycheck-next-error)
     (define-key map "p"         #'flycheck-previous-error)
     (define-key map "l"         #'flycheck-list-errors)
@@ -1537,6 +1538,7 @@ Only has effect when variable `global-flycheck-mode' is non-nil."
                   (seq-find #'flycheck-checker-supports-major-mode-p
                             flycheck-checkers))]
      ["Check current buffer" flycheck-buffer flycheck-mode]
+     ["Check whole project" flycheck-check-project t]
      ["Clear errors in buffer" flycheck-clear t]
      ["Run checker as compile command" flycheck-compile flycheck-mode]
      "---"
@@ -5337,7 +5339,8 @@ Each function is called with the project key (see
 contributed to the project, and returns a list of `flycheck-error'
 objects for files of that project that no buffer's check reported --
 e.g. the diagnostics an LSP server pushed about files that are not
-visited.  The LSP bridges register here.  The results pass the same
+visited, or what a project checker's run found.  The LSP bridges and
+the project-checker runs register here.  The results pass the same
 filter as recorded errors (see `flycheck--project-storable-errors') and
 deduplicate against the buffers' contributions; each error should carry
 a file name, or identical diagnostics from different contributors
@@ -5414,6 +5417,229 @@ the file changed without running a check."
             (nconc (nreverse result)
                    (flycheck--project-extra-errors project-key buffers owner))))
     result))
+
+(defvar flycheck--project-checkers nil
+  "Alist of the defined project checkers, in definition order.
+Each entry maps the checker symbol to its property plist; see
+`flycheck-define-project-checker'.")
+
+(defun flycheck-define-project-checker (symbol docstring &rest properties)
+  "Define SYMBOL as a project checker with DOCSTRING and PROPERTIES.
+
+A project checker runs a tool once over a whole project, on demand
+via `flycheck-check-project', and its diagnostics join the
+project-wide error store behind the error list's project scope and
+the mode line's project counts.  It is not a syntax checker: it
+never runs automatically and takes no part in buffer checks.
+
+The following PROPERTIES constitute a project checker:
+
+`:command (EXECUTABLE ARG ...)'
+     The command to run in the project's root directory, as a list
+     of strings.
+
+`:parser FUNCTION'
+     A function called with the command's output as a string, the
+     checker symbol and the project directory, returning the
+     diagnostics as a list of `flycheck-error' objects whose file
+     names are absolute.  An error the function signals becomes the
+     run's failure message, so a parser that recognizes the tool
+     saying \"this project needs setting up\" can say so.
+
+`:enabled FUNCTION'
+     A function called with the project directory, returning
+     non-nil when the checker applies to that project - say, when
+     files the tool reads are there.
+
+Defining a checker with the SYMBOL of an existing one replaces it."
+  (declare (indent 1) (doc-string 2))
+  (dolist (prop '(:command :parser :enabled))
+    (unless (plist-get properties prop)
+      (error "Project checker %s misses %s" symbol prop)))
+  (if-let* ((cell (assq symbol flycheck--project-checkers)))
+      (setcdr cell (plist-put (copy-sequence properties)
+                              :docstring docstring))
+    (setq flycheck--project-checkers
+          (append flycheck--project-checkers
+                  (list (cons symbol
+                              (plist-put (copy-sequence properties)
+                                         :docstring docstring))))))
+  symbol)
+
+(defvar flycheck--project-runs (make-hash-table :test 'equal)
+  "State of the project-checker runs, keyed by (PROJECT-KEY . CHECKER).
+Each value is a plist of `:process', the run still under way if any,
+and `:errors', what the last completed run reported.  The errors
+reflect the project as of that run; they stay until the next
+`flycheck-check-project' there replaces or clears them.")
+
+(defun flycheck--project-run-extra-errors (project-key _buffers)
+  "Return what project-checker runs reported for PROJECT-KEY."
+  (let (result)
+    (maphash (lambda (key state)
+               (when (equal (car key) project-key)
+                 (setq result (append (plist-get state :errors) result))))
+             flycheck--project-runs)
+    result))
+
+(add-hook 'flycheck--project-extra-errors-functions
+          #'flycheck--project-run-extra-errors)
+
+(defun flycheck--project-runs-forget (project-key)
+  "Drop the run results and kill the running checks of PROJECT-KEY."
+  (let (stale)
+    (maphash (lambda (key state)
+               (when (equal (car key) project-key)
+                 (when-let* ((proc (plist-get state :process)))
+                   (when (process-live-p proc)
+                     (delete-process proc)))
+                 (push key stale)))
+             flycheck--project-runs)
+    (dolist (key stale)
+      (remhash key flycheck--project-runs))))
+
+(defun flycheck--project-run-finish (proc)
+  "Collect what the finished project-checker process PROC produced."
+  (let ((status (process-status proc))
+        (stdout (process-buffer proc))
+        (stderr (process-get proc 'flycheck-stderr)))
+    (when (memq status '(exit signal))
+      (let* ((root (process-get proc 'flycheck-project-root))
+             (checker (process-get proc 'flycheck-project-checker))
+             (key (cons root checker))
+             (state (gethash key flycheck--project-runs)))
+        ;; A killed process was replaced or cleared; only the current
+        ;; one's normal exit reports
+        (when (and (eq status 'exit)
+                   (eq proc (plist-get state :process)))
+          (let* ((output (if (buffer-live-p stdout)
+                             (with-current-buffer stdout (buffer-string))
+                           ""))
+                 (failure nil)
+                 (errors (condition-case err
+                             (funcall (process-get proc 'flycheck-parser)
+                                      output checker root)
+                           (error (setq failure (error-message-string err))
+                                  nil))))
+            (puthash key (list :process nil :errors errors)
+                     flycheck--project-runs)
+            (flycheck--project-diagnostics-changed)
+            (flycheck-error-list-refresh)
+            (cond
+             (failure (message "%s: %s" checker failure))
+             (errors (message "%s reported %d project diagnostic%s"
+                              checker (length errors)
+                              (if (= (length errors) 1) "" "s")))
+             ((zerop (process-exit-status proc))
+              (message "%s found nothing to report" checker))
+             (t (message "%s failed%s" checker
+                         (let ((hint (and (buffer-live-p stderr)
+                                          (car (split-string
+                                                (with-current-buffer stderr
+                                                  (buffer-string))
+                                                "\n" t)))))
+                           (if hint (concat ": " hint) ""))))))))
+      (when-let* ((pipe (and (buffer-live-p stderr)
+                             (get-buffer-process stderr))))
+        (delete-process pipe))
+      (when (buffer-live-p stdout) (kill-buffer stdout))
+      (when (buffer-live-p stderr) (kill-buffer stderr)))))
+
+(defun flycheck--project-run (root checker props)
+  "Start the project checker CHECKER with PROPS over the project at ROOT."
+  (let* ((key (cons root checker))
+         (state (gethash key flycheck--project-runs)))
+    ;; A fresher run replaces one still under way
+    (when-let* ((proc (plist-get state :process)))
+      (when (process-live-p proc)
+        (delete-process proc)))
+    (let* ((default-directory root)
+           (stdout (generate-new-buffer
+                    (format " *flycheck-project-%s*" checker)))
+           (stderr (generate-new-buffer
+                    (format " *flycheck-project-%s-stderr*" checker)))
+           (proc (condition-case err
+                     (make-process
+                      :name (format "flycheck-project-%s" checker)
+                      :buffer stdout
+                      :stderr stderr
+                      :command (plist-get props :command)
+                      :noquery t
+                      :sentinel (lambda (proc _event)
+                                  (flycheck--project-run-finish proc)))
+                   ;; A tool gone missing between the executable check
+                   ;; and here must not silence the other checkers
+                   (error
+                    (kill-buffer stdout)
+                    (kill-buffer stderr)
+                    (message "%s could not start: %s" checker
+                             (error-message-string err))
+                    nil))))
+      (when proc
+        ;; The hidden pipe process feeding the stderr buffer would
+        ;; write a "finished" line of its own into it, polluting the
+        ;; failure hint the buffer is kept for
+        (when-let* ((pipe (get-buffer-process stderr)))
+          (set-process-sentinel pipe #'ignore))
+        (process-put proc 'flycheck-project-root root)
+        (process-put proc 'flycheck-project-checker checker)
+        (process-put proc 'flycheck-parser (plist-get props :parser))
+        (process-put proc 'flycheck-stderr stderr)
+        (puthash key (list :process proc
+                           :errors (plist-get
+                                    (gethash key flycheck--project-runs)
+                                    :errors))
+                 flycheck--project-runs)))))
+
+(defun flycheck-check-project (&optional clear)
+  "Check the whole project with every applicable project checker.
+
+A project checker runs its tool once over the project - see
+`flycheck-define-project-checker' - for the problems no single
+buffer's check can see, and its diagnostics show alongside the
+recorded buffer checks in the error list's project scope (see
+`flycheck-error-list-scope') and the mode line's project counts.
+
+The results reflect the project as of the run and stay until the
+next run here; with prefix argument CLEAR, drop them instead of
+checking again."
+  (interactive "P")
+  (let ((root (or (flycheck--buffer-project-key)
+                  (user-error "Cannot tell which project this buffer is in"))))
+    (when (file-remote-p root)
+      (user-error "Project checks do not support remote projects yet"))
+    (if clear
+        (progn
+          (flycheck--project-runs-forget root)
+          (flycheck--project-diagnostics-changed)
+          (flycheck-error-list-refresh)
+          (message "Project check results dropped"))
+      (let* ((applicable
+              (seq-filter (lambda (entry)
+                            (funcall (plist-get (cdr entry) :enabled) root))
+                          flycheck--project-checkers))
+             (runnable
+              (seq-filter (lambda (entry)
+                            (executable-find
+                             (car (plist-get (cdr entry) :command))))
+                          applicable)))
+        (cond
+         ((null applicable)
+          (user-error "No project checker applies to %s"
+                      (abbreviate-file-name root)))
+         ((null runnable)
+          (user-error "No %s executable to check this project with"
+                      (mapconcat
+                       (lambda (entry)
+                         (car (plist-get (cdr entry) :command)))
+                       applicable " or ")))
+         (t
+          (dolist (entry runnable)
+            (flycheck--project-run root (car entry) (cdr entry)))
+          (message "Checking project %s with %s..."
+                   (abbreviate-file-name root)
+                   (mapconcat (lambda (entry) (symbol-name (car entry)))
+                              runnable ", "))))))))
 
 (defun flycheck-fill-and-expand-error-file-names (errors directory)
   "Fill and expand file names in ERRORS relative to DIRECTORY.
@@ -19587,6 +19813,57 @@ See URL `https://github.com/terraform-linters/tflint'."
   (flycheck-error-explainer-from-url
    "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/%s.md"
    (lambda (id) (and (string-prefix-p "terraform_" id) id))))
+
+(defun flycheck-parse-terraform-validate (output _checker directory)
+  "Parse `terraform validate -json' OUTPUT for the project at DIRECTORY.
+
+Terraform's one-based columns and right-open end columns are used as
+they are.  A diagnostic about the configuration as a whole carries no
+source location to jump to, so when only those turn up - an
+uninitialized project, mostly - the first one becomes the run's
+failure message instead.
+
+See URL `https://developer.hashicorp.com/terraform/cli/commands/validate'."
+  (let-alist (car (flycheck-parse-json output))
+    (let ((ranged (seq-filter (lambda (diag)
+                                (let-alist diag
+                                  (and .range .range.filename)))
+                              .diagnostics)))
+      (when (and .diagnostics (null ranged))
+        (let-alist (car .diagnostics)
+          (error "%s" .summary)))
+      (mapcar
+       (lambda (diag)
+         (let-alist diag
+           (flycheck-error-new-at
+            .range.start.line .range.start.column
+            (pcase .severity
+              ("warning" 'warning)
+              (_ 'error))
+            (if (and .detail (not (string-empty-p .detail)))
+                (concat .summary ": " .detail)
+              .summary)
+            :end-line .range.end.line
+            :end-column .range.end.column
+            :checker 'terraform-validate
+            :filename (expand-file-name .range.filename directory)
+            :buffer nil)))
+       ranged))))
+
+(flycheck-define-project-checker 'terraform-validate
+  "A Terraform project checker using `terraform validate'.
+
+Validates the root module in the project directory as a whole,
+catching the cross-file problems a single buffer's check cannot
+see, like references to undeclared variables.  A configuration
+using providers or modules needs `terraform init' run in the
+project first.
+
+See URL `https://developer.hashicorp.com/terraform/cli/commands/validate'."
+  :command '("terraform" "validate" "-json")
+  :parser #'flycheck-parse-terraform-validate
+  :enabled (lambda (directory)
+             (directory-files directory nil "\\.tf\\'" t 1)))
 
 (flycheck-def-option-var flycheck-chktex-extra-flags nil tex-chktex
   "A list of extra arguments to give to chktex.

--- a/test/fixtures/terraform-validate/language/terraform/validate.txt
+++ b/test/fixtures/terraform-validate/language/terraform/validate.txt
@@ -1,0 +1,60 @@
+{
+  "format_version": "1.0",
+  "valid": false,
+  "error_count": 2,
+  "warning_count": 0,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "summary": "Reference to undeclared local value",
+      "detail": "A local value with the name \"missing\" has not been declared.",
+      "range": {
+        "filename": "outputs.tf",
+        "start": {
+          "line": 2,
+          "column": 11,
+          "byte": 27
+        },
+        "end": {
+          "line": 2,
+          "column": 24,
+          "byte": 40
+        }
+      },
+      "snippet": {
+        "context": "output \"total\"",
+        "code": "  value = local.missing",
+        "start_line": 2,
+        "highlight_start_offset": 10,
+        "highlight_end_offset": 23,
+        "values": []
+      }
+    },
+    {
+      "severity": "error",
+      "summary": "Reference to undeclared input variable",
+      "detail": "An input variable with the name \"count\" has not been declared. This variable can be declared with a variable \"count\" {} block.",
+      "range": {
+        "filename": "outputs.tf",
+        "start": {
+          "line": 6,
+          "column": 11,
+          "byte": 75
+        },
+        "end": {
+          "line": 6,
+          "column": 20,
+          "byte": 84
+        }
+      },
+      "snippet": {
+        "context": "output \"instances\"",
+        "code": "  value = var.count",
+        "start_line": 6,
+        "highlight_start_offset": 10,
+        "highlight_end_offset": 19,
+        "values": []
+      }
+    }
+  ]
+}

--- a/test/record-fixture.el
+++ b/test/record-fixture.el
@@ -115,14 +115,26 @@ the tool was run."
   (when-let* ((config (flycheck-record-fixture-quirk checker :config)))
     `((flycheck-stylelint-config . ,(flycheck-record-fixture--resource config)))))
 
+(defun flycheck-record-fixture--run-project (_checker props directory)
+  "Run the project checker with PROPS in its resource DIRECTORY."
+  (let ((command (plist-get props :command))
+        (default-directory (file-name-as-directory directory)))
+    (with-temp-buffer
+      (let ((status (apply #'call-process (car command) nil t nil
+                           (cdr command))))
+        (list command status (buffer-string))))))
+
 (defun flycheck-record-fixture--run (checker file)
   "Run CHECKER's command over FILE and return (COMMAND EXIT-STATUS OUTPUT).
 
 The command is the one Flycheck would run, so a fixture recorded
 here matches what the checker actually invokes.  A checker that
 reads standard input gets the file's contents there, like it would
-during a real check."
-  (with-current-buffer (find-file-noselect file)
+during a real check.  A project checker runs in FILE, its resource
+directory, instead of over it."
+  (if-let* ((props (flycheck-fixture--project-checker checker)))
+      (flycheck-record-fixture--run-project checker props file)
+    (with-current-buffer (find-file-noselect file)
     (let* ((settings (flycheck-record-fixture-settings checker))
            (_ (dolist (setting settings)
                 (set (make-local-variable (car setting)) (cdr setting))))
@@ -149,7 +161,7 @@ during a real check."
         ;; Substituting the arguments can leave a copy of the file beside
         ;; the original, which a real check would have cleaned up and
         ;; which the next tool to look at that directory would see
-        (flycheck-safe-delete-temporaries)))))
+        (flycheck-safe-delete-temporaries))))))
 
 (defconst flycheck-record-fixture--volatile
   '(;; The copy Flycheck checks, and the caches some checkers ask for,
@@ -217,17 +229,29 @@ Return the file the fixture was written to."
 
 (defun flycheck-record-fixture-tool-available-p (checker)
   "Whether CHECKER's tool can actually run here."
-  (when-let* ((program (flycheck-find-checker-executable checker)))
+  (if-let* ((props (flycheck-fixture--project-checker checker)))
+      (executable-find (car (plist-get props :command)))
+    (when-let* ((program (flycheck-find-checker-executable checker)))
     (if-let* ((module (flycheck-record-fixture-quirk checker :module)))
         (eq 0 (call-process program nil nil nil "-c" (format "import %s" module)))
-      t)))
+      t))))
+
+(defun flycheck-fixture--project-checker (checker)
+  "The property plist of the project checker CHECKER, or nil.
+Project checkers (see `flycheck-define-project-checker') record and
+verify through the same machinery as command checkers, with their
+command run in the resource directory and their output read by
+their parser."
+  (alist-get checker (bound-and-true-p flycheck--project-checkers)))
 
 (defun flycheck-fixture--checker-of (directory)
   "The checker whose recordings live in DIRECTORY, or nil."
   (let ((name (intern (replace-regexp-in-string
                        "_" "/" (file-name-nondirectory
                                 (directory-file-name directory))))))
-    (and (flycheck-valid-checker-p name) name)))
+    (and (or (flycheck-valid-checker-p name)
+             (flycheck-fixture--project-checker name))
+         name)))
 
 (defun flycheck-fixture--reads (checker output)
   "How many errors CHECKER reads out of OUTPUT.
@@ -237,9 +261,13 @@ output no better than one that finds nothing in it.  Cargo printing
 that it has no library target rather than the JSON the checker
 expects gets here."
   (condition-case nil
-      (length (flycheck-filter-errors
-               (flycheck-parse-output output checker (current-buffer))
-               checker))
+      (length
+       (if-let* ((props (flycheck-fixture--project-checker checker)))
+           (funcall (plist-get props :parser) output checker
+                    default-directory)
+         (flycheck-filter-errors
+          (flycheck-parse-output output checker (current-buffer))
+          checker)))
     (error 0)))
 
 (defvar flycheck-verify-fixtures--checked 0

--- a/test/resources/language/terraform/validate/main.tf
+++ b/test/resources/language/terraform/validate/main.tf
@@ -1,0 +1,7 @@
+variable "region" {
+  type = string
+}
+
+locals {
+  region = "${var.region}"
+}

--- a/test/resources/language/terraform/validate/outputs.tf
+++ b/test/resources/language/terraform/validate/outputs.tf
@@ -1,0 +1,7 @@
+output "total" {
+  value = local.missing
+}
+
+output "instances" {
+  value = var.count
+}

--- a/test/specs/test-checker-specs.el
+++ b/test/specs/test-checker-specs.el
@@ -124,7 +124,8 @@ and recursion respectively."
                   (checker (intern (replace-regexp-in-string "_" "/" sub))))
               (when (and (file-directory-p dir)
                          (directory-files-recursively dir "\\.txt\\'")
-                         (not (flycheck-valid-checker-p checker)))
+                         (not (flycheck-valid-checker-p checker))
+                         (not (assq checker flycheck--project-checkers)))
                 (push sub orphans))))
           (expect (nreverse orphans) :to-equal nil)))))
 

--- a/test/specs/test-project-runs.el
+++ b/test/specs/test-project-runs.el
@@ -1,0 +1,216 @@
+;;; test-project-runs.el --- Flycheck Specs: Project checkers -*- lexical-binding: t; -*-
+;;; Code:
+(require 'flycheck-buttercup)
+(require 'test-helpers)
+
+(describe "Project checkers"
+
+  (defvar flycheck-test--project-checkers-outside nil)
+
+  (before-each
+    (spy-on 'project-current :and-return-value nil)
+    (clrhash flycheck--project-error-store)
+    (setq flycheck-test--project-checkers-outside flycheck--project-checkers))
+
+  (after-each
+    (maphash (lambda (_key state)
+               (when-let* ((proc (plist-get state :process)))
+                 (when (process-live-p proc)
+                   (delete-process proc))))
+             flycheck--project-runs)
+    (clrhash flycheck--project-runs)
+    (setq flycheck--project-checkers flycheck-test--project-checkers-outside))
+
+  (defmacro flycheck-test--with-temp-project (dir-var &rest body)
+    "Run BODY in a buffer inside a fresh project, DIR-VAR bound to its key."
+    (declare (indent 1))
+    `(let ((flycheck-test--project-tmp (make-temp-file "flycheck-prj" t)))
+       (unwind-protect
+           (with-temp-buffer
+             (setq default-directory (file-name-as-directory
+                                      flycheck-test--project-tmp))
+             (let ((,dir-var (flycheck--project-directory)))
+               ,@body))
+         ;; Kill any run still going before taking its directory away,
+         ;; and give Windows a moment to let go of just-deleted files
+         (maphash (lambda (_key state)
+                    (when-let* ((proc (plist-get state :process)))
+                      (when (process-live-p proc)
+                        (delete-process proc))))
+                  flycheck--project-runs)
+         (let ((attempts 10))
+           (while (and (> attempts 0)
+                       (not (ignore-errors
+                              (delete-directory flycheck-test--project-tmp t)
+                              t)))
+             (setq attempts (1- attempts))
+             (sleep-for 0.1))
+           (when (file-directory-p flycheck-test--project-tmp)
+             (delete-directory flycheck-test--project-tmp t))))))
+
+  (defun flycheck-test--emacs-command (form)
+    "A command list running FORM in a batch Emacs."
+    (list (expand-file-name invocation-name invocation-directory)
+          "-Q" "--batch" "--eval" (format "%S" form)))
+
+  (defun flycheck-test--define-run-checker (&rest override)
+    "Define a fake project checker, with OVERRIDE plist entries."
+    (apply #'flycheck-define-project-checker 'test-run "Fake."
+           (append override
+                   (list :command (flycheck-test--emacs-command
+                                   '(princ "gamma.rb:3:boom"))
+                         :parser #'flycheck-test--parse-run
+                         :enabled (lambda (_dir) t)))))
+
+  (defun flycheck-test--parse-run (output _checker directory)
+    "Parse OUTPUT lines of FILE:LINE:MESSAGE under DIRECTORY."
+    (delq nil
+          (mapcar (lambda (line)
+                    (when (string-match "\\`\\(.+\\):\\([0-9]+\\):\\(.+\\)\\'"
+                                        line)
+                      (flycheck-error-new-at
+                       (string-to-number (match-string 2 line)) 1
+                       'error (match-string 3 line)
+                       :checker 'test-run
+                       :filename (expand-file-name (match-string 1 line)
+                                                   directory)
+                       :buffer nil)))
+                  (split-string output "\n" t))))
+
+  (defun flycheck-test--wait-for-run (key)
+    "Wait until the run recorded under KEY has finished."
+    (let ((tries 200))
+      (while (and (> tries 0)
+                  (plist-get (gethash key flycheck--project-runs) :process))
+        (accept-process-output nil 0.1)
+        (setq tries (1- tries)))))
+
+  (describe "flycheck-define-project-checker"
+
+    (it "replaces a checker defined again"
+      (flycheck-test--define-run-checker)
+      (flycheck-test--define-run-checker :enabled #'ignore)
+      (let ((entries (seq-filter (lambda (entry) (eq (car entry) 'test-run))
+                                 flycheck--project-checkers)))
+        (expect (length entries) :to-equal 1)
+        (expect (plist-get (cdr (car entries)) :enabled) :to-be #'ignore)))
+
+    (it "rejects a definition without a parser"
+      (expect (flycheck-define-project-checker 'test-broken "Fake."
+                :command '("true") :enabled #'ignore)
+              :to-throw 'error)))
+
+  (describe "flycheck-check-project"
+
+    (it "feeds the run's diagnostics into the project scope"
+      (flycheck-test--define-run-checker)
+      (flycheck-test--with-temp-project dir
+        (flycheck-check-project)
+        (flycheck-test--wait-for-run (cons dir 'test-run))
+        (let ((errors (flycheck--project-errors dir)))
+          (expect (length errors) :to-equal 1)
+          (expect (flycheck-error-filename (car errors))
+                  :to-equal (expand-file-name "gamma.rb" dir))
+          (expect (flycheck-error-line (car errors)) :to-equal 3)
+          (expect (flycheck-error-message (car errors)) :to-equal "boom"))))
+
+    (it "replaces the previous run's results"
+      (flycheck-test--define-run-checker)
+      (flycheck-test--with-temp-project dir
+        (let ((key (cons dir 'test-run)))
+          (puthash key (list :process nil
+                             :errors (list (flycheck-error-new-at
+                                            1 1 'error "stale"
+                                            :checker 'test-run
+                                            :filename (expand-file-name
+                                                       "old.rb" dir))))
+                   flycheck--project-runs)
+          (flycheck-check-project)
+          (flycheck-test--wait-for-run key)
+          (let ((errors (flycheck--project-errors dir)))
+            (expect (length errors) :to-equal 1)
+            (expect (flycheck-error-message (car errors)) :to-equal "boom")))))
+
+    (it "drops the results with the prefix argument"
+      (flycheck-test--define-run-checker)
+      (flycheck-test--with-temp-project dir
+        (puthash (cons dir 'test-run)
+                 (list :process nil
+                       :errors (list (flycheck-error-new-at
+                                      1 1 'error "stale"
+                                      :checker 'test-run
+                                      :filename (expand-file-name "old.rb"
+                                                                  dir))))
+                 flycheck--project-runs)
+        (let ((generation flycheck--project-diagnostics-generation))
+          (flycheck-check-project 'clear)
+          (expect (flycheck--project-errors dir) :to-be nil)
+          (expect flycheck--project-diagnostics-generation
+                  :to-be-greater-than generation))))
+
+    (it "surfaces a parser's error as the run's failure"
+      (flycheck-test--define-run-checker
+       :parser (lambda (_output _checker _dir)
+                 (error "This project needs setting up")))
+      (flycheck-test--with-temp-project dir
+        (let ((key (cons dir 'test-run)))
+          (flycheck-check-project)
+          (flycheck-test--wait-for-run key)
+          (expect (flycheck--project-errors dir) :to-be nil)
+          (expect (plist-get (gethash key flycheck--project-runs) :errors)
+                  :to-be nil))))
+
+    (it "says so when no checker applies"
+      (flycheck-test--define-run-checker :enabled #'ignore)
+      (flycheck-test--with-temp-project _dir
+        (should-error (flycheck-check-project) :type 'user-error)))
+
+    (it "says so when the tool is not installed"
+      (flycheck-test--define-run-checker
+       :command '("flycheck-no-such-tool-anywhere"))
+      (flycheck-test--with-temp-project _dir
+        (should-error (flycheck-check-project) :type 'user-error))))
+
+  (describe "terraform-validate"
+
+    (it "applies to a directory with Terraform files"
+      (let ((enabled (plist-get (alist-get 'terraform-validate
+                                           flycheck--project-checkers)
+                                :enabled)))
+        (flycheck-test--with-temp-project dir
+          (expect (funcall enabled dir) :to-be nil)
+          (write-region "" nil (expand-file-name "main.tf" dir))
+          (expect (funcall enabled dir) :to-be-truthy))))
+
+    (it "reads the recorded validate output"
+      (let* ((fixture (expand-file-name
+                       "../fixtures/terraform-validate/language/terraform/validate.txt"
+                       flycheck-test-resources-directory))
+             (output (with-temp-buffer
+                       (insert-file-contents fixture)
+                       (buffer-string)))
+             (errors (flycheck-parse-terraform-validate
+                      output 'terraform-validate
+                      (expand-file-name "/prj/"))))
+        (expect (mapcar #'flycheck-error-line errors) :to-equal '(2 6))
+        (expect (flycheck-error-filename (car errors))
+                :to-equal (expand-file-name "/prj/outputs.tf"))
+        (expect (flycheck-error-column (car errors)) :to-equal 11)
+        (expect (flycheck-error-end-column (car errors)) :to-equal 24)
+        (expect (flycheck-error-level (car errors)) :to-equal 'error)
+        (expect (flycheck-error-message (car errors))
+                :to-equal (concat "Reference to undeclared local value: "
+                                  "A local value with the name \"missing\" "
+                                  "has not been declared."))))
+
+    (it "turns a location-less diagnostic into the run's failure"
+      (expect
+       (flycheck-parse-terraform-validate
+        (concat "{\"valid\": false, \"diagnostics\": "
+                "[{\"severity\": \"error\","
+                " \"summary\": \"Missing required provider\","
+                " \"detail\": \"Run terraform init.\"}]}")
+        'terraform-validate "/prj/")
+       :to-throw 'error))))
+
+;;; test-project-runs.el ends here


### PR DESCRIPTION
Some problems live between files where no buffer's check can see them, like a Terraform output referencing a variable no file declares. `M-x flycheck-check-project` (`C-c ! P`) now runs *project checkers* - tools that check the whole project at once, asynchronously - and their diagnostics land in the error list's project scope and the mode line's project counts, next to what buffer checks recorded.

The first one is `terraform-validate`: `terraform validate -json` over the root module, with exact spans for its cross-file findings. A location-less diagnostic (an uninitialized project, mostly) becomes the run's failure message rather than disappearing. The recording harness treats project-checker fixtures like command-checker ones, so the terraform recording gets the same weekly drift check.

Verified live against real terraform in the checker image: both cross-file errors arrive with exact spans through the full async pipeline.