### PR TITLE
[Fix #2367] Keep line numbers right under a below annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bugs fixed
 
+- [#2368](https://github.com/flycheck/flycheck/pull/2368): A `below`-style annotation no longer takes the following line's number under `display-line-numbers-mode`: the block now stands in for the annotated line's newline, which keeps the numbers right and visual-line motion stepping down over it; moving up onto a line annotated this way, which takes `flycheck-annotate-other-lines-style` set to `below`, now lands at its end rather than at the goal column ([#2367](https://github.com/flycheck/flycheck/issues/2367)).
 - [#2366](https://github.com/flycheck/flycheck/pull/2366): The `go-vet` checker vets the buffer's whole package as saved on disk instead of the single file, which `go vet` treats as a package of its own and fills with spurious undefined references to sibling files; outside a module it steps aside, saying why ([#2365](https://github.com/flycheck/flycheck/issues/2365)).
 - [#2361](https://github.com/flycheck/flycheck/pull/2361): A checker chain continues through a disabled or unavailable link to the checkers behind it, so disabling one checker no longer silences the rest of its chain ([#2359](https://github.com/flycheck/flycheck/issues/2359)).
 - [#2350](https://github.com/flycheck/flycheck/pull/2350): The Eglot bridge composes diagnostic messages from Emacs 32's split Flymake fields itself, so they read identically across Emacs versions instead of picking up stray separators.

--- a/flycheck.el
+++ b/flycheck.el
@@ -9021,33 +9021,49 @@ clamped to the line so a checker column past the end still lands on it."
   "Create a tracked overlay rendering BLOCK on its own lines below ANCHOR.
 
 BACKGROUND, when given, is a face put under the whole block so the tinted
-line and its messages read as one region.  The block hangs off the *next*
-line, outside the range the line tint covers, so it has to carry the tint
-itself rather than inherit it.
+line and its messages read as one region; the block carries the tint
+itself, newlines included, so it reaches the window edge.
 
-BLOCK is the annotation text without surrounding newlines.  It is hung off
-the beginning of the following line as a `before-string' ending in a
-newline, so its extra screen rows belong to that line's buffer position
-rather than to ANCHOR's line.  That keeps visual-line motion working:
-`next-line' (with the variable `line-move-visual') and
-`evil-next-visual-line' move point onto the next line of code, instead of
-stalling on the annotation or, under Evil, getting stuck before it.  On
-the last line of the buffer, where there is no following line, the block
-is hung off ANCHOR with a leading newline and a `cursor'-anchored space
-instead.  Return the overlay."
-  (let ((string (if (< anchor (point-max))
-                    (concat block "\n")
-                  (concat (propertize " " 'cursor t) "\n" block))))
+BLOCK is the annotation text without surrounding newlines.  The overlay
+spans ANCHOR's newline and replaces it, through a `display' string, with
+a newline, the block and a newline again.  That placement satisfies two
+parts of Emacs at once.  Line numbers (`display-line-numbers-mode') go
+by the buffer position a screen row starts at: the block's rows start
+at the newline, inside the annotated line, so they get no number and
+the line after keeps its own.  A block hung off the next line's start
+instead took that line's number (issue #2367).  Visual-line motion
+(`next-line' with the variable `line-move-visual', and
+`evil-next-visual-line') steps down over a display string as a unit,
+so point lands on the next line of code rather than stalling on the
+annotation, as it would with an `after-string' at the end of the line.
+Stepping up onto a line that has a block - only ever the case with
+`flycheck-annotate-other-lines-style' set to `below', since the
+focused line's block is rebuilt as point leaves it - lands at the end
+of that line rather than at the goal column, the one place the
+display string falls short of a plain buffer line.
+A `cursor'-anchored space leads the string so the cursor sits after the
+code when point is at ANCHOR.  On the last line of the buffer, where
+there is no newline to replace, the string hangs off ANCHOR as a
+`before-string' instead.  Return the overlay."
+  (let* ((last (>= anchor (point-max)))
+         (string (concat (propertize " " 'cursor t) "\n" block
+                         (if last "" "\n"))))
     ;; Appended, so the messages keep their own colours and only take the
     ;; background from the tint.  It has to cover the newlines too, or the
     ;; tint would stop at the text instead of reaching the window edge.
     (when background
       (add-face-text-property 0 (length string) background 'append string))
-    (let ((ov (if (< anchor (point-max))
-                  (make-overlay (1+ anchor) (1+ anchor) nil t nil)
-                (make-overlay anchor anchor nil t nil))))
+    ;; A display string takes its base face from the newline it replaces,
+    ;; overlays included, so the block would light up under `hl-line' or
+    ;; an active region; `default' underneath everything keeps it plain
+    (add-face-text-property 0 (length string) 'default 'append string)
+    (let ((ov (make-overlay anchor (if last anchor (1+ anchor)) nil t nil)))
       (overlay-put ov 'priority 100)
-      (overlay-put ov 'before-string string)
+      (cond
+       (last (overlay-put ov 'before-string string))
+       (t (overlay-put ov 'display string)
+          ;; Gone with the newline it stood in for, when lines are joined
+          (overlay-put ov 'evaporate t)))
       (flycheck-annotate--track ov))))
 
 (defun flycheck-annotate-below-style (errors anchor _focused)

--- a/test/specs/test-annotate.el
+++ b/test/specs/test-annotate.el
@@ -44,7 +44,7 @@ Line 2 gets an error and a warning; line 4 gets a warning."
   "Return OV's annotation string, minus the leading cursor-anchor space.
 Return nil for overlays that carry no annotation, such as tint overlays,
 so it doubles as a predicate for the message overlays."
-  (when-let* ((s (overlay-get ov 'before-string)))
+  (when-let* ((s (or (overlay-get ov 'display) (overlay-get ov 'before-string))))
     (if (get-text-property 0 'cursor s) (substring s 1) s)))
 
 (defun test-annotate/sideline (code msg-width win-width &optional gutter)
@@ -68,14 +68,11 @@ space stripped."
 
 (defun test-annotate/anchors ()
   "Return an alist mapping each message overlay's code line to its text.
-A `below'-style block is hung off the start of the line after the code it
-annotates (so it doesn't disturb visual-line motion); such a block ends in
-a newline, so key it back under the code line."
+Every style anchors its overlay on the annotated line: a `below'-style
+block replaces that line's newline, so it begins with one."
   (mapcar (lambda (ov)
-            (let* ((text (test-annotate/text ov))
-                   (below (string-suffix-p "\n" text)))
-              (cons (- (line-number-at-pos (overlay-start ov)) (if below 1 0))
-                    (substring-no-properties text))))
+            (cons (line-number-at-pos (overlay-start ov))
+                  (substring-no-properties (test-annotate/text ov))))
           (seq-filter #'test-annotate/text flycheck-annotate--overlays)))
 
 (defun test-annotate/tints ()
@@ -185,9 +182,9 @@ a newline, so key it back under the code line."
         (if (listp face) face (list face))))
 
     (it "carries the line tint through the whole block"
-      ;; The block hangs off the next line, outside the range the tint
-      ;; overlay covers, so it has to carry the tint itself or the code
-      ;; line and its messages look like separate regions.  See #2276.
+      ;; The block carries the tint itself rather than inheriting the line
+      ;; tint's: the last line's `before-string' inherits nothing, and every
+      ;; other block is kept plain underneath on purpose.  See #2276.
       (flycheck-buttercup-with-temp-buffer
         (insert "abcdef\nghijkl\n")
         (let* ((eol (save-excursion (goto-char (point-min)) (line-end-position)))
@@ -218,7 +215,10 @@ a newline, so key it back under the code line."
                (text (test-annotate/text ov)))
           (dotimes (i (length text))
             (expect (test-annotate/faces-at ov i)
-                    :not :to-contain 'flycheck-annotate-error-background)))))
+                    :not :to-contain 'flycheck-annotate-error-background)
+            ;; and it stays plain under hl-line or the region: the display
+            ;; string would otherwise inherit the newline's overlay faces
+            (expect (test-annotate/faces-at ov i) :to-contain 'default)))))
 
     (it "stacks each message on its own line under the code"
       (flycheck-buttercup-with-temp-buffer
@@ -231,14 +231,14 @@ a newline, so key it back under the code line."
                (flycheck-annotate--overlays nil)
                (ov (flycheck-annotate-below-style errs eol t))
                (s (substring-no-properties (test-annotate/text ov))))
-          ;; the block hangs off the next line, so it ends (not begins) with a
-          ;; newline, keeping visual-line motion off the annotated line
+          ;; the block stands in for the line's newline, so it begins with
+          ;; one and ends with one
+          (expect (string-prefix-p "\n" s) :to-be t)
           (expect (string-suffix-p "\n" s) :to-be t)
-          (expect (string-prefix-p "\n" s) :to-be nil)
           (expect s :to-match "one")
           (expect s :to-match "two")
-          ;; one line per error, then the trailing newline
-          (expect (length (split-string s "\n")) :to-equal 3))))
+          ;; the leading newline, one line per error, the trailing newline
+          (expect (length (split-string s "\n")) :to-equal 4))))
 
     (it "aligns the connector to the error's display column past a tab"
       (flycheck-buttercup-with-temp-buffer
@@ -252,7 +252,8 @@ a newline, so key it back under the code line."
                (ov (flycheck-annotate-below-style errs eol t))
                (s (test-annotate/text ov)))
           ;; the leading pad aligns to display column 8, not 1
-          (expect (get-text-property 0 'display s)
+          ;; index 0 is the newline the block stands in for; the pad follows
+          (expect (get-text-property 1 'display s)
                   :to-equal '(space :align-to 8)))))
 
     (it "adds no pad for an error in the first column"
@@ -265,7 +266,7 @@ a newline, so key it back under the code line."
                (ov (flycheck-annotate-below-style errs eol t))
                (s (test-annotate/text ov)))
           ;; char 0 is the connector itself, no stretch space
-          (expect (get-text-property 0 'display s) :to-be nil))))
+          (expect (get-text-property 1 'display s) :to-be nil))))
 
     (it "trails an error's related locations on their own lines"
       (flycheck-buttercup-with-temp-buffer
@@ -281,25 +282,38 @@ a newline, so key it back under the code line."
                (s (substring-no-properties (test-annotate/text ov))))
           (expect s :to-match "redefined")
           (expect s :to-match "↳ first here (5:2)")
-          ;; the message line, the related-location line, then the trailing newline
-          (expect (length (split-string s "\n")) :to-equal 3))))
+          ;; the leading newline, the message line, the related-location
+          ;; line, then the trailing newline
+          (expect (length (split-string s "\n")) :to-equal 4))))
 
-    (it "hangs the block off the start of the next line"
-      ;; Regression guard: anchoring the multi-line block on the following
-      ;; line's buffer position (rather than the annotated line's newline)
-      ;; keeps `next-line' and `evil-next-visual-line' from stalling on -- or,
-      ;; under Evil, getting stuck before -- the annotation.
+    (it "replaces the annotated line's newline with the block"
+      ;; Regression guard for two things at once.  Under
+      ;; `display-line-numbers-mode' a block hung off the next line's start
+      ;; took that line's number and left the line itself unnumbered
+      ;; (issue #2367); a plain `after-string' at the end of the line
+      ;; numbers right but stalls `next-line' and `evil-next-visual-line'
+      ;; on the annotation.  A `display' string standing in for the
+      ;; newline keeps the block's rows within the annotated line, which
+      ;; the numbering skips and visual-line motion steps over as a unit.
       (flycheck-buttercup-with-temp-buffer
         (insert "abcdef\nghijkl\n")
         (let* ((eol (save-excursion (goto-char (point-min)) (line-end-position)))
                (errs (list (flycheck-error-new-at 1 1 'error "boom"
                                                   :checker 'emacs-lisp)))
                (flycheck-annotate--overlays nil)
-               (ov (flycheck-annotate-below-style errs eol t)))
-          (expect (line-number-at-pos (overlay-start ov)) :to-equal 2)
-          (expect (overlay-start ov)
-                  :to-equal (save-excursion (goto-char (point-min))
-                                            (line-beginning-position 2))))))
+               (ov (flycheck-annotate-below-style errs eol t))
+               (raw (overlay-get ov 'display)))
+          (expect (overlay-start ov) :to-equal eol)
+          (expect (overlay-end ov) :to-equal (1+ eol))
+          (expect (overlay-get ov 'before-string) :to-be nil)
+          ;; the cursor stays after the code, then the newline it stands in
+          ;; for, the block, and a newline to end it
+          (expect (get-text-property 0 'cursor raw) :to-be t)
+          (expect (string-prefix-p " \n" (substring-no-properties raw)) :to-be t)
+          (expect (string-suffix-p "\n" (substring-no-properties raw)) :to-be t)
+          ;; and it goes with the newline when the lines are joined
+          (save-excursion (goto-char eol) (delete-char 1))
+          (expect (overlay-buffer ov) :to-be nil))))
 
     (it "falls back to a leading newline on the buffer's last line"
       (flycheck-buttercup-with-temp-buffer
@@ -603,9 +617,9 @@ a newline, so key it back under the code line."
       ;; plain space carrying a `cursor' property.  That keeps C-e and typing
       ;; parked at the end of the code instead of the end of the annotation.  A
       ;; plain space is essential: the `cursor' property lands at the far end of
-      ;; the `sideline' `:align-to' stretch.  The multi-line `below' style keeps
-      ;; the cursor on the code line by hanging its block off the next line
-      ;; instead (see its own specs), so it is excluded here.
+      ;; the `sideline' `:align-to' stretch.  The multi-line `below' style
+      ;; anchors the cursor the same way, but in a `display' string (see its
+      ;; own specs), so it is excluded here.
       (flycheck-buttercup-with-temp-buffer
         (save-window-excursion
           (set-window-buffer (selected-window) (current-buffer))


### PR DESCRIPTION
Fixes #2367.

The `below` block was hung off the start of the next line (a `before-string` ending in a newline), so `display-line-numbers-mode` numbered the block's first row as the next line and had nothing left for the line itself. That placement existed to keep `next-line` from stalling on the block, which an `after-string` at the end of the line does.

Standing the block in for the annotated line's newline via a `display` string - cursor-anchored space, newline, block, newline - gets both right. Measured in a terminal Emacs 30: gutter reads 1, blank, 2; `C-n` from line 1 lands on 2 and then 3; the cursor sits after the code at end of line and typing there goes before the block. Also verified with the real checker on an elisp buffer: a three-message block with wrapped rows, no numbers on any of them, the following lines numbered as before.