### PR TITLE
[Fix #2359] Continue checker chains through unusable links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bugs fixed
 
+- [#2361](https://github.com/flycheck/flycheck/pull/2361): A checker chain continues through a disabled or unavailable link to the checkers behind it, so disabling one checker no longer silences the rest of its chain ([#2359](https://github.com/flycheck/flycheck/issues/2359)).
 - [#2350](https://github.com/flycheck/flycheck/pull/2350): The Eglot bridge composes diagnostic messages from Emacs 32's split Flymake fields itself, so they read identically across Emacs versions instead of picking up stray separators.
 - [#2349](https://github.com/flycheck/flycheck/pull/2349): The `rst-sphinx` checker reads the warning-type tags Sphinx 8 appends (e.g. `[ref.envvar]`) as error identifiers instead of leaving them in the message.
 - [#2348](https://github.com/flycheck/flycheck/pull/2348): Range queries against the diagnostics of a `flycheck-eglot-mode` buffer now keep `overlays-in`'s strict edges, so a diagnostic merely touching a boundary is no longer served.

--- a/doc/user/syntax-checkers.rst
+++ b/doc/user/syntax-checkers.rst
@@ -411,8 +411,9 @@ up looking at is every checker's findings in one list, not just the last one's.
 A chain stops as soon as a checker has no next checker left to run.  At each
 step Flycheck takes the first entry of ``:next-checkers`` that fits: its error
 level has to match (see below) and the checker has to be usable in this buffer.
-An entry that doesn't fit is skipped rather than ending the chain, so a chain
-can name a checker that is only sometimes available and still reach the ones
+An entry that doesn't fit is skipped rather than ending the chain, and the
+checkers behind an unusable one are considered in its place: a chain can name
+a checker that is disabled here or not installed and still reach the ones
 behind it.
 
 Some checker chains are already set up by default in Flycheck: e.g.,

--- a/flycheck.el
+++ b/flycheck.el
@@ -2659,16 +2659,21 @@ nil otherwise."
          (flycheck-may-enable-checker checker)
          (or (null predicate) (funcall predicate)))))
 
+(defun flycheck--next-checker-level-passes-p (next-checker)
+  "Whether NEXT-CHECKER's error-level condition holds right now.
+
+NEXT-CHECKER is a cons (LEVEL . CHECKER) or a plain checker
+symbol, which continues unconditionally."
+  (let ((level (if (consp next-checker) (car next-checker) t)))
+    (or (eq level t)
+        (flycheck-has-max-current-errors-p level))))
+
 (defun flycheck-may-use-next-checker (next-checker)
   "Determine whether NEXT-CHECKER may be used."
-  (when (symbolp next-checker)
-    (push t next-checker))
-  (let ((level (car next-checker))
-        (next-checker (cdr next-checker)))
-    (and (or (eq level t)
-             (flycheck-has-max-current-errors-p level))
-         (flycheck-registered-checker-p next-checker)
-         (flycheck-may-use-checker next-checker))))
+  (let ((checker (flycheck--get-next-checker-symbol next-checker)))
+    (and (flycheck--next-checker-level-passes-p next-checker)
+         (flycheck-registered-checker-p checker)
+         (flycheck-may-use-checker checker))))
 
 
 ;;; Help for generic syntax checkers
@@ -3523,11 +3528,30 @@ nil otherwise."
     (seq-find #'flycheck-may-use-checker flycheck-checkers)))
 
 (defun flycheck-get-next-checker-for-buffer (checker)
-  "Get the checker to run after CHECKER for the current buffer."
-  (let ((next (seq-find #'flycheck-may-use-next-checker
-                        (flycheck-checker-get checker 'next-checkers))))
-    (when next
-      (if (symbolp next) next (cdr next)))))
+  "Get the checker to run after CHECKER for the current buffer.
+
+A next checker that cannot run here - disabled with
+`flycheck-disable-checker', not installed - does not cut the chain
+short: the checkers following it are considered in its place, so
+disabling one link keeps the rest of the chain reachable.  The
+unusable checker's error-level condition still gates the descent,
+since a chain that would not continue through it usable does not
+continue through it unusable either."
+  (let ((visited (list checker))
+        (queue (flycheck-checker-get checker 'next-checkers))
+        (found nil))
+    (while (and queue (not found))
+      (let* ((entry (pop queue))
+             (next (flycheck--get-next-checker-symbol entry)))
+        (when (and (not (memq next visited))
+                   (flycheck--next-checker-level-passes-p entry))
+          (push next visited)
+          (if (and (flycheck-registered-checker-p next)
+                   (flycheck-may-use-checker next))
+              (setq found next)
+            (setq queue (append (flycheck-checker-get next 'next-checkers)
+                                queue))))))
+    found))
 
 (defun flycheck-select-checker (checker)
   "Select CHECKER for the current buffer.
@@ -11833,8 +11857,10 @@ lint server both contribute, and then to the first command checker that
 supports the mode, so a command checker contributes too.
 
 Chaining to a bridge is safe whether or not that bridge is on in a given
-buffer: its predicate refuses the buffer, and Flycheck moves on to the
-next entry.  That matters because `next-checkers' is a property of the
+buffer: its predicate refuses the buffer, and Flycheck continues through
+it to the checkers behind it (see
+`flycheck-get-next-checker-for-buffer'), where a mode-matching entry is
+found.  That matters because `next-checkers' is a property of the
 checker, shared by every buffer, while the modes are buffer-local.
 
 Shared by the `flycheck-lsp' and `eglot-check' bridges."

--- a/test/specs/test-checker-api.el
+++ b/test/specs/test-checker-api.el
@@ -302,6 +302,94 @@
           (expect (flycheck-may-use-checker 'emacs-lisp) :to-be-truthy)
           (expect was-called :to-be-truthy)))))
 
+  (describe "flycheck-get-next-checker-for-buffer"
+
+    (before-each
+      (dolist (pair '((test-chain-a . ((warning . test-chain-b)))
+                      (test-chain-b . (test-chain-c))
+                      (test-chain-c . nil)))
+        (flycheck-define-generic-checker (car pair)
+          "A fake chain link."
+          :start (lambda (_checker callback) (funcall callback 'finished nil))
+          :modes '(text-mode)
+          :next-checkers (cdr pair))
+        (cl-pushnew (car pair) flycheck-checkers)))
+
+    (after-each
+      (dolist (checker '(test-chain-a test-chain-b test-chain-c test-chain-d))
+        (setq flycheck-checkers (delq checker flycheck-checkers))
+        ;; Undefine the fake outright, or the customization spec finds
+        ;; a defined checker that is not registered
+        (put checker 'flycheck-generic-checker-version nil)))
+
+    (it "picks the first usable next checker"
+      (with-temp-buffer
+        (text-mode)
+        (expect (flycheck-get-next-checker-for-buffer 'test-chain-a)
+                :to-be 'test-chain-b)))
+
+    (it "continues through a disabled link to the rest of the chain"
+      (with-temp-buffer
+        (text-mode)
+        (let ((flycheck-disabled-checkers '(test-chain-b)))
+          (expect (flycheck-get-next-checker-for-buffer 'test-chain-a)
+                  :to-be 'test-chain-c))))
+
+    (it "does not continue when the whole tail is disabled"
+      (with-temp-buffer
+        (text-mode)
+        (let ((flycheck-disabled-checkers '(test-chain-b test-chain-c)))
+          (expect (flycheck-get-next-checker-for-buffer 'test-chain-a)
+                  :to-be nil))))
+
+    (it "keeps the disabled link's place in the order"
+      ;; The skipped checker's own next checkers substitute for it,
+      ;; ahead of whatever followed it
+      (flycheck-define-generic-checker 'test-chain-a
+        "A fake chain head with two next checkers."
+        :start (lambda (_checker callback) (funcall callback 'finished nil))
+        :modes '(text-mode)
+        :next-checkers '(test-chain-b test-chain-c))
+      (flycheck-define-generic-checker 'test-chain-d
+        "A fake chain tail."
+        :start (lambda (_checker callback) (funcall callback 'finished nil))
+        :modes '(text-mode))
+      (cl-pushnew 'test-chain-d flycheck-checkers)
+      (flycheck-define-generic-checker 'test-chain-b
+        "A fake middle link pointing at the tail."
+        :start (lambda (_checker callback) (funcall callback 'finished nil))
+        :modes '(text-mode)
+        :next-checkers '(test-chain-d))
+      (with-temp-buffer
+        (text-mode)
+        (let ((flycheck-disabled-checkers '(test-chain-b)))
+          (expect (flycheck-get-next-checker-for-buffer 'test-chain-a)
+                  :to-be 'test-chain-d))))
+
+    (it "still respects the level condition of the disabled link"
+      ;; test-chain-a continues to b only below error severity; a
+      ;; disabled b must not become MORE reachable than an enabled one
+      (with-temp-buffer
+        (text-mode)
+        (let ((flycheck-current-errors
+               (list (flycheck-error-new-at 1 1 'error "boom"
+                                            :checker 'test-chain-a)))
+              (flycheck-disabled-checkers '(test-chain-b)))
+          (expect (flycheck-get-next-checker-for-buffer 'test-chain-a)
+                  :to-be nil))))
+
+    (it "survives a cycle of unusable links"
+      (flycheck-define-generic-checker 'test-chain-b
+        "A fake middle link looping back."
+        :start (lambda (_checker callback) (funcall callback 'finished nil))
+        :modes '(text-mode)
+        :next-checkers '(test-chain-a))
+      (with-temp-buffer
+        (text-mode)
+        (let ((flycheck-disabled-checkers '(test-chain-a test-chain-b)))
+          (expect (flycheck-get-next-checker-for-buffer 'test-chain-a)
+                  :to-be nil)))))
+
   (describe "flycheck-may-enable-checker"
     (it "emacs-lisp"
       (flycheck-buttercup-with-resource-buffer "language/emacs-lisp/warnings.el"


### PR DESCRIPTION
Fixes #2359.

The next-checker walk only considered a chain's immediate entries, so a link that couldn't run - disabled, or its tool missing - cut off everything behind it: disabling `python-ruff` in a `flycheck-lsp` → ruff → mypy chain silenced mypy too, even though `flycheck-verify-setup` lists mypy as part of the chain. The walk now continues through an unusable link into its own next checkers, at the link's position in the order. The link's error-level condition still gates the descent, and a visited set keeps definition cycles finite.