### PR TITLE
Record output for the Go checkers that need a module

### DIFF
--- a/test/fixtures/go-build/language/go/build/main.go.txt
+++ b/test/fixtures/go-build/language/go/build/main.go.txt
@@ -1,0 +1,6 @@
+# build
+./main.go:10:17: cannot use 1 (untyped int constant) as string value in variable declaration
+./main.go:11:22: not enough arguments in call to pair
+	have (number)
+	want (int, int)
+./main.go:12:2: undefined: undefined

--- a/test/fixtures/go-errcheck/language/go/errcheck/main.go.txt
+++ b/test/fixtures/go-errcheck/language/go/errcheck/main.go.txt
@@ -1,0 +1,2 @@
+test/resources/language/go/errcheck/main.go:7:9:	f.Close()
+test/resources/language/go/errcheck/main.go:9:9:	os.Stat("enoent")

--- a/test/fixtures/go-staticcheck/language/go/staticcheck/main.go.txt
+++ b/test/fixtures/go-staticcheck/language/go/staticcheck/main.go.txt
@@ -1,0 +1,3 @@
+{"code":"S1005","severity":"error","location":{"file":"test/resources/language/go/staticcheck/main.go","line":8,"column":6},"end":{"file":"test/resources/language/go/staticcheck/main.go","line":8,"column":7},"message":"unnecessary assignment to the blank identifier"}
+{"code":"SA1018","severity":"error","location":{"file":"test/resources/language/go/staticcheck/main.go","line":12,"column":39},"end":{"file":"test/resources/language/go/staticcheck/main.go","line":12,"column":40},"message":"calling strings.Replace with n == 0 will return no results, did you mean -1?"}
+{"code":"U1000","severity":"error","location":{"file":"test/resources/language/go/staticcheck/main.go","line":16,"column":6},"end":{"file":"","line":0,"column":0},"message":"func unused is unused"}

--- a/test/fixtures/go-test/language/go/test-error/lib_test.go.txt
+++ b/test/fixtures/go-test/language/go/test-error/lib_test.go.txt
@@ -1,0 +1,2 @@
+# testerror [testerror.test]
+./lib_test.go:6:2: undefined: fmt

--- a/test/fixtures/go-unconvert/language/go/unconvert/main.go.txt
+++ b/test/fixtures/go-unconvert/language/go/unconvert/main.go.txt
@@ -1,0 +1,1 @@
+test/resources/language/go/unconvert/main.go:7:17: unnecessary conversion

--- a/test/resources/language/go/build/go.mod
+++ b/test/resources/language/go/build/go.mod
@@ -1,0 +1,3 @@
+module build
+
+go 1.16

--- a/test/resources/language/go/build/main.go
+++ b/test/resources/language/go/build/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func pair(a int, b int) int {
+	return a + b
+}
+
+func main() {
+	var s string = 1
+	fmt.Println(s, pair(1))
+	undefined()
+}

--- a/test/resources/language/go/errcheck/go.mod
+++ b/test/resources/language/go/errcheck/go.mod
@@ -1,0 +1,3 @@
+module errcheck
+
+go 1.16

--- a/test/resources/language/go/errcheck/main.go
+++ b/test/resources/language/go/errcheck/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "os"
+
+func main() {
+	f, _ := os.Open("enoent")
+	f.Close()
+
+	os.Stat("enoent")
+}

--- a/test/resources/language/go/staticcheck/go.mod
+++ b/test/resources/language/go/staticcheck/go.mod
@@ -1,0 +1,3 @@
+module staticcheck
+
+go 1.16

--- a/test/resources/language/go/staticcheck/main.go
+++ b/test/resources/language/go/staticcheck/main.go
@@ -1,0 +1,16 @@
+package main
+
+import "strings"
+
+func main() {
+	// S1005 (gosimple); xs is declared in a sibling file, so the check
+	// fails if staticcheck is handed this file alone instead of the package
+	for _ = range xs {
+	}
+
+	// SA1018 (staticcheck)
+	_ = strings.Replace("foo", "f", "b", 0)
+}
+
+// U1000 (unused)
+func unused() {}

--- a/test/resources/language/go/staticcheck/xs.go
+++ b/test/resources/language/go/staticcheck/xs.go
@@ -1,0 +1,3 @@
+package main
+
+var xs = []int{1, 2, 3}

--- a/test/resources/language/go/test-error/go.mod
+++ b/test/resources/language/go/test-error/go.mod
@@ -1,0 +1,3 @@
+module testerror
+
+go 1.16

--- a/test/resources/language/go/test-error/lib.go
+++ b/test/resources/language/go/test-error/lib.go
@@ -1,0 +1,5 @@
+package testerror
+
+func Answer() int {
+	return 42
+}

--- a/test/resources/language/go/test-error/lib_test.go
+++ b/test/resources/language/go/test-error/lib_test.go
@@ -1,0 +1,7 @@
+package testerror
+
+import "testing"
+
+func TestAnswer(t *testing.T) {
+	fmt.Println(Answer())
+}

--- a/test/resources/language/go/unconvert/go.mod
+++ b/test/resources/language/go/unconvert/go.mod
@@ -1,0 +1,3 @@
+module unconvert
+
+go 1.16

--- a/test/resources/language/go/unconvert/main.go
+++ b/test/resources/language/go/unconvert/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	var x int
+	fmt.Println(int(x))
+}

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -200,6 +200,32 @@
       ;; none of the undefined references vet reports about a file vetted
       ;; alone (the buffer view then keeps only its own file's warnings)
       '(6 14 warning "fmt.Printf format %d has arg \"s\" of wrong type string"
-          :id "printf" :end-line 6 :end-column 16))))
+          :id "printf" :end-line 6 :end-column 16))
+    (flycheck-buttercup-def-parse-test go-build "language/go/build/main.go"
+      ;; The compiler names the package on a line of its own, which no
+      ;; pattern claims, and folds the detail of a call-site mismatch
+      ;; onto tab-indented continuation lines that belong to the message
+      '(10 17 error "cannot use 1 (untyped int constant) as string value in variable declaration")
+      '(11 22 error "not enough arguments in call to pair
+	have (number)
+	want (int, int)")
+      '(12 2 error "undefined: undefined"))
+    (flycheck-buttercup-def-parse-test go-test "language/go/test-error/lib_test.go"
+      ;; `go test -c' compiles the test binary, so the package header
+      ;; names the test package rather than the package under test
+      '(6 2 error "undefined: fmt"))
+    (flycheck-buttercup-def-parse-test go-errcheck "language/go/errcheck/main.go"
+      ;; errcheck prints the offending expression, which the error filter
+      ;; turns into a sentence
+      '(7 9 warning "Ignored `error` returned from `f.Close()`")
+      '(9 9 warning "Ignored `error` returned from `os.Stat(\"enoent\")`"))
+    (flycheck-buttercup-def-parse-test go-unconvert "language/go/unconvert/main.go"
+      '(7 17 warning "unnecessary conversion"))
+    (flycheck-buttercup-def-parse-test go-staticcheck "language/go/staticcheck/main.go"
+      ;; One JSON document per finding, with the check's code as the id
+      '(8 6 error "unnecessary assignment to the blank identifier" :id "S1005")
+      '(12 39 error "calling strings.Replace with n == 0 will return no results, did you mean -1?"
+           :id "SA1018")
+      '(16 6 error "func unused is unused" :id "U1000"))))
 
 ;;; test-go.el ends here


### PR DESCRIPTION
The Go checkers that need a real module context had no recorded output, so nothing watched them for drift. Run against a lone file they report nothing, which is why earlier recording attempts came up empty; each now gets a small module resource with a `go 1.16` go.mod (low on purpose, to avoid a toolchain download) and a fixture recorded through the recorder, with parse specs reading them back.

Recording turned up three things I left alone, since I can't run the tools outside the image to verify a change:

- the live checker tests in `test-go.el` are still GOPATH-era and would fail against modern Go (`go build` in `src/b1` has no go.mod, and the missing-package spec asserts wording Go no longer prints)
- `go-build`'s `found packages` pattern is dead for the same reason
- `go-staticcheck` throws away the `end` object staticcheck sends, so its errors are points rather than ranges; a fix has to treat the zero end on U1000 findings as absent