### PR TITLE
Run project checks on the project's host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [#2378](https://github.com/flycheck/flycheck/pull/2378): `flycheck-check-project` works on a project that lives on a remote host, running the checker over TRAMP on the host the project is on instead of refusing.
 - [#2373](https://github.com/flycheck/flycheck/pull/2373): `go-staticcheck` errors carry the end position staticcheck reports, so a finding highlights the expression it is about rather than a single point; a finding that spans nothing, such as an unused declaration, stays a point.
 - [#2357](https://github.com/flycheck/flycheck/pull/2357): `haskell-ghc` reads GHC 9.10's JSON diagnostics when the compiler has them (probed per binary): errors carry precise spans and GHC-NNNNN ids that `C-c ! e` explains via the Haskell error index, and JSON-reading checkers in general no longer choke on text lines that merely start with a bracket, like GHC's compilation progress.
 - [#2356](https://github.com/flycheck/flycheck/pull/2356): `haskell-hlint` reads hlint's JSON ideas: hint names become error ids, spans get right-open end columns, and an idea with a replacement carries a machine-applicable fix, applied with `C-c ! f`.

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -200,6 +200,10 @@ them: a Terraform output referencing a variable no file declares, say.  A
    The results reflect the project as of the run and stay until the next
    run there; with a prefix argument the results are dropped instead.
 
+A project on a remote host is checked like a local one: the tool runs on
+that host over TRAMP, so it needs to be installed there, and the paths it
+reports are opened there rather than at the same paths on this machine.
+
 Project checkers never run automatically and take no part in buffer
 checks.  Flycheck ships with these; new ones can be defined with
 ``flycheck-define-project-checker``:

--- a/flycheck.el
+++ b/flycheck.el
@@ -5488,8 +5488,9 @@ never runs automatically and takes no part in buffer checks.
 The following PROPERTIES constitute a project checker:
 
 `:command (EXECUTABLE ARG ...)'
-     The command to run in the project's root directory, as a list
-     of strings.
+     The command to run in the project's root directory, on the host
+     that directory is on, as a list of strings.  It must name no file
+     on this machine, and the tool has to be installed there.
 
 `:parser FUNCTION'
      A function called with the command's output as a string, the
@@ -5636,6 +5637,11 @@ reflect the project as of that run; they stay until the next
                       :buffer stdout
                       :stderr stderr
                       :command (plist-get props :command)
+                      ;; Run where the project is: without this the
+                      ;; process ignores a remote `default-directory' and
+                      ;; runs on this machine instead, against files it
+                      ;; cannot see.
+                      :file-handler t
                       :noquery t
                       :sentinel (lambda (proc _event)
                                   (flycheck--project-run-finish proc)))
@@ -5678,8 +5684,6 @@ checking again."
   (interactive "P")
   (let ((root (or (flycheck--buffer-project-key)
                   (user-error "Cannot tell which project this buffer is in"))))
-    (when (file-remote-p root)
-      (user-error "Project checks do not support remote projects yet"))
     (if clear
         (progn
           (flycheck--project-runs-forget root)
@@ -5688,15 +5692,34 @@ checking again."
           (flycheck--project-diagnostics-changed)
           (flycheck-error-list-refresh)
           (message "Project check results dropped"))
-      (let* ((applicable
-              (seq-filter (lambda (entry)
-                            (funcall (plist-get (cdr entry) :enabled) root))
-                          flycheck--project-checkers))
-             (runnable
-              (seq-filter (lambda (entry)
-                            (executable-find
-                             (car (plist-get (cdr entry) :command))))
-                          applicable))
+      (let* ((probed
+              ;; Both filters ask the project's host: `:enabled' stats
+              ;; files there and the executable search reads its
+              ;; `exec-path', which both need the directory bound rather
+              ;; than a flag.  A host that cannot be reached signals from
+              ;; deep inside TRAMP, so say which project is unreachable
+              ;; instead of surfacing that.
+              (condition-case err
+                  (let ((default-directory root))
+                    (let ((applicable
+                           (seq-filter (lambda (entry)
+                                         (funcall (plist-get (cdr entry)
+                                                             :enabled)
+                                                  root))
+                                       flycheck--project-checkers)))
+                      (cons applicable
+                            (seq-filter
+                             (lambda (entry)
+                               (executable-find
+                                (car (plist-get (cdr entry) :command))
+                                (file-remote-p root)))
+                             applicable))))
+                (file-error
+                 (user-error "Cannot reach %s: %s"
+                             (abbreviate-file-name root)
+                             (error-message-string err)))))
+             (applicable (car probed))
+             (runnable (cdr probed))
              ;; Other sources start their work as they are asked
              (others (apply #'append
                             (mapcar (lambda (fn) (funcall fn root))
@@ -20346,7 +20369,7 @@ See URL `https://developer.hashicorp.com/terraform/cli/commands/validate'."
             :end-line .range.end.line
             :end-column .range.end.column
             :checker 'terraform-validate
-            :filename (expand-file-name .range.filename directory)
+            :filename (flycheck--expand-file-name .range.filename directory)
             :buffer nil)))
        ranged))))
 

