### PR TITLE
Do not let an unsatisfiable upgrade fail the build

### DIFF
--- a/Eask
+++ b/Eask
@@ -33,9 +33,10 @@
 
  ;; Various modes for use in the unit tests
  (depends-on "adoc-mode")
- ;; bazel-mode requires Emacs 29; its checker specs skip without the
- ;; buildifier binary anyway, so just drop it on older versions
- (when (>= emacs-major-version 29)
+ ;; bazel-mode moved its floor to Emacs 30.1, and `eask upgrade' fails
+ ;; the whole install when it cannot satisfy that.  Its checker specs
+ ;; skip without the buildifier binary anyway, so drop it on older ones.
+ (when (>= emacs-major-version 30)
    (depends-on "bazel"))
  (depends-on "coffee-mode")
  (depends-on "cperl-mode")

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,11 @@ endif
 .PHONY: init
 init:
 	$(EASK) install-deps --dev
-	$(EASK) upgrade
+# Opportunistic: install-deps has already satisfied everything Eask asks
+# for, and an upgrade that cannot be satisfied must not fail the build.
+# A dependency raising its Emacs floor otherwise breaks every job on an
+# older Emacs, without a commit landing here.
+	-$(EASK) upgrade
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
bazel-mode's 20260826 release moved its floor to Emacs 30.1, and `eask upgrade` fails the whole step when it can't satisfy that. So `make init` has been dying on both Emacs 29 jobs before a single spec runs, on every PR.

Raising the Eask guard on bazel from 29 to 30 isn't enough on its own: the cache `restore-keys` fall back to a cache that already has it installed, and `eask upgrade` upgrades what's installed rather than only what Eask declares. So the upgrade is now allowed to fail quietly. It's opportunistic anyway, since `install-deps` has already satisfied everything Eask asks for, and this way the next dependency to raise its Emacs floor isn't an outage. The guard moves to 30 as well, so a fresh cache doesn't install it there in the first place.

Worth noting it fails locally too, for an unrelated reason (buttercup as a system package), so `make init` has been returning non-zero on developer machines as well.