### PR TITLE
Check remote files with a server on their own host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### New Features
 
+- [#2385](https://github.com/flycheck/flycheck/pull/2385): The native `flycheck-lsp` client checks a file on a remote host, starting the language server on that host over TRAMP instead of declining the buffer.
 - [#2381](https://github.com/flycheck/flycheck/pull/2381): New commands `flycheck-lsp-list-servers`, `flycheck-lsp-restart-server` and `flycheck-lsp-shutdown-servers` show the language servers Flycheck is running and stop them, which previously took restarting Emacs.
 - [#2380](https://github.com/flycheck/flycheck/pull/2380): New `flycheck-lsp-prefer-server` option: automatic checker selection can use a linter's own resident LSP server in place of the command checker that spawns it afresh on every check, for the linters `flycheck-lsp-checker-servers` names.
 - [#2364](https://github.com/flycheck/flycheck/pull/2364): The native `flycheck-lsp` client speaks the pull model of LSP 3.17: a server offering a `diagnosticProvider` is asked for each document's diagnostics, and `flycheck-check-project` asks servers covering their workspace for the diagnostics of every file in it, visited or not.

--- a/doc/user/syntax-checks.rst
+++ b/doc/user/syntax-checks.rst
@@ -328,11 +328,12 @@ whose language server you don't have.
 
 .. note::
 
-   A file on a remote host is left to the command checkers, which do run over
-   TRAMP.  The native client would look for the server on the remote host but
-   start it on this one, so it is declined rather than run against the wrong
-   machine.  ``flycheck-eglot-mode`` is the way to get LSP diagnostics for a
-   remote file: Eglot runs the server on the right host.
+   A file on a remote host is checked like a local one: the server runs on
+   that host over TRAMP, so it needs to be installed there rather than here,
+   and the diagnostics it reports open the right files.  Flycheck runs it
+   with the remote line discipline in raw mode, because the shell TRAMP runs
+   it under would otherwise translate the carriage returns that LSP framing
+   depends on.
 
 Preferring a server over a command checker
 ------------------------------------------

--- a/flycheck.el
+++ b/flycheck.el
@@ -12377,15 +12377,16 @@ the root does not change over a buffer's life."
 (defun flycheck-lsp--buffer-uri ()
   "Return the `file:' URI of the current buffer's file, or nil.
 
-A file on a remote host has none: reducing its name for the server
-would spell it exactly like the local file of that name, and the two
-buffers would then share a document.  The checker declines those
-buffers anyway, see `flycheck-lsp--enabled-p'."
-  (and buffer-file-name
-       (not (file-remote-p buffer-file-name))
-       (flycheck-lsp--path-to-uri buffer-file-name)))
+The URI names the file as the server\='s host sees it; the host itself is
+carried by the document key, see `flycheck-lsp--doc-key'."
+  (and buffer-file-name (flycheck-lsp--path-to-uri buffer-file-name)))
 
-(defun flycheck-lsp--doc-key (uri)
+(defun flycheck-lsp--server-remote (server)
+  "Return SERVER\='s remote prefix, or nil when it runs on this machine."
+  (when-let* ((root (flycheck-lsp--server-root server)))
+    (file-remote-p root)))
+
+(defun flycheck-lsp--doc-key (uri &optional remote)
   "Return the canonical key (an absolute path) for the document URI.
 
 The client and the server may spell the same file's URI differently (a
@@ -12393,10 +12394,11 @@ re-encoded percent escape, an authority component, a Windows drive
 case).  Keying open documents and their diagnostics on the decoded,
 expanded path, rather than the raw URI, makes both sides agree.
 
-URI is always a server's, and a server only ever serves files local to
-the host it runs on, so the key is a plain local path with no remote
-prefix to put back."
-  (expand-file-name (flycheck-lsp--uri-to-path uri)))
+URI is always a server's, naming the file as its own host sees it.
+REMOTE, a prefix as `file-remote-p' returns, is that host, so the key
+names the file as Emacs does: two servers on different hosts holding the
+same path get different keys, and the key opens the right file."
+  (expand-file-name (flycheck-lsp--uri-to-path uri remote)))
 
 (defun flycheck-lsp--server-live-p (server)
   "Return non-nil when SERVER's connection is still running."
@@ -12420,7 +12422,9 @@ published (guarded against recursion); a report repeating what the
 cache holds changes nothing about the buffer, and servers republish
 freely while they index.  PUSHED says the report was a push, for the
 counts `flycheck-verify-setup' shows."
-  (let ((doc (flycheck-lsp--document server (flycheck-lsp--doc-key uri))))
+  (let ((doc (flycheck-lsp--document
+              server (flycheck-lsp--doc-key
+                      uri (flycheck-lsp--server-remote server)))))
     (unless (and version
                  (flycheck-lsp--doc-version doc)
                  (not (equal version (flycheck-lsp--doc-version doc))))
@@ -12484,8 +12488,11 @@ leaves the document to be asked about again by the next check."
      :timeout flycheck-lsp--pull-timeout
      :success-fn (lambda (result)
                    (when (and (equal (plist-get result :kind) "full")
-                              (eq doc (gethash (flycheck-lsp--doc-key uri)
-                                               documents)))
+                              (eq doc (gethash
+                                       (flycheck-lsp--doc-key
+                                        uri (flycheck-lsp--server-remote
+                                             server))
+                                       documents)))
                      (flycheck-lsp--accept-diagnostics
                       server uri (plist-get result :items) version
                       (plist-get result :resultId))))
@@ -12687,7 +12694,10 @@ afresh.  The servers stay."
 
 (defun flycheck-lsp--initialize-params (root)
   "Return the LSP `initialize' params for a server rooted at ROOT."
-  (list :processId (emacs-pid)
+  (list :processId (unless (file-remote-p root) (emacs-pid))
+        ;; A server on another host cannot see our process, and some
+        ;; older ones want the path rather than the URI.
+        :rootPath (file-local-name (expand-file-name root))
         :rootUri (flycheck-lsp--path-to-uri root)
         :capabilities
         (list :textDocument
@@ -12737,6 +12747,52 @@ Remove it from the registry so a later check starts a fresh one."
   (flycheck-lsp--shutdown-server server)
   (remhash (flycheck-lsp--server-key server) flycheck-lsp--servers))
 
+(defvar tramp-use-ssh-controlmaster-options)
+(declare-function tramp-shell-quote-argument "tramp" (s))
+(defvar tramp-ssh-controlmaster-options)
+
+(defun flycheck-lsp--remote-command (command)
+  "Return COMMAND wrapped for a server started on a remote host.
+
+The shell TRAMP runs the command under translates a carriage return into
+a newline, which destroys the CRLF framing LSP headers use.  Turning the
+line discipline raw leaves the byte stream alone.  Eglot wraps remote
+servers the same way.
+
+Arguments are quoted the way a POSIX shell reads them rather than the
+way this machine\='s shell does, since that is what runs them."
+  (list "sh" "-c"
+        (concat "stty raw > /dev/null 2>&1; exec "
+                (mapconcat #'tramp-shell-quote-argument command " "))))
+
+(defun flycheck-lsp--spawn (name command stderr)
+  "Start COMMAND as process NAME with STDERR, on this host or the remote one.
+
+A remote `default-directory' needs `:file-handler', or the process runs
+here instead, against files it cannot see.  It also needs the wrapper
+`flycheck-lsp--remote-command' builds, which is what preserves the byte
+stream the LSP framing depends on."
+  (if (file-remote-p default-directory)
+      (progn
+        ;; Loaded before the bindings below: on Emacs 30 one of them is
+        ;; an obsolete alias, and `defvaralias' refuses to alias a symbol
+        ;; that is let-bound, so loading it inside would signal.
+        (require 'tramp-sh nil t)
+        (let (;; A connection carrying this much data is not what
+              ;; ControlMaster is for.  Eglot suppresses it for the same
+              ;; reason (Emacs bug#61350).  The string matters only on
+              ;; Emacs 28 and 29, where `suppress' reads as plain
+              ;; truthy.
+              (tramp-use-ssh-controlmaster-options 'suppress)
+              (tramp-ssh-controlmaster-options
+               "-o ControlMaster=no -o ControlPath=none"))
+          (make-process :name name
+                        :command (flycheck-lsp--remote-command command)
+                        :connection-type 'pipe :coding 'utf-8-emacs-unix
+                        :noquery t :stderr stderr :file-handler t)))
+    (make-process :name name :command command :connection-type 'pipe
+                  :coding 'utf-8-emacs-unix :noquery t :stderr stderr)))
+
 (defun flycheck-lsp--start-server (root command)
   "Start an LSP server running COMMAND under ROOT and initialize it.
 
@@ -12760,9 +12816,7 @@ the server down.  Return nil if the process could not be spawned at all."
         (progn
           ;; Spawned inside the handler below: a missing program signals
           ;; here, and the stderr buffer would be left behind.
-          (setq proc (make-process
-                      :name name :command command :connection-type 'pipe
-                      :coding 'utf-8-emacs-unix :noquery t :stderr stderr))
+          (setq proc (flycheck-lsp--spawn name command stderr))
           (setf (flycheck-lsp--server-connection server)
                 (make-instance
                  'jsonrpc-process-connection
@@ -12902,7 +12956,9 @@ as unavailable."
     ;; command (or a `flycheck-fix-all-errors' batch).
     (ignore-errors
       (flycheck-lsp--sync-document
-       server (flycheck-lsp--document server (flycheck-lsp--doc-key uri))
+       server (flycheck-lsp--document
+               server (flycheck-lsp--doc-key
+                       uri (flycheck-lsp--server-remote server)))
        uri (flycheck-lsp--language-id major-mode))
       (when-let* ((actions (append
                             (flycheck-lsp--request
@@ -13009,7 +13065,8 @@ handshake's completion re-triggers the check (see
             (funcall callback 'finished nil)
           (let* ((buffer (current-buffer))
                  (doc (flycheck-lsp--document
-                       server (flycheck-lsp--doc-key uri))))
+                       server (flycheck-lsp--doc-key
+                               uri (flycheck-lsp--server-remote server)))))
             (setf (flycheck-lsp--doc-buffer doc) buffer)
             (if (not (flycheck-lsp--server-initialized server))
                 (funcall callback 'finished nil)
@@ -13032,20 +13089,18 @@ handshake's completion re-triggers the check (see
   "Return non-nil when the `flycheck-lsp' checker may run in the current buffer.
 
 That is, `flycheck-lsp-mode' is on or `flycheck-lsp-prefer-server' stands
-this checker in for a command checker, the buffer visits a local file,
-and its major mode has a server in `flycheck-lsp-servers' whose program
+this checker in for a command checker, the buffer visits a file, and
+its major mode has a server in `flycheck-lsp-servers' whose program
 is installed.  Used as the checker's predicate, so `flycheck-lsp' is
 never selected unless something opted in and the server is available.
 
-A file on a remote host is declined.  The server would be looked for on
-that host but started on this one, so a buffer checked that way is
-served by whatever local program happens to share the name, reading file
-names that mean nothing to it.  Command checkers do run over TRAMP, and
-the buffer falls through to them."
+A file on a remote host is served by a server started there, over TRAMP;
+`flycheck-lsp--spawn' runs it on that host and the document keys name
+files as Emacs does, so the server needs to be installed there rather
+than here."
   (and (or (bound-and-true-p flycheck-lsp-mode)
            (flycheck-lsp--preferred-p))
        buffer-file-name
-       (not (file-remote-p default-directory))
        (flycheck-lsp--available-command major-mode)
        t))
 
@@ -13102,17 +13157,24 @@ The server itself is left running -- like Eglot, it is kept for the rest
 of the session and torn down only when Emacs exits (see
 `flycheck-lsp--shutdown-all') -- so reopening or checking another of its
 files does not pay to restart it."
-  (when-let* ((uri (flycheck-lsp--buffer-uri))
-              (key (flycheck-lsp--doc-key uri)))
-    (maphash
+  (when-let* ((uri (flycheck-lsp--buffer-uri)))
+    ;; A local buffer's host is nil, which is a value, not an absence.
+    (let* ((remote (file-remote-p buffer-file-name))
+           (key (flycheck-lsp--doc-key uri remote)))
+      (maphash
      (lambda (_server-key server)
-       (when (gethash key (flycheck-lsp--server-documents server))
-         (remhash key (flycheck-lsp--server-documents server))
-         (when (flycheck-lsp--server-live-p server)
-           (ignore-errors
-             (flycheck-lsp--notify server 'textDocument/didClose
-                                   (list :textDocument (list :uri uri)))))))
-     flycheck-lsp--servers)))
+       ;; The key carries this buffer's host, so a server elsewhere
+       ;; holding the same path for another buffer does not match and
+       ;; keeps its document.
+       (progn
+         (when (gethash key (flycheck-lsp--server-documents server))
+           (remhash key (flycheck-lsp--server-documents server))
+           (when (flycheck-lsp--server-live-p server)
+             (ignore-errors
+               (flycheck-lsp--notify server 'textDocument/didClose
+                                       (list :textDocument
+                                             (list :uri uri))))))))
+       flycheck-lsp--servers))))
 
 (defun flycheck-lsp--forget-server (key server)
   "Drop SERVER, registered under KEY, and shut it down.
@@ -13172,9 +13234,6 @@ buffers it serves and even `flycheck-lsp-mode' being turned off."
 With prefix argument ALL, shut down every running server instead."
   (interactive "P")
   (let ((root (and (not all)
-                   ;; A remote buffer has no server, and asking for its
-                   ;; project would reach for the host.
-                   (not (file-remote-p default-directory))
                    (file-name-as-directory
                     (expand-file-name (flycheck-lsp--root)))))
         (count 0))

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -955,11 +955,11 @@
                    :prefer t :selected 'ruby-rubocop)
                   :to-be 'ruby-rubocop))
 
-        (it "leaves a remote buffer to the command checkers"
-          ;; The native client declines those, so standing in for a
-          ;; checker that does run there would lose the check.  Asks the
-          ;; substitution directly: running the whole of selection would
-          ;; have the command checker reach for the host.
+        (it "serves a remote buffer too"
+          ;; The server runs on that host, so the preference applies
+          ;; there as well.  Asks the substitution directly: running the
+          ;; whole of selection would have the command checker reach for
+          ;; the host.
           (with-temp-buffer
             (delay-mode-hooks (ruby-mode))
             (setq buffer-file-name "/ssh:host:/proj/a.rb"
@@ -967,10 +967,10 @@
             (let ((flycheck-executable-find #'identity)
                   (flycheck-checkers '(ruby-rubocop flycheck-lsp))
                   (flycheck-lsp-prefer-server t))
-              ;; The preference is active here, and the predicate still
-              ;; says no because the buffer is remote.
+              ;; The preference is active here, and a remote buffer is
+              ;; served like any other now.
               (expect (flycheck-lsp--preferred-p) :to-be-truthy)
-              (expect (flycheck-lsp--enabled-p) :to-be nil))))
+              (expect (flycheck-lsp--enabled-p) :to-be-truthy))))
 
         (it "respects disabling and unregistering the checker"
           (expect (flycheck-test--preferred-checker
@@ -1166,11 +1166,111 @@ holding its document"
                   (expect (buffer-string) :to-match "ruby-lsp")))
             (kill-buffer "*Flycheck LSP servers*"))))
 
-      (it "declines a remote buffer"
-        ;; The server is looked for on the remote host but would be
-        ;; started on this one, so the buffer must fall through to the
-        ;; command checkers, which do run over TRAMP.  The local
-        ;; assertion is the control: without it a mode with no
+      (it "starts a remote server on the buffer's own host"
+        ;; Without a file handler `make-process' ignores a remote
+        ;; `default-directory' and starts here, against files the server
+        ;; cannot see.
+        (let (spawned)
+          (spy-on 'make-process :and-call-fake
+                  (lambda (&rest args) (setq spawned args) nil))
+          (let ((default-directory "/ssh:host:/srv/app/"))
+            (ignore-errors (flycheck-lsp--spawn "srv" '("rubocop" "--lsp")
+                                                (current-buffer))))
+          (expect (plist-get spawned :file-handler) :to-be t)
+          (expect (plist-get spawned :command)
+                  :to-equal (flycheck-lsp--remote-command
+                             '("rubocop" "--lsp")))))
+
+      (it "starts a local server plainly"
+        (let (spawned)
+          (spy-on 'make-process :and-call-fake
+                  (lambda (&rest args) (setq spawned args) nil))
+          (let ((default-directory "/srv/app/"))
+            (ignore-errors (flycheck-lsp--spawn "srv" '("rubocop" "--lsp")
+                                                (current-buffer))))
+          (expect (plist-get spawned :file-handler) :to-be nil)
+          (expect (plist-get spawned :command) :to-equal '("rubocop" "--lsp"))))
+
+      (it "keys a document by the host its server runs on"
+        ;; Every doc-key call site passes the server's host; if that
+        ;; stopped happening, two hosts would share one key.
+        (let* ((server (flycheck-lsp--server-create
+                        :root "/ssh:host:/srv/app/" :command '("srv")))
+               (doc (flycheck-lsp--document
+                     server (flycheck-lsp--doc-key
+                             "file:///srv/app/a.rb"
+                             (flycheck-lsp--server-remote server)))))
+          (expect (flycheck-lsp--server-remote server) :to-equal "/ssh:host:")
+          (expect (hash-table-keys (flycheck-lsp--server-documents server))
+                  :to-equal '("/ssh:host:/srv/app/a.rb"))
+          (expect doc :to-be-truthy)))
+
+      (it "closes a document only on its own host's server"
+        ;; Two hosts can hold the same path.  Closing a buffer on one
+        ;; must not tell the other to drop a file it is still serving.
+        (let ((flycheck-lsp--servers (make-hash-table :test 'equal))
+              (local (flycheck-lsp--server-create
+                      :root "/srv/app/" :command '("srv")))
+              (remote (flycheck-lsp--server-create
+                       :root "/ssh:host:/srv/app/" :command '("srv"))))
+          (flycheck-lsp--document local (flycheck-lsp--doc-key
+                                         "file:///srv/app/a.rb"))
+          (flycheck-lsp--document remote (flycheck-lsp--doc-key
+                                          "file:///srv/app/a.rb" "/ssh:host:"))
+          (puthash '("/srv/app/" "srv") local flycheck-lsp--servers)
+          (puthash '("/ssh:host:/srv/app/" "srv") remote flycheck-lsp--servers)
+          ;; Closing the local buffer leaves the remote server alone.
+          (flycheck-buttercup-with-temp-buffer
+            (setq buffer-file-name "/srv/app/a.rb")
+            (flycheck-lsp--close-buffer))
+          (expect (hash-table-count (flycheck-lsp--server-documents local))
+                  :to-equal 0)
+          (expect (hash-table-count (flycheck-lsp--server-documents remote))
+                  :to-equal 1)
+          ;; And the other way round: put the local one back, then close
+          ;; the remote buffer and check only the remote server loses it.
+          (flycheck-lsp--document local (flycheck-lsp--doc-key
+                                         "file:///srv/app/a.rb"))
+          (flycheck-buttercup-with-temp-buffer
+            (setq buffer-file-name "/ssh:host:/srv/app/a.rb")
+            (flycheck-lsp--close-buffer))
+          (expect (hash-table-count (flycheck-lsp--server-documents remote))
+                  :to-equal 0)
+          (expect (hash-table-count (flycheck-lsp--server-documents local))
+                  :to-equal 1)))
+
+      (it "wraps a remote server so the framing survives"
+        ;; TRAMP's shared shell turns a carriage return into a newline,
+        ;; and the direct methods spawn through a pty, either of which
+        ;; destroys the CRLF framing LSP headers use.
+        (expect (flycheck-lsp--remote-command '("rubocop" "--lsp"))
+                :to-equal '("sh" "-c" "stty raw > /dev/null 2>&1; exec rubocop --lsp"))
+        ;; Arguments are quoted, so a path with a space survives.
+        (expect (nth 2 (flycheck-lsp--remote-command '("srv" "a b")))
+                :to-match (regexp-quote "a\\ b")))
+
+      (it "tells a remote server nothing about our process"
+        ;; A pid on this machine means nothing on the server's host, and
+        ;; an older server may want the path rather than the URI.
+        (let ((params (flycheck-lsp--initialize-params "/ssh:host:/srv/app/")))
+          ;; The field is required by LSP, so it must be present and
+          ;; null rather than simply absent.
+          (expect (plist-member params :processId) :to-be-truthy)
+          (expect (plist-get params :processId) :to-be nil)
+          (expect (plist-get params :rootPath) :to-equal "/srv/app/")
+          (expect (plist-get params :rootUri) :to-equal "file:///srv/app/"))
+        (let ((params (flycheck-lsp--initialize-params "/srv/app/")))
+          (expect (plist-get params :processId) :to-equal (emacs-pid))))
+
+      (it "keeps a remote document apart from a local file of that path"
+        ;; Both name "/etc/hosts" to their own server; the key is what
+        ;; distinguishes them, so closing one must not close the other.
+        (expect (flycheck-lsp--doc-key "file:///etc/hosts" "/ssh:host:")
+                :not :to-equal (flycheck-lsp--doc-key "file:///etc/hosts")))
+
+      (it "serves a remote buffer"
+        ;; The server runs on the buffer's own host, so a remote buffer
+        ;; is checked like a local one.  The local assertion is the control: without it a mode with no
         ;; configured server would pass this either way.
         (flycheck-buttercup-with-temp-buffer
           (delay-mode-hooks (ruby-mode))
@@ -1178,17 +1278,22 @@ holding its document"
                 (flycheck-executable-find #'identity))
             (setq buffer-file-name "/proj/a.rb" default-directory "/proj/")
             (expect (flycheck-lsp--enabled-p) :to-be-truthy)
+            ;; A remote buffer is served too now: the server runs on
+            ;; that host.
             (setq buffer-file-name "/ssh:host:/proj/a.rb"
                   default-directory "/ssh:host:/proj/")
-            (expect (flycheck-lsp--enabled-p) :to-be nil))))
+            (expect (flycheck-lsp--enabled-p) :to-be-truthy))))
 
-      (it "gives a remote buffer no document URI"
-        ;; Reducing a remote name for the server spells it exactly like
-        ;; the local file of that name, so the two buffers would share a
-        ;; document and killing one would close the other's.
+      (it "names a remote file as the server's host sees it"
+        ;; The URI carries no host; the document key does, so a remote
+        ;; buffer and a local file of the same path stay distinct.
         (flycheck-buttercup-with-temp-buffer
-          (setq buffer-file-name "/sudo::/etc/hosts")
-          (expect (flycheck-lsp--buffer-uri) :to-be nil))
+          (setq buffer-file-name "/ssh:host:/etc/hosts")
+          (expect (flycheck-lsp--buffer-uri) :to-equal "file:///etc/hosts")
+          (expect (flycheck-lsp--doc-key (flycheck-lsp--buffer-uri) "/ssh:host:")
+                  :to-equal "/ssh:host:/etc/hosts")
+          (expect (flycheck-lsp--doc-key (flycheck-lsp--buffer-uri))
+                  :to-equal "/etc/hosts"))
         (flycheck-buttercup-with-temp-buffer
           (setq buffer-file-name "/etc/hosts")
           ;; Windows expands this against the current drive, so match the


### PR DESCRIPTION
`flycheck-lsp` declined a buffer on a remote host. It looked the server up *there* through `flycheck-executable-find` and then started it *here*, since `make-process` ignores a remote `default-directory` without `:file-handler`. It can run on the right host instead.

What stands between TRAMP and LSP is the shell TRAMP runs the command under: it turns a carriage return into a newline, which destroys the CRLF framing LSP headers use. Running the server behind `stty raw` leaves the byte stream alone, which is what Eglot has always done. I went down a blind alley first with `tramp-direct-async-process` and it turned out to be inert here - TRAMP reads that connection-locally, not from a dynamic binding - so the wrapper is doing all the work.

Document keys now carry the host. A server names files as its own host sees them, so without that a remote buffer and a local file of the same path share a key: closing one closed the other and told that server to drop a file another buffer was still editing. That is the collision #2374 worked around by refusing remote buffers a URI at all, now fixed at the source.

Verified against `rubocop --lsp` running in a container over TRAMP's `docker` method, not a mock: four real offences reported against the remote buffer, with file names that open the right file.

Two things I did not change. A remote host without `mknod`/`mkfifo` cannot give the process a separate stderr buffer, so the server fails to start there with a message that reads like the tool is missing - Eglot has the same constraint. And `flycheck--path-under-prefixes-p` falls back to `file-truename`, which is now reachable with remote paths and costs a round trip the first time a local project check runs after a remote buffer is opened.