--- a/test/specs/test-helpers.el
+++ b/test/specs/test-helpers.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'flycheck-buttercup)
+(require 'tramp)
 (require 'record-fixture)
 (require 'shut-up)
 
@@ -445,7 +446,28 @@ The manifest path is relative to
 (require 'ess-site nil 'noerror)
 
 
+(defconst flycheck-test-tramp-remote-prefix "/mock:localhost:"
+  "TRAMP prefix of the local mock connection used by the specs.")
+
+(defun flycheck-test-tramp-setup-method ()
+  "Register TRAMP's mock method, running a local shell as the remote."
+  (add-to-list 'tramp-methods
+               '("mock"
+                 (tramp-login-program "sh")
+                 (tramp-login-args (("-i")))
+                 (tramp-remote-shell "/bin/sh")
+                 (tramp-remote-shell-args ("-c"))
+                 (tramp-connection-timeout 10)))
+  (add-to-list 'tramp-default-host-alist '("\\`mock\\'" nil "localhost")))
+
+(defun flycheck-test-tramp-connectable-p ()
+  "Return non-nil if a mock TRAMP connection can be established."
+  (ignore-errors
+    (let ((default-directory flycheck-test-tramp-remote-prefix))
+      (file-exists-p (concat flycheck-test-tramp-remote-prefix "/")))))
+
 (provide 'test-helpers)
+
 
 ;; Local Variables:
 ;; no-byte-compile: t

--- a/test/specs/test-project-runs.el
+++ b/test/specs/test-project-runs.el
@@ -199,6 +199,58 @@
       (flycheck-test--with-temp-project _dir
         (should-error (flycheck-check-project) :type 'user-error))))
 
+  (describe "a project on a remote host"
+
+    ;; The checker has to run where the project is.  Without a file
+    ;; handler the process ignores a remote `default-directory' and runs
+    ;; on this machine instead, against files it cannot see.
+    (before-all
+      (flycheck-test-tramp-setup-method))
+
+    (after-each
+      (ignore-errors (tramp-cleanup-all-connections)))
+
+    (it "runs the checker on the project's host"
+      ;; The mock method addresses a Unix path; a Windows temp directory
+      ;; cannot be named through it.
+      (assume (not (eq system-type 'windows-nt))
+              "the mock method cannot address Windows paths")
+      (assume (flycheck-test-tramp-connectable-p) "no mock TRAMP connection")
+      (flycheck-test--define-run-checker
+       ;; Report where the process actually ran, so a check that silently
+       ;; ran here instead fails rather than passing.
+       :command (flycheck-test--emacs-command
+                 '(princ (format "gamma.rb:3:%s" default-directory))))
+      (let ((flycheck-test--project-tmp (make-temp-file "flycheck-prj" t)))
+        (unwind-protect
+            (with-temp-buffer
+              (setq default-directory
+                    (concat flycheck-test-tramp-remote-prefix
+                            (file-name-as-directory
+                             flycheck-test--project-tmp)))
+              (let ((dir (flycheck--project-directory)))
+                (expect (file-remote-p dir) :to-be-truthy)
+                (flycheck-check-project)
+                (flycheck-test--wait-for-run (cons dir 'test-run))
+                (let ((errors (flycheck--project-errors dir)))
+                  (expect (length errors) :to-equal 1)
+                  ;; The path the checker reported is expanded back onto
+                  ;; the project's host, not opened locally.
+                  (expect (flycheck-error-filename (car errors))
+                          :to-equal (concat dir "gamma.rb"))
+                  ;; And it really ran there: without a file handler
+                  ;; the process starts in this machine's home directory
+                  ;; instead of the project.
+                  (expect (file-equal-p (flycheck-error-message (car errors))
+                                        flycheck-test--project-tmp)
+                          :to-be-truthy))))
+          (maphash (lambda (_key state)
+                     (when-let* ((proc (plist-get state :process)))
+                       (when (process-live-p proc) (delete-process proc))))
+                   flycheck--project-runs)
+          (ignore-errors
+            (delete-directory flycheck-test--project-tmp t))))))
+
   (describe "terraform-validate"
 
     (it "applies to a directory with Terraform files"
@@ -240,6 +292,21 @@
                 " \"detail\": \"Run terraform init.\"}]}")
         'terraform-validate "/prj/")
        :to-throw 'error)))
+
+    (it "keeps the host on an absolute path from a remote project"
+      ;; terraform reports paths as its own host sees them; expanding an
+      ;; absolute one with plain `expand-file-name' would drop the prefix
+      ;; and name the same path on this machine.
+      (let ((errors (flycheck-parse-terraform-validate
+                     (concat "{\"valid\":false,\"diagnostics\":"
+                             "[{\"severity\":\"error\",\"summary\":\"Bad\","
+                             "\"detail\":\"\",\"range\":{\"filename\":"
+                             "\"/srv/app/main.tf\",\"start\":"
+                             "{\"line\":1,\"column\":1},"
+                             "\"end\":{\"line\":1,\"column\":2}}}]}")
+                     'terraform-validate "/ssh:host:/srv/app/")))
+        (expect (flycheck-error-filename (car errors))
+                :to-equal "/ssh:host:/srv/app/main.tf")))
 
   (describe "cargo-check"
 

--- a/test/specs/test-tramp.el
+++ b/test/specs/test-tramp.el
@@ -31,26 +31,6 @@
 (require 'tramp)
 (require 'python)
 
-(defconst flycheck-test-tramp-remote-prefix "/mock:localhost:"
-  "TRAMP prefix of the local mock connection used by these specs.")
-
-(defun flycheck-test-tramp-setup-method ()
-  "Register TRAMP's mock method, running a local shell as the remote."
-  (add-to-list 'tramp-methods
-               '("mock"
-                 (tramp-login-program "sh")
-                 (tramp-login-args (("-i")))
-                 (tramp-remote-shell "/bin/sh")
-                 (tramp-remote-shell-args ("-c"))
-                 (tramp-connection-timeout 10)))
-  (add-to-list 'tramp-default-host-alist '("\\`mock\\'" nil "localhost")))
-
-(defun flycheck-test-tramp-connectable-p ()
-  "Return non-nil if a mock TRAMP connection can be established."
-  (ignore-errors
-    (let ((default-directory flycheck-test-tramp-remote-prefix))
-      (file-exists-p (concat flycheck-test-tramp-remote-prefix "/")))))
-
 (describe "Remote syntax checking over TRAMP"
   (before-all
     (flycheck-test-tramp-setup-method))


### PR DESCRIPTION
`flycheck-check-project` refused a project on a remote host. It can run there, so it does now.

The checker process needs `:file-handler t`, or `make-process` ignores the remote `default-directory` and starts on this machine, in the home directory, against files it cannot see. The executable search was subtler: `executable-find`'s REMOTE argument is a flag, not a host, and the host it searches comes from `default-directory`. So the tool was looked for here while the checker ran there, and it only worked because the calling buffer usually sits on the same host as the project. Both filters now run with the root bound.

Reaching that host can fail, which used to be unreachable code behind the refusal. A connection failure now names the project rather than surfacing `Tramp failed to connect` as a Flycheck command error.

The spec runs a real project check over TRAMP's mock method and asserts where the process ran; it reports the home directory without the file-handler fix.

Two things I looked at and left alone, worth knowing about. A remote host without `mknod`/`mkfifo` can't give the process a separate stderr buffer, so `make-process` fails there and the checker reports "could not start" - the stderr buffer only exists to produce a one-line failure hint, so retrying without it would be better, but I have no such host to test against. And Flycheck compares project keys by string, so a project opened as `/ssh:host:` and buffers opened as `/scp:host:` won't collapse into one project view.