### PR TITLE
Show the language servers, and let them be stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### New Features
 
+- [#2381](https://github.com/flycheck/flycheck/pull/2381): New commands `flycheck-lsp-list-servers`, `flycheck-lsp-restart-server` and `flycheck-lsp-shutdown-servers` show the language servers Flycheck is running and stop them, which previously took restarting Emacs.
 - [#2380](https://github.com/flycheck/flycheck/pull/2380): New `flycheck-lsp-prefer-server` option: automatic checker selection can use a linter's own resident LSP server in place of the command checker that spawns it afresh on every check, for the linters `flycheck-lsp-checker-servers` names.
 - [#2364](https://github.com/flycheck/flycheck/pull/2364): The native `flycheck-lsp` client speaks the pull model of LSP 3.17: a server offering a `diagnosticProvider` is asked for each document's diagnostics, and `flycheck-check-project` asks servers covering their workspace for the diagnostics of every file in it, visited or not.
 - [#2362](https://github.com/flycheck/flycheck/pull/2362): New project checkers `cargo-check` and `mypy-project` check a whole Rust workspace or mypy-configured Python project at once via `flycheck-check-project`, reporting through `rust-cargo` and `python-mypy` so identical findings collapse against buffer checks.

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -371,6 +371,30 @@ The server reads its own configuration file rather than Flycheck's options,
 so the ``flycheck-rubocop-*`` variables and their like configure the command
 checker and not the server, and the diagnostics can differ.
 
+Seeing and stopping the servers
+-------------------------------
+
+Flycheck keeps a server for the rest of the session, one per project root and
+command, so a project you visited hours ago may still have one running:
+
+.. define-key:: M-x flycheck-lsp-list-servers
+
+   List the running servers: the project each serves, its command, whether it
+   is still live, how many documents it holds and how many of those a live
+   buffer still owns.
+
+.. define-key:: M-x flycheck-lsp-restart-server
+
+   Shut down the server serving this buffer and forget it, so the next check
+   starts a fresh one.  Without this a server that has wedged can only be
+   cleared by restarting Emacs, since a server outlives its buffers and
+   survives ``flycheck-lsp-mode`` being turned off.
+
+.. define-key:: M-x flycheck-lsp-shutdown-servers
+
+   Shut down this project's servers, or every running one with a prefix
+   argument.
+
 Which LSP integration should I use?
 -----------------------------------
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -13096,13 +13096,138 @@ files does not pay to restart it."
                                    (list :textDocument (list :uri uri)))))))
      flycheck-lsp--servers)))
 
+(defun flycheck-lsp--forget-server (key server)
+  "Drop SERVER, registered under KEY, and shut it down.
+
+Dropped first: shutting down pumps process output, and a diagnostics
+push arriving then can re-trigger a check that registers a fresh server
+under the same key.  Removing afterwards would delete that one instead,
+leaving its process running and unreachable."
+  (remhash key flycheck-lsp--servers)
+  (flycheck-lsp--shutdown-server server))
+
+(defun flycheck-lsp--server-buffer-count (server)
+  "Return how many of SERVER's documents a live buffer still owns.
+
+Not the size of the table: a workspace pull registers a document for
+every file it reports on, including files no buffer visits."
+  (let ((count 0))
+    (maphash (lambda (_key doc)
+               (when (buffer-live-p (flycheck-lsp--doc-buffer doc))
+                 (setq count (1+ count))))
+             (flycheck-lsp--server-documents server))
+    count))
+
+(defun flycheck-lsp--server-for-buffer ()
+  "Return the registry key of the server serving the current buffer.
+
+The key `flycheck-lsp--start' would build, so this names the server that
+actually checks this buffer.  Project roots nest, and a workspace pull
+registers a document for every file it reports on, so several servers
+can hold the same document and the one holding it is not necessarily the
+one serving it."
+  (when-let* ((command (flycheck-lsp--command major-mode))
+              (key (cons (flycheck-lsp--root) command))
+              ((gethash key flycheck-lsp--servers)))
+    key))
+
+(defun flycheck-lsp-restart-server ()
+  "Shut down the language server serving this buffer and forget it.
+
+The next check starts a fresh one.  Without this a server that has wedged
+can only be cleared by restarting Emacs, since a server outlives the
+buffers it serves and even `flycheck-lsp-mode' being turned off."
+  (interactive)
+  (let* ((key (or (flycheck-lsp--server-for-buffer)
+                  (user-error "No language server is serving this buffer")))
+         (server (gethash key flycheck-lsp--servers)))
+    (flycheck-lsp--forget-server key server)
+    (if flycheck-mode
+        (progn (message "Shut %s down; the next check starts it again"
+                        (car (flycheck-lsp--server-command server)))
+               (flycheck-buffer-deferred))
+      (message "Shut %s down" (car (flycheck-lsp--server-command server))))))
+
+(defun flycheck-lsp-shutdown-servers (&optional all)
+  "Shut down the language servers of this buffer's project.
+
+With prefix argument ALL, shut down every running server instead."
+  (interactive "P")
+  (let ((root (and (not all)
+                   ;; A remote buffer has no server, and asking for its
+                   ;; project would reach for the host.
+                   (not (file-remote-p default-directory))
+                   (file-name-as-directory
+                    (expand-file-name (flycheck-lsp--root)))))
+        (count 0))
+    ;; Over a snapshot: shutting a server down pumps process output, and
+    ;; a check triggered by that can register a server mid-iteration.
+    (dolist (key (hash-table-keys flycheck-lsp--servers))
+      (when-let* ((server (gethash key flycheck-lsp--servers)))
+        (when (or all
+                  (and root
+                       (string-prefix-p
+                        root (file-name-as-directory
+                              (expand-file-name
+                               (flycheck-lsp--server-root server))))))
+          (flycheck-lsp--forget-server key server)
+          (setq count (1+ count)))))
+    (message "Shut down %d language server%s" count
+             (if (= count 1) "" "s"))))
+
+(defun flycheck-lsp--server-list-entries ()
+  "Return `tabulated-list-entries' for the running servers."
+  (let (entries)
+    (maphash
+     (lambda (key server)
+       (push (list key
+                   (vector (abbreviate-file-name
+                            (flycheck-lsp--server-root server))
+                           (string-join (flycheck-lsp--server-command server)
+                                        " ")
+                           (if (flycheck-lsp--server-live-p server)
+                               "live" "dead")
+                           (number-to-string
+                            (hash-table-count
+                             (flycheck-lsp--server-documents server)))
+                           (number-to-string
+                            (flycheck-lsp--server-buffer-count server))))
+             entries))
+     flycheck-lsp--servers)
+    (nreverse entries)))
+
+(define-derived-mode flycheck-lsp-server-list-mode tabulated-list-mode
+  "Flycheck LSP servers"
+  "Major mode listing the language servers Flycheck is running."
+  (setq tabulated-list-format [("Project" 30 t)
+                               ("Command" 28 t)
+                               ("State" 6 t)
+                               ("Docs" 5 t)
+                               ("Buffers" 7 t)]
+        tabulated-list-sort-key '("Project" . nil)
+        tabulated-list-entries #'flycheck-lsp--server-list-entries)
+  (tabulated-list-init-header))
+
+(defun flycheck-lsp-list-servers ()
+  "List the language servers Flycheck is running.
+
+A server is kept for the rest of the session, so this is the way to see
+what is running, how many documents each holds, and how many of those a
+live buffer still owns."
+  (interactive)
+  (with-current-buffer (get-buffer-create "*Flycheck LSP servers*")
+    ;; Entering the mode again would discard the sort column and point.
+    (unless (derived-mode-p 'flycheck-lsp-server-list-mode)
+      (flycheck-lsp-server-list-mode))
+    (tabulated-list-print)
+    (pop-to-buffer (current-buffer))))
+
 (defun flycheck-lsp--shutdown-all ()
   "Shut down every running LSP server.
 Added to `kill-emacs-hook' the first time a server starts."
-  (maphash (lambda (key server)
-             (flycheck-lsp--shutdown-server server)
-             (remhash key flycheck-lsp--servers))
-           flycheck-lsp--servers))
+  (dolist (key (hash-table-keys flycheck-lsp--servers))
+    (when-let* ((server (gethash key flycheck-lsp--servers)))
+      (flycheck-lsp--forget-server key server))))
 
 (defun flycheck-lsp--enable ()
   "Set up the current buffer to report its LSP server's diagnostics.

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -1010,6 +1010,134 @@
                               :to-be nil))))
               (delete-directory dir t)))))
 
+      (describe "listing and stopping servers"
+
+        ;; A server outlives the buffers it serves and even the mode
+        ;; being turned off, so without these a wedged one can only be
+        ;; cleared by restarting Emacs.
+
+        (defun flycheck-test--fake-server (root command &rest buffers)
+          "Register a server for ROOT running COMMAND holding BUFFERS.
+A nil in BUFFERS stands for a document no buffer visits, as a
+workspace pull leaves behind."
+          (let ((server (flycheck-lsp--server-create
+                         :root root :command command))
+                (n 0))
+            (dolist (buffer buffers)
+              (puthash (format "/doc%d" (setq n (1+ n)))
+                       (flycheck-lsp--doc-create :buffer buffer)
+                       (flycheck-lsp--server-documents server)))
+            (puthash (cons root command) server flycheck-lsp--servers)
+            server))
+
+        (after-each (clrhash flycheck-lsp--servers))
+
+        (it "counts only the documents a live buffer still owns"
+          ;; A workspace pull registers a document per reported file, so
+          ;; the table size is not the number of buffers.
+          (let* ((buffer (generate-new-buffer "held"))
+                 (server (flycheck-test--fake-server
+                          "/proj/" '("rubocop" "--lsp") buffer nil)))
+            (expect (hash-table-count (flycheck-lsp--server-documents server))
+                    :to-equal 2)
+            (expect (flycheck-lsp--server-buffer-count server) :to-equal 1)
+            (kill-buffer buffer)
+            (expect (flycheck-lsp--server-buffer-count server) :to-equal 0)))
+
+        (it "lists what is running, documents apart from buffers"
+          (let ((buffer (generate-new-buffer "held")))
+            (unwind-protect
+                (progn
+                  (flycheck-test--fake-server "/proj/" '("rubocop" "--lsp")
+                                              buffer nil)
+                  (let ((entry (car (flycheck-lsp--server-list-entries))))
+                    (expect (append (cadr entry) nil)
+                            :to-equal (list (abbreviate-file-name "/proj/")
+                                            "rubocop --lsp" "dead" "2" "1"))))
+              (kill-buffer buffer))))
+
+        (it "finds the server that serves the buffer, not merely one
+holding its document"
+          ;; Roots nest, so a document can sit in several servers.  Only
+          ;; the one keyed on this buffer's root actually checks it.
+          (flycheck-test--fake-server "/p/" '("ruby-lsp"))
+          (flycheck-test--fake-server "/p/sub/" '("ruby-lsp"))
+          (flycheck-buttercup-with-temp-buffer
+            (setq buffer-file-name "/p/sub/a.rb"
+                  default-directory "/p/sub/")
+            (cl-letf (((symbol-function 'flycheck-lsp--root) (lambda () "/p/sub/"))
+                      ((symbol-function 'flycheck-lsp--command)
+                       (lambda (_mode) '("ruby-lsp"))))
+              (expect (flycheck-lsp--server-for-buffer)
+                      :to-equal '("/p/sub/" "ruby-lsp")))))
+
+        (it "shuts the buffer's server down and asks for a fresh check"
+          (let ((stopped nil))
+            (spy-on 'flycheck-lsp--shutdown-server
+                    :and-call-fake (lambda (s) (push s stopped)))
+            (spy-on 'flycheck-buffer-deferred)
+            (flycheck-test--fake-server "/p/" '("ruby-lsp"))
+            (flycheck-buttercup-with-temp-buffer
+              (setq buffer-file-name "/p/a.rb" default-directory "/p/")
+              (cl-letf (((symbol-function 'flycheck-lsp--root) (lambda () "/p/"))
+                        ((symbol-function 'flycheck-lsp--command)
+                         (lambda (_mode) '("ruby-lsp"))))
+                (let ((flycheck-mode t))
+                  (flycheck-lsp-restart-server))))
+            (expect (length stopped) :to-equal 1)
+            (expect (hash-table-count flycheck-lsp--servers) :to-equal 0)
+            (expect 'flycheck-buffer-deferred :to-have-been-called)))
+
+        (it "drops a server from the registry before stopping it"
+          ;; Stopping pumps process output, and a check triggered by that
+          ;; can register a fresh server under the same key.  Removing
+          ;; afterwards would delete that one and leak its process.
+          (let ((registered-during-shutdown nil))
+            (spy-on 'flycheck-lsp--shutdown-server
+                    :and-call-fake
+                    (lambda (_server)
+                      (setq registered-during-shutdown
+                            (hash-table-count flycheck-lsp--servers))))
+            (flycheck-test--fake-server "/p/" '("ruby-lsp"))
+            (flycheck-lsp-shutdown-servers 'all)
+            (expect registered-during-shutdown :to-equal 0)))
+
+        (it "shuts down this project's servers, or all of them"
+          (spy-on 'flycheck-lsp--shutdown-server)
+          (flycheck-test--fake-server "/a/" '("rubocop" "--lsp"))
+          (flycheck-test--fake-server "/a/nested/" '("ruff" "server"))
+          (flycheck-test--fake-server "/b/" '("ruff" "server"))
+          (flycheck-buttercup-with-temp-buffer
+            (setq default-directory "/a/")
+            (cl-letf (((symbol-function 'flycheck-lsp--root) (lambda () "/a/")))
+              (flycheck-lsp-shutdown-servers)))
+          ;; The nested root belongs to this project too.
+          (expect 'flycheck-lsp--shutdown-server :to-have-been-called-times 2)
+          (expect (hash-table-count flycheck-lsp--servers) :to-equal 1)
+          (flycheck-lsp-shutdown-servers 'all)
+          (expect (hash-table-count flycheck-lsp--servers) :to-equal 0))
+
+        (it "refuses to restart when no server serves the buffer"
+          ;; A server exists, but not for this buffer.
+          (flycheck-test--fake-server "/other/" '("ruby-lsp"))
+          (flycheck-buttercup-with-temp-buffer
+            (setq buffer-file-name "/p/a.rb" default-directory "/p/")
+            (cl-letf (((symbol-function 'flycheck-lsp--root) (lambda () "/p/"))
+                      ((symbol-function 'flycheck-lsp--command)
+                       (lambda (_mode) '("ruby-lsp"))))
+              (expect (flycheck-lsp-restart-server) :to-throw 'user-error))))
+
+        (it "prints a list buffer with a row per server"
+          (flycheck-test--fake-server "/p/" '("ruby-lsp"))
+          (unwind-protect
+              (progn
+                (flycheck-lsp-list-servers)
+                (with-current-buffer "*Flycheck LSP servers*"
+                  (expect (derived-mode-p 'flycheck-lsp-server-list-mode)
+                          :to-be-truthy)
+                  (expect (buffer-string) :to-match "ruby-lsp")))
+            (kill-buffer "*Flycheck LSP servers*"))))
+
       (it "declines a remote buffer"
         ;; The server is looked for on the remote host but would be
         ;; started on this one, so the buffer must fall through to the


### PR DESCRIPTION
Flycheck keeps a language server for the rest of the session, one per project root and command. It outlives the buffers it serves and survives `flycheck-lsp-mode` being turned off, and nothing showed what was running: a server that wedged could only be cleared by restarting Emacs. #2380 makes that sharper, since a buffer can now acquire a server without the user turning any mode on.

`flycheck-lsp-list-servers` shows each server's project, command, whether it is live, and how many documents it holds against how many a live buffer still owns. Those are deliberately two numbers: a workspace pull registers a document for every file it reports on, so the table size is not a buffer count. `flycheck-lsp-restart-server` drops the one serving this buffer and `flycheck-lsp-shutdown-servers` drops the project's, or all with a prefix argument.

Two things I got wrong first time and are worth knowing about. Both commands name the server by the key a check would build rather than searching for one holding the buffer's document, because project roots nest and several servers can hold the same document while only one checks it. And a server is dropped from the registry *before* it is stopped: shutting down pumps process output, a diagnostics push arriving then can re-trigger a check that registers a fresh server under the same key, and removing afterwards deletes that one instead, leaving its process running with nothing holding it. `flycheck-lsp--shutdown-all` had the same shape and is fixed along with it.

Verified against a real `rubocop --lsp`, not a mock: the server starts, lists with its document and buffer counts, and restart tears it down.