### PR TITLE
Use PATTERN make variable to filter tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OPTIPNG = optipng
 
 # Program options
 EMACSOPTS =
-PATTERN = .*
+PATTERN = \\\`
 # Internal variables
 EMACSBATCH = $(EMACS) -Q --batch -L . -L test/specs $(EMACSOPTS)
 RUNEMACS =

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ compile:
 
 .PHONY: specs
 specs: compile
-	$(EASK) exec buttercup -L . -L test -L test/specs test/specs
+	$(EASK) exec buttercup -p '$(PATTERN)' -L . -L test -L test/specs test/specs
 
 # Times the hot paths; nothing asserts, the numbers are for comparing a
 # branch against master on the same machine.


### PR DESCRIPTION
The Contributor’s Guide says:

> `make specs` runs all Buttercup specs for Flycheck. Set PATTERN to run only specs matching a specific regular expression, e.g. `make PATTERN='^Mode Line'` specs to run only tests for the mode line.

Make this actually work, by passing the pattern to Buttercup.