### PR TITLE
Say that a preferred server runs alone

### DIFF
--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -371,6 +371,11 @@ The server reads its own configuration file rather than Flycheck's options,
 so the ``flycheck-rubocop-*`` variables and their like configure the command
 checker and not the server, and the diagnostics can differ.
 
+A buffer served this way runs the server alone.  The checker it stood in for
+does not run after it, nor does that checker's chain, so a Ruby buffer linted
+by RuboCop's server does not go on to `ruby-reek`.  ``flycheck-lsp-exclusive``
+governs chaining for ``flycheck-lsp-mode`` and does not apply here.
+
 Seeing and stopping the servers
 -------------------------------
 

--- a/flycheck.el
+++ b/flycheck.el
@@ -12135,7 +12135,12 @@ To run this server behind Eglot's rather than instead of it, turn
 Eglot leads and `flycheck-lsp' follows.
 
 Note that this takes effect globally when a buffer enables the mode: it is
-stored in `flycheck-lsp's chain, not per buffer."
+stored in `flycheck-lsp's chain, not per buffer.
+
+It has no effect on a buffer served through `flycheck-lsp-prefer-server'
+rather than this mode.  Such a buffer runs the server alone: the checker
+the server stood in for is not run after it, and neither is that
+checker's chain."
   :type 'boolean
   :safe #'booleanp
   :group 'flycheck


### PR DESCRIPTION
`flycheck-lsp-exclusive` governs chaining for `flycheck-lsp-mode` and does nothing for a buffer served through `flycheck-lsp-prefer-server`, which runs the server alone: the checker it stood in for does not run after it, and neither does that checker's chain, so a Ruby buffer linted by RuboCop's server does not go on to `ruby-reek`.

That was only written down in #2380's description, which is not where anyone will look for it. Making the chain actually follow the displaced checker would mean editing `flycheck-get-next-checker-for-buffer`, which runs on every check, and it would only change anything for someone who has both the preference on and `flycheck-lsp-exclusive` off. Not worth the risk to that path for now, so the behaviour is documented instead.