### PR TITLE
Do not fail the manual when GNU's mirrors are down

### DIFF
--- a/doc/info.py
+++ b/doc/info.py
@@ -217,8 +217,12 @@ def resolve_info_references(app, _env, refnode, contnode):
             reference += contnode
             return reference
     else:
-        # Without an xref DB we're unable to resolve any info references
-        return None
+        # Without an xref DB no info reference can be resolved.  Hand back
+        # the plain text so the reference reads as its title and Sphinx
+        # counts it handled: returning nothing makes Sphinx report every
+        # one of them as a missing target, which fails a -W build for
+        # want of a database that lives on someone else's server.
+        return contnode
 
 
 def setup(app):


### PR DESCRIPTION
`build-manual` started failing with 21 warnings, every one of them an unresolved `(elisp)`/`(emacs)` info reference in files nobody had touched.

The Info cross-reference database is fetched from ftp.gnu.org while the docs build. The extension already intends to cope when that fetch fails - there's a comment saying a `-W` build "should fail for defects in the documentation, not because GNU's mirrors are having a bad day" - but the missing-reference handler returns nothing in that case, which is how you tell Sphinx *nobody* resolved the reference, so it reports each one as a missing target and `-W` turns them into errors.

Handing back the plain text instead means the reference reads as its title and Sphinx counts it handled. Reproduced locally by pointing the mirrors at an unreachable host: the build fails before this change, passes after, and still emits real links when the database is reachable.