### PR TITLE
Read the span staticcheck reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [#2373](https://github.com/flycheck/flycheck/pull/2373): `go-staticcheck` errors carry the end position staticcheck reports, so a finding highlights the expression it is about rather than a single point; a finding that spans nothing, such as an unused declaration, stays a point.
 - [#2357](https://github.com/flycheck/flycheck/pull/2357): `haskell-ghc` reads GHC 9.10's JSON diagnostics when the compiler has them (probed per binary): errors carry precise spans and GHC-NNNNN ids that `C-c ! e` explains via the Haskell error index, and JSON-reading checkers in general no longer choke on text lines that merely start with a bracket, like GHC's compilation progress.
 - [#2356](https://github.com/flycheck/flycheck/pull/2356): `haskell-hlint` reads hlint's JSON ideas: hint names become error ids, spans get right-open end columns, and an idea with a replacement carries a machine-applicable fix, applied with `C-c ! f`.
 - [#2355](https://github.com/flycheck/flycheck/pull/2355): `go-vet` reads `go vet -json`: analyzer findings carry the analyzer's name as their id and byte-precise positions with end columns, and a compile error that stops the analyzers is reported at its real position as an error rather than a warning.

--- a/flycheck.el
+++ b/flycheck.el
@@ -11165,7 +11165,12 @@ information about staticcheck."
           :id .code
           :checker checker
           :buffer buffer
-          :filename .location.file)
+          :filename .location.file
+          ;; A finding that spans nothing, such as an unused
+          ;; declaration, still carries an `end' object, with an empty
+          ;; file and zeroed position.  Report it as a point.
+          :end-line (and .end.line (/= .end.line 0) .end.line)
+          :end-column (and .end.column (/= .end.column 0) .end.column))
          errors)))
     (nreverse errors)))
 

--- a/test/specs/languages/test-go.el
+++ b/test/specs/languages/test-go.el
@@ -223,9 +223,13 @@
       '(7 17 warning "unnecessary conversion"))
     (flycheck-buttercup-def-parse-test go-staticcheck "language/go/staticcheck/main.go"
       ;; One JSON document per finding, with the check's code as the id
-      '(8 6 error "unnecessary assignment to the blank identifier" :id "S1005")
+      ;; and the span staticcheck reports alongside the location
+      '(8 6 error "unnecessary assignment to the blank identifier" :id "S1005"
+          :end-line 8 :end-column 7)
       '(12 39 error "calling strings.Replace with n == 0 will return no results, did you mean -1?"
-           :id "SA1018")
+           :id "SA1018" :end-line 12 :end-column 40)
+      ;; An unused declaration spans nothing, and its `end' is zeroed
+      ;; rather than absent, so it stays a point
       '(16 6 error "func unused is unused" :id "U1000"))))
 
 ;;; test-go.el ends here


### PR DESCRIPTION
staticcheck sends an `end` object next to each finding's location, which the parser threw away, so every finding came out as a single point instead of highlighting the expression it is about. Recording the fixtures in #2369 is what made this visible.

The wrinkle is that a finding which spans nothing, like an unused declaration, zeroes that object rather than omitting it, so a zeroed end is read as absent and stays a point. The recorded output covers both shapes.