### PR TITLE
Let a resident server stand in for its command checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### New Features
 
+- [#2380](https://github.com/flycheck/flycheck/pull/2380): New `flycheck-lsp-prefer-server` option: automatic checker selection can use a linter's own resident LSP server in place of the command checker that spawns it afresh on every check, for the linters `flycheck-lsp-checker-servers` names.
 - [#2364](https://github.com/flycheck/flycheck/pull/2364): The native `flycheck-lsp` client speaks the pull model of LSP 3.17: a server offering a `diagnosticProvider` is asked for each document's diagnostics, and `flycheck-check-project` asks servers covering their workspace for the diagnostics of every file in it, visited or not.
 - [#2362](https://github.com/flycheck/flycheck/pull/2362): New project checkers `cargo-check` and `mypy-project` check a whole Rust workspace or mypy-configured Python project at once via `flycheck-check-project`, reporting through `rust-cargo` and `python-mypy` so identical findings collapse against buffer checks.
 - [#2360](https://github.com/flycheck/flycheck/pull/2360): New command `flycheck-check-project` (`C-c ! P`) runs project checkers - tools that check a whole project at once for the cross-file problems buffer checks cannot see - starting with `terraform-validate`; their diagnostics join the error list's project scope and the mode line's project counts.

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -330,6 +330,43 @@ whose language server you don't have.
    machine.  ``flycheck-eglot-mode`` is the way to get LSP diagnostics for a
    remote file: Eglot runs the server on the right host.
 
+Preferring a server over a command checker
+------------------------------------------
+
+A command checker spawns its linter afresh on every check.  Where the linter
+ships its own server, Flycheck can use that instead, so the linter stays
+resident and lints incrementally:
+
+.. code-block:: elisp
+
+   (setq flycheck-lsp-prefer-server t)
+
+.. defcustom:: flycheck-lsp-prefer-server
+
+   Whether automatic checker selection uses a linter's resident server in
+   place of its command checker.  ``nil`` by default, so nothing changes.
+   With ``t`` it applies wherever a resident equivalent is configured and
+   installed; with a list of checker symbols it applies only to those, which
+   also makes it usable as a directory-local for one project.
+
+   A checker chosen with `flycheck-select-checker`, or set as a file-local
+   ``flycheck-checker``, is never substituted, and neither is a buffer on a
+   remote host.  Type :kbd:`C-c ! v` to see which server superseded which
+   checker.
+
+.. defcustom:: flycheck-lsp-checker-servers
+
+   Which resident server stands in for which command checker.  The
+   substitution happens only where this agrees with what
+   ``flycheck-lsp-servers`` configures for the buffer's major mode, so
+   pointing a mode at a different linter's server turns the substitution off
+   for that checker rather than quietly reporting another linter's
+   diagnostics under the first one's name.
+
+The server reads its own configuration file rather than Flycheck's options,
+so the ``flycheck-rubocop-*`` variables and their like configure the command
+checker and not the server, and the diagnostics can differ.
+
 Which LSP integration should I use?
 -----------------------------------
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -256,7 +256,8 @@
     yaml-yamllint
     ;; Only ever selected when `flycheck-eglot-mode' is on (see its predicate).
     eglot-check
-    ;; Only ever selected when `flycheck-lsp-mode' is on (see its predicate).
+    ;; Selected when `flycheck-lsp-mode' is on, or when
+    ;; `flycheck-lsp-prefer-server' stands it in for a command checker.
     flycheck-lsp)
   "Syntax checkers available for automatic selection.
 
@@ -3534,7 +3535,10 @@ nil otherwise."
   (if flycheck-checker
       (when (flycheck-may-use-checker flycheck-checker)
         flycheck-checker)
-    (seq-find #'flycheck-may-use-checker flycheck-checkers)))
+    (when-let* ((checker (seq-find #'flycheck-may-use-checker
+                                   flycheck-checkers)))
+      ;; Only here, so a checker the user selected is never stood in for.
+      (or (flycheck-lsp--substitute checker) checker))))
 
 (defun flycheck-get-next-checker-for-buffer (checker)
   "Get the checker to run after CHECKER for the current buffer.
@@ -12112,6 +12116,59 @@ stored in `flycheck-lsp's chain, not per buffer."
   :group 'flycheck
   :package-version '(flycheck . "38"))
 
+(defcustom flycheck-lsp-checker-servers
+  '((ruby-rubocop "rubocop" "--lsp")
+    (python-ruff "ruff" "server"))
+  "Alist mapping a command checker to the server that supersedes it.
+
+Each entry is (CHECKER PROGRAM ARG...): the resident server that lints
+what CHECKER lints.  Consulted only when `flycheck-lsp-prefer-server'
+asks for the substitution, and only where it agrees with what
+`flycheck-lsp-servers' configures for the buffer's major mode: a mode
+pointed at another linter's server is left alone, so the substitution
+never quietly swaps one linter for a different one."
+  :type '(alist :key-type (symbol :tag "Checker")
+                :value-type (repeat :tag "Server command" string))
+  :group 'flycheck
+  :package-version '(flycheck . "40"))
+
+(defcustom flycheck-lsp-prefer-server nil
+  "Whether to prefer a linter's resident server over its command checker.
+
+With nil, the default, nothing changes: automatic selection picks the
+first usable checker from `flycheck-checkers', and a language server is
+used only where `flycheck-lsp-mode' is on.
+
+With t, automatic selection uses `flycheck-lsp' in place of a command
+checker that `flycheck-lsp-checker-servers' names a resident equivalent
+for, when `flycheck-lsp-servers' points the buffer's major mode at that
+same program and it is installed.  A command checker spawns its linter
+afresh on every check; the server stays resident and lints
+incrementally, which is markedly faster for a linter slow to start.
+
+With a list of checker symbols only those are substituted, so the
+preference can be turned on for one language, or for one project
+through a directory-local value.
+
+A checker chosen with \\[flycheck-select-checker], or set as a
+file-local `flycheck-checker', is never substituted, and neither is a
+buffer on a remote host, which the native client declines.
+
+The server reads its own configuration file rather than Flycheck's
+options, so `flycheck-rubocop-except' and its like configure the
+command checker and not the server, and the diagnostics may differ.
+\\[flycheck-verify-setup] reports which server superseded which
+checker."
+  :type '(choice (const :tag "Never prefer a server" nil)
+                 (const :tag "Whenever a resident equivalent is available" t)
+                 (repeat :tag "Only for these checkers"
+                         (symbol :tag "Checker")))
+  :safe (lambda (value) (or (booleanp value) (flycheck-symbol-list-p value)))
+  :group 'flycheck
+  :package-version '(flycheck . "40"))
+
+
+
 (defcustom flycheck-lsp-initialize-timeout 5
   "Seconds to wait for a language server to answer `initialize'.
 
@@ -12206,6 +12263,67 @@ and the `flycheck-lsp' checker's predicate calls this on every check."
                          command))))
       (setq-local flycheck-lsp--command-cache (cons mode result))
       result)))
+
+(defun flycheck-lsp--same-program-p (program command)
+  "Return non-nil when COMMAND runs PROGRAM.
+
+Compares base names, and looks at every word of COMMAND, so a server
+named by an absolute path or run through a wrapper, as `bundle exec
+rubocop --lsp' does, still counts as the program it runs."
+  (let ((want (file-name-nondirectory program)))
+    (seq-some (lambda (word) (equal (file-name-nondirectory word) want))
+              command)))
+
+(defun flycheck-lsp--superseding-server (checker)
+  "Return the server command that supersedes CHECKER here, or nil.
+
+Only when `flycheck-lsp-prefer-server' asks for CHECKER, and only when
+the server `flycheck-lsp-servers' configures for this buffer's major
+mode is the same program `flycheck-lsp-checker-servers' names for
+CHECKER.  A mode pointed at a different linter's server is left alone,
+so this never stands one linter in for another."
+  (and (pcase flycheck-lsp-prefer-server
+         ('nil nil)
+         ('t t)
+         ((pred listp) (memq checker flycheck-lsp-prefer-server))
+         ;; Anything else is a mistake; refuse rather than read it as t
+         ;; and turn the preference on for the whole catalog.
+         (_ nil))
+       (when-let* ((want (alist-get checker flycheck-lsp-checker-servers))
+                   (have (flycheck-lsp--available-command major-mode))
+                   ((flycheck-lsp--same-program-p (car want) have)))
+         have)))
+
+(defun flycheck-lsp--preferred-p ()
+  "Return non-nil when the preference would use a server in this buffer.
+
+Derived rather than remembered, so turning `flycheck-lsp-prefer-server'
+off takes effect at once and no buffer is left flagged."
+  (seq-some #'flycheck-lsp--superseding-server
+            (mapcar #'car flycheck-lsp-checker-servers)))
+
+(defun flycheck-lsp--substitute (checker)
+  "Return `flycheck-lsp' when it supersedes CHECKER here, else nil.
+
+Called on the checker automatic selection picked, never on one the user
+selected, so a deliberate choice is left alone."
+  (and (not (eq checker 'flycheck-lsp))
+       ;; Removing it from the registry is how a checker is dropped from
+       ;; automatic selection; that has to hold here too.
+       (memq 'flycheck-lsp flycheck-checkers)
+       (flycheck-lsp--superseding-server checker)
+       (progn
+         ;; Only the minor mode registers the mode otherwise.  Guarded:
+         ;; `flycheck-add-mode' is a bare push, and this runs on every
+         ;; check.
+         (unless (flycheck-checker-supports-major-mode-p 'flycheck-lsp
+                                                         major-mode)
+           (flycheck-add-mode 'flycheck-lsp major-mode))
+         ;; Ask the same question as any other candidate, so a disabled
+         ;; `flycheck-lsp' stays disabled and the buffer-file-name and
+         ;; remote guards live in one place.
+         (flycheck-may-use-checker 'flycheck-lsp))
+       'flycheck-lsp))
 
 (defun flycheck-lsp--language-id (mode)
   "Return a best-effort LSP languageId string for major MODE."
@@ -12833,6 +12951,13 @@ While the server is still finishing its asynchronous `initialize'
 handshake, report nothing and leave the document registered: the
 handshake's completion re-triggers the check (see
 `flycheck-lsp--on-initialized')."
+  ;; `flycheck-lsp-mode' is not the only way a buffer gets a document
+  ;; now: `flycheck-lsp-prefer-server' brings one here without the mode.
+  ;; Both of these are the mode's doing otherwise, and a buffer that skips
+  ;; them leaks its document and writes the recheck guard globally.
+  (add-hook 'kill-buffer-hook #'flycheck-lsp--close-buffer nil 'local)
+  (unless (local-variable-p 'flycheck-lsp--suppress-recheck)
+    (setq-local flycheck-lsp--suppress-recheck flycheck-lsp--suppress-recheck))
   (condition-case err
       (let* ((command (flycheck-lsp--command major-mode))
              (uri (flycheck-lsp--buffer-uri))
@@ -12865,30 +12990,53 @@ handshake's completion re-triggers the check (see
 (defun flycheck-lsp--enabled-p ()
   "Return non-nil when the `flycheck-lsp' checker may run in the current buffer.
 
-That is, `flycheck-lsp-mode' is on, the buffer visits a local file, and
-its major mode has a server in `flycheck-lsp-servers' whose program is
-installed.  Used as the checker's predicate so `flycheck-lsp' is never selected
-unless the mode opted in and the server is actually available.
+That is, `flycheck-lsp-mode' is on or `flycheck-lsp-prefer-server' stands
+this checker in for a command checker, the buffer visits a local file,
+and its major mode has a server in `flycheck-lsp-servers' whose program
+is installed.  Used as the checker's predicate, so `flycheck-lsp' is
+never selected unless something opted in and the server is available.
 
 A file on a remote host is declined.  The server would be looked for on
 that host but started on this one, so a buffer checked that way is
 served by whatever local program happens to share the name, reading file
 names that mean nothing to it.  Command checkers do run over TRAMP, and
 the buffer falls through to them."
-  (and (bound-and-true-p flycheck-lsp-mode)
+  (and (or (bound-and-true-p flycheck-lsp-mode)
+           (flycheck-lsp--preferred-p))
        buffer-file-name
        (not (file-remote-p default-directory))
        (flycheck-lsp--available-command major-mode)
        t))
+
+(defun flycheck-lsp--verify (_checker)
+  "Report how `flycheck-lsp' came to be used in this buffer."
+  (let ((command (flycheck-lsp--available-command major-mode)))
+    (cons (flycheck-verification-result-new
+           :label "server"
+           :message (if command
+                        (mapconcat #'identity command " ")
+                      "none configured for this mode")
+           :face (if command 'success '(bold warning)))
+          (when-let* ((superseded (seq-find #'flycheck-lsp--superseding-server
+                                            flycheck-checkers)))
+            ;; Say why the command checker stopped running, or the
+            ;; substitution looks like the linter broke.
+            (list (flycheck-verification-result-new
+                   :label "supersedes"
+                   :message (format "%s, see `flycheck-lsp-prefer-server'"
+                                    superseded)
+                   :face 'success))))))
 
 (flycheck-define-generic-checker 'flycheck-lsp
   "Report the diagnostics of a Language Server Protocol server.
 
 Talks to the server configured for the buffer's major mode in
 `flycheck-lsp-servers' directly, over the built-in `jsonrpc' library, with
-no Eglot involved.  Enabled by `flycheck-lsp-mode'."
+no Eglot involved.  Enabled by `flycheck-lsp-mode', or used in place of
+a command checker by `flycheck-lsp-prefer-server'."
   :start #'flycheck-lsp--start
   :predicate #'flycheck-lsp--enabled-p
+  :verify #'flycheck-lsp--verify
   :modes '(prog-mode text-mode))
 
 (defun flycheck--lsp-server-gone ()

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -819,6 +819,197 @@
         (expect (flycheck-valid-checker-p 'flycheck-lsp) :to-be-truthy)
         (expect (flycheck-checker-get 'flycheck-lsp 'start) :to-be #'flycheck-lsp--start))
 
+      (describe "preferring a resident server"
+
+        ;; A command checker spawns its linter afresh on every check; the
+        ;; linter's own server stays resident.  The substitution happens
+        ;; only where automatic selection chose the superseded checker.
+
+        ;; Registering the mode mutates a property shared by every
+        ;; buffer, so put it back rather than leaving it for later specs.
+        (before-each
+          (setq flycheck-test--lsp-modes
+                (flycheck-checker-get 'flycheck-lsp 'modes)))
+        (after-each
+          (setf (flycheck-checker-get 'flycheck-lsp 'modes)
+                flycheck-test--lsp-modes))
+
+        (defvar flycheck-test--lsp-modes nil)
+
+        (defun flycheck-test--preferred-checker (&rest bindings)
+          "Return the checker chosen in a Ruby buffer under BINDINGS."
+          (let ((dir (file-name-as-directory
+                      (make-temp-file "flycheck-prefer" t))))
+            (unwind-protect
+                (with-temp-buffer
+                  (delay-mode-hooks (ruby-mode))
+                  (setq buffer-file-name (expand-file-name "a.rb" dir)
+                        default-directory dir)
+                  (let ((flycheck-executable-find
+                         (if (plist-member bindings :find)
+                             (plist-get bindings :find)
+                           #'identity))
+                        (flycheck-checkers
+                         (or (plist-get bindings :checkers)
+                             '(ruby-rubocop flycheck-lsp)))
+                        (flycheck-disabled-checkers
+                         (plist-get bindings :disabled))
+                        (flycheck-lsp-servers
+                         (or (plist-get bindings :servers)
+                             flycheck-lsp-servers))
+                        (flycheck-lsp-checker-servers
+                         (or (plist-get bindings :checker-servers)
+                             flycheck-lsp-checker-servers)))
+                    (if (plist-member bindings :prefer)
+                        (let ((flycheck-lsp-prefer-server
+                               (plist-get bindings :prefer))
+                              (flycheck-checker (plist-get bindings :selected)))
+                          (flycheck-get-checker-for-buffer))
+                      ;; No binding at all, so the default is under test.
+                      (flycheck-get-checker-for-buffer))))
+              (delete-directory dir t))))
+
+        (it "leaves the command checker alone out of the box"
+          ;; Deliberately does not bind the option: the default is what
+          ;; ships, and flipping it must fail this.
+          (expect (default-value 'flycheck-lsp-prefer-server) :to-be nil)
+          (expect (flycheck-test--preferred-checker) :to-be 'ruby-rubocop))
+
+        (it "uses the server when asked to, and it is usable"
+          (let ((dir (file-name-as-directory
+                      (make-temp-file "flycheck-prefer" t))))
+            (unwind-protect
+                (with-temp-buffer
+                  (delay-mode-hooks (ruby-mode))
+                  (setq buffer-file-name (expand-file-name "a.rb" dir)
+                        default-directory dir)
+                  (let ((flycheck-executable-find #'identity)
+                        (flycheck-checkers '(ruby-rubocop flycheck-lsp))
+                        (flycheck-lsp-prefer-server t))
+                    (expect (flycheck-get-checker-for-buffer)
+                            :to-be 'flycheck-lsp)
+                    ;; Returning the symbol is not enough: selection has
+                    ;; always yielded a checker that may actually run.
+                    (expect (flycheck-may-use-checker 'flycheck-lsp)
+                            :to-be-truthy)
+                    ;; Which is the predicate's second reason, not the mode.
+                    (expect (bound-and-true-p flycheck-lsp-mode) :to-be nil)
+                    (expect (flycheck-lsp--preferred-p) :to-be-truthy)))
+              (delete-directory dir t))))
+
+        (it "honours a list of checkers"
+          (expect (flycheck-test--preferred-checker :prefer '(ruby-rubocop))
+                  :to-be 'flycheck-lsp)
+          (expect (flycheck-test--preferred-checker :prefer '(python-ruff))
+                  :to-be 'ruby-rubocop))
+
+        (it "does not stand one linter in for another"
+          ;; The manual tells people to point a mode at standardrb's
+          ;; server.  Substituting RuboCop's checker with it would report
+          ;; a different linter's diagnostics under RuboCop's name.
+          (expect (flycheck-test--preferred-checker
+                   :prefer t :servers '((ruby-mode "standardrb" "--lsp")))
+                  :to-be 'ruby-rubocop))
+
+        (it "sees through a wrapper and an absolute path"
+          ;; `bundle exec rubocop --lsp' is how Ruby projects run it.
+          (expect (flycheck-test--preferred-checker
+                   :prefer t
+                   :servers '((ruby-mode "bundle" "exec" "rubocop" "--lsp")))
+                  :to-be 'flycheck-lsp)
+          (expect (flycheck-test--preferred-checker
+                   :prefer t
+                   :servers '((ruby-mode "/opt/rubocop" "--lsp")))
+                  :to-be 'flycheck-lsp))
+
+        (it "never overrides a checker the user selected"
+          (expect (flycheck-test--preferred-checker
+                   :prefer t :selected 'ruby-rubocop)
+                  :to-be 'ruby-rubocop))
+
+        (it "leaves a remote buffer to the command checkers"
+          ;; The native client declines those, so standing in for a
+          ;; checker that does run there would lose the check.  Asks the
+          ;; substitution directly: running the whole of selection would
+          ;; have the command checker reach for the host.
+          (with-temp-buffer
+            (delay-mode-hooks (ruby-mode))
+            (setq buffer-file-name "/ssh:host:/proj/a.rb"
+                  default-directory "/ssh:host:/proj/")
+            (let ((flycheck-executable-find #'identity)
+                  (flycheck-checkers '(ruby-rubocop flycheck-lsp))
+                  (flycheck-lsp-prefer-server t))
+              ;; The preference is active here, and the predicate still
+              ;; says no because the buffer is remote.
+              (expect (flycheck-lsp--preferred-p) :to-be-truthy)
+              (expect (flycheck-lsp--enabled-p) :to-be nil))))
+
+        (it "respects disabling and unregistering the checker"
+          (expect (flycheck-test--preferred-checker
+                   :prefer t :disabled '(flycheck-lsp))
+                  :to-be 'ruby-rubocop)
+          (expect (flycheck-test--preferred-checker
+                   :prefer t :checkers '(ruby-rubocop))
+                  :to-be 'ruby-rubocop))
+
+        (it "refuses a malformed value instead of reading it as t"
+          ;; `ruby-rubocop' rather than `(ruby-rubocop)' is the likely
+          ;; typo, and must not turn the preference on for everything.
+          (expect (flycheck-test--preferred-checker :prefer 'ruby-rubocop)
+                  :to-be 'ruby-rubocop))
+
+        (it "declines when the server program is not installed"
+          ;; Only the server is missing: the command checker's own
+          ;; executable is still found, so it stays selectable.
+          (expect (flycheck-test--preferred-checker
+                   :prefer t
+                   :servers '((ruby-mode "absent-server" "--lsp"))
+                   :checker-servers '((ruby-rubocop "absent-server" "--lsp"))
+                   :find (lambda (x) (unless (equal x "absent-server") x)))
+                  :to-be 'ruby-rubocop))
+
+        (it "registers the mode once, however often it is asked"
+          ;; `flycheck-add-mode' is a bare push and this runs on every
+          ;; check, so an unguarded call grows a global list without end.
+          (let ((dir (file-name-as-directory
+                      (make-temp-file "flycheck-prefer" t))))
+            (unwind-protect
+                (with-temp-buffer
+                  (delay-mode-hooks (ruby-mode))
+                  (setq buffer-file-name (expand-file-name "a.rb" dir)
+                        default-directory dir)
+                  (let ((flycheck-executable-find #'identity)
+                        (flycheck-checkers '(ruby-rubocop flycheck-lsp))
+                        (flycheck-lsp-prefer-server t))
+                    (dotimes (_ 5) (flycheck-get-checker-for-buffer))
+                    (expect (seq-count (lambda (m) (eq m 'ruby-mode))
+                                       (flycheck-checker-get 'flycheck-lsp
+                                                             'modes))
+                            :to-equal 1)))
+              (delete-directory dir t))))
+
+        (it "stops substituting as soon as the option goes off"
+          ;; Nothing is remembered per buffer, so a buffer that used a
+          ;; server is not left flagged.
+          (let ((dir (file-name-as-directory
+                      (make-temp-file "flycheck-prefer" t))))
+            (unwind-protect
+                (with-temp-buffer
+                  (delay-mode-hooks (ruby-mode))
+                  (setq buffer-file-name (expand-file-name "a.rb" dir)
+                        default-directory dir)
+                  (let ((flycheck-executable-find #'identity)
+                        (flycheck-checkers '(ruby-rubocop flycheck-lsp)))
+                    (let ((flycheck-lsp-prefer-server t))
+                      (expect (flycheck-get-checker-for-buffer)
+                              :to-be 'flycheck-lsp))
+                    (let ((flycheck-lsp-prefer-server nil))
+                      (expect (flycheck-get-checker-for-buffer)
+                              :to-be 'ruby-rubocop)
+                      (expect (flycheck-may-use-checker 'flycheck-lsp)
+                              :to-be nil))))
+              (delete-directory dir t)))))
+
       (it "declines a remote buffer"
         ;; The server is looked for on the remote host but would be
         ;; started on this one, so the buffer must fall through to the


### PR DESCRIPTION
A command checker spawns its linter afresh on every check. Where the linter ships its own LSP server, that server stays resident and lints incrementally. The manual has recommended preferring those for a while without offering any way to get it: you had to turn `flycheck-lsp-mode` on, and the bridge then wrote `flycheck-checker` behind your back.

`flycheck-lsp-prefer-server` (nil by default, `t`, or a list of checkers) asks automatic selection to use `flycheck-lsp` in place of a command checker that `flycheck-lsp-checker-servers` names a resident equivalent for. RuboCop and Ruff ship in that table; I checked both really do speak LSP, and that they differ, `rubocop --lsp` pushing diagnostics while `ruff server` advertises a `diagnosticProvider`.

Three things keep it honest. It substitutes only in the automatic branch of `flycheck-get-checker-for-buffer`, so a checker you chose is never stood in for, and it asks `flycheck-may-use-checker` like any other candidate, so disabling `flycheck-lsp` or dropping it from `flycheck-checkers` still works. It substitutes only where the server configured for the mode runs the *same program* the table names, because the manual tells people to point `ruby-mode` at standardrb's server and without that check a RuboCop buffer would be linted by standardrb and still say `rubocop`; matching is by base name across the whole command, so `bundle exec rubocop --lsp` counts. And nothing is remembered per buffer, so turning the option off takes effect at once.

Two things I did not do, both fine for a first slice but worth knowing. The displaced checker's chain is dropped, so `flycheck-lsp-exclusive` has no effect on this path. And a substituted buffer's server does not contribute to the project-wide error list the way a `flycheck-lsp-mode` buffer's does.

Worth your call rather than mine: the server reads its own config file, so the `flycheck-rubocop-*` options configure the command checker and not the server, and diagnostics can differ. `C-c ! v` names the substitution, but there's no warning beyond that. And the option is `:safe`, so a repo can turn it on through directory-locals and start a subprocess.