### PR TITLE
Apply fixes to errors in other files of the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### New Features
 
+- [#2386](https://github.com/flycheck/flycheck/pull/2386): Fixes apply to errors in other files of the project: `x` in the error list opens the file an error belongs to and applies the fix there, and `X` in the project scope fixes every file the list shows.
 - [#2385](https://github.com/flycheck/flycheck/pull/2385): The native `flycheck-lsp` client checks a file on a remote host, starting the language server on that host over TRAMP instead of declining the buffer.
 - [#2381](https://github.com/flycheck/flycheck/pull/2381): New commands `flycheck-lsp-list-servers`, `flycheck-lsp-restart-server` and `flycheck-lsp-shutdown-servers` show the language servers Flycheck is running and stop them, which previously took restarting Emacs.
 - [#2380](https://github.com/flycheck/flycheck/pull/2380): New `flycheck-lsp-prefer-server` option: automatic checker selection can use a linter's own resident LSP server in place of the command checker that spawns it afresh on every check, for the linters `flycheck-lsp-checker-servers` names.

--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -350,13 +350,14 @@ In the :ref:`error list <flycheck-error-list>` press :kbd:`x`
 current row, or :kbd:`X` (``flycheck-error-list-fix-all``) to apply every
 fix in the list's source buffer.
 
-:kbd:`x` works across files in the list's project scope (:kbd:`P`, see
+Both work across files in the list's project scope (:kbd:`P`, see
 :doc:`error-list`).  A project checker such as ``cargo-check`` reports fixable
 errors for files no buffer visits; applying one opens that file, makes the
 change and leaves the buffer unsaved, so you can look it over and undo it.
-A file that has been written since the check is left alone rather than edited
-at positions that no longer describe it, and so is one whose buffer has
-unsaved changes.
+:kbd:`X` then fixes every file the list shows, one undoable change each, and
+asks first when that means opening files.  A file that has been written since
+the check is left alone rather than edited at positions that no longer
+describe it, and so is one whose buffer has unsaved changes.
 
 A fix is applied as a single undoable change, so :kbd:`C-/` reverts it.  The
 checkers that currently provide fixes are ``javascript-eslint``,

--- a/doc/user/error-interaction.rst
+++ b/doc/user/error-interaction.rst
@@ -350,6 +350,14 @@ In the :ref:`error list <flycheck-error-list>` press :kbd:`x`
 current row, or :kbd:`X` (``flycheck-error-list-fix-all``) to apply every
 fix in the list's source buffer.
 
+:kbd:`x` works across files in the list's project scope (:kbd:`P`, see
+:doc:`error-list`).  A project checker such as ``cargo-check`` reports fixable
+errors for files no buffer visits; applying one opens that file, makes the
+change and leaves the buffer unsaved, so you can look it over and undo it.
+A file that has been written since the check is left alone rather than edited
+at positions that no longer describe it, and so is one whose buffer has
+unsaved changes.
+
 A fix is applied as a single undoable change, so :kbd:`C-/` reverts it.  The
 checkers that currently provide fixes are ``javascript-eslint``,
 ``python-ruff``, ``sh-shellcheck``, the ``rust`` checkers (from ``cargo

--- a/flycheck.el
+++ b/flycheck.el
@@ -3658,13 +3658,23 @@ A fix a checker suggests carries this tick (see `flycheck--make-fix')
 so `flycheck-apply-fix' can tell whether the buffer has changed since
 the checker read it, and thus whether the fix's positions are stale.")
 
+(defvar-local flycheck--syntax-check-start-time nil
+  "When the current check started, as a Lisp timestamp.
+
+The tick above covers the fixes for this buffer.  A check can also
+suggest a fix for another file it read from disk, which no tick of this
+buffer describes; that fix is good only as long as the file has not been
+written since this time (see `flycheck--check-fix-file-state').")
+
 (defun flycheck-start-current-syntax-check (checker)
   "Start a syntax check in the current buffer with CHECKER.
 
 Set `flycheck-current-syntax-check' accordingly."
   ;; Remember the buffer's modification state, so a fix this check produces
-  ;; can be refused later if the buffer has changed in the meantime.
-  (setq flycheck--syntax-check-modified-tick (buffer-chars-modified-tick))
+  ;; can be refused later if the buffer has changed in the meantime, and the
+  ;; time, which is what a fix for another file answers to instead.
+  (setq flycheck--syntax-check-modified-tick (buffer-chars-modified-tick)
+        flycheck--syntax-check-start-time (current-time))
   ;; Allocate the current syntax check *before* starting it.  This allows for
   ;; synchronous checks, which call the status callback immediately in their
   ;; start function.
@@ -4953,6 +4963,26 @@ nothing, when an edit's coordinates make no sense or the edits overlap."
           (goto-char beg)
           (insert (or replacement "")))))))
 
+(defun flycheck--apply-fix-in (fix buffer &optional guard)
+  "Apply FIX's edits in BUFFER as a single undoable change.
+
+GUARD, when given, is called with FIX in BUFFER before anything is
+applied and signals when the fix must not be applied.  What makes a fix
+stale depends on where it came from: a fix for the buffer that was
+checked compares modification ticks (see `flycheck--check-fix-tick'),
+while a fix for a file the checker read from disk has no tick to compare
+and its caller checks the file instead (see
+`flycheck--check-fix-file-state')."
+  (unless (buffer-live-p buffer)
+    (user-error "Cannot apply a fix: its buffer is gone"))
+  (with-current-buffer buffer
+    (when buffer-read-only
+      (user-error "Cannot apply a fix in a read-only buffer"))
+    (when guard (funcall guard fix))
+    (save-restriction
+      (widen)
+      (flycheck--apply-edits (flycheck-fix-edits fix)))))
+
 (defun flycheck-apply-fix (fix &optional buffer)
   "Apply FIX in BUFFER, defaulting to the current buffer.
 
@@ -4965,16 +4995,8 @@ or read-only, when the buffer has changed since the check that
 produced the fix (its line and column numbers would be stale), or
 when the fix's own edits overlap -- so a fix can never silently
 corrupt the buffer."
-  (let ((buffer (or buffer (current-buffer))))
-    (unless (buffer-live-p buffer)
-      (user-error "Cannot apply a fix: its buffer is gone"))
-    (with-current-buffer buffer
-      (when buffer-read-only
-        (user-error "Cannot apply a fix in a read-only buffer"))
-      (flycheck--check-fix-tick fix)
-      (save-restriction
-        (widen)
-        (flycheck--apply-edits (flycheck-fix-edits fix))))))
+  (flycheck--apply-fix-in fix (or buffer (current-buffer))
+                          #'flycheck--check-fix-tick))
 
 (defun flycheck--fix-span (fix)
   "Return the buffer region (BEG . END) that FIX's edits span.
@@ -4984,6 +5006,46 @@ FIX's edits, resolved in the current buffer."
   (let ((regions (mapcar #'flycheck--fix-edit-region (flycheck-fix-edits fix))))
     (cons (apply #'min (mapcar #'car regions))
           (apply #'max (mapcar #'cdr regions)))))
+
+(defun flycheck--apply-fixes-in (fixes buffer &optional guard)
+  "Apply as many of FIXES together in BUFFER as do not conflict.
+
+GUARD, when given, is called with FIXES in BUFFER before anything is
+applied and signals when they must not be applied; see
+`flycheck--apply-fix-in'.  Return the number of fixes applied."
+  (unless (buffer-live-p buffer)
+    (user-error "Cannot apply fixes: their buffer is gone"))
+  (with-current-buffer buffer
+    (when buffer-read-only
+      (user-error "Cannot apply fixes in a read-only buffer"))
+    (when guard (funcall guard fixes))
+    ;; Ignore fixes with no edits: they contribute nothing and would trip
+    ;; up `flycheck--fix-span'.  In practice every live fix has edits.
+    (setq fixes (seq-filter #'flycheck-fix-edits fixes))
+    (save-restriction
+      (widen)
+      ;; Greedily select a non-overlapping subset, bottom-up: process the
+      ;; fixes lowest in the buffer first and keep a fix only if its whole
+      ;; span sits at or above every fix already selected below it.
+      (let ((spanned (mapcar (lambda (fix)
+                               (cons (flycheck--fix-span fix) fix))
+                             fixes))
+            (boundary most-positive-fixnum)
+            (selected nil))
+        ;; Sort by span start, latest in the buffer first, and keep a fix
+        ;; when its whole span ends at or before every fix already kept
+        ;; below it.  Sorting by start (not end) maximizes the number of
+        ;; fixes applied: it is the classic interval-scheduling greedy, so
+        ;; one wide-span fix can't crowd out several small ones.
+        (setq spanned (sort spanned (lambda (a b) (> (caar a) (caar b)))))
+        (pcase-dolist (`((,beg . ,end) . ,fix) spanned)
+          (when (<= end boundary)
+            (push fix selected)
+            (setq boundary (min boundary beg))))
+        (when selected
+          (flycheck--apply-edits
+           (apply #'append (mapcar #'flycheck-fix-edits selected))))
+        (length selected)))))
 
 (defun flycheck-apply-fixes (fixes &optional buffer)
   "Apply as many of FIXES together in BUFFER as do not conflict.
@@ -4998,40 +5060,9 @@ applied.
 Signal a `user-error', touching nothing, when BUFFER is not live or
 read-only, or when any fix is stale -- the buffer changed since it was
 computed."
-  (let ((buffer (or buffer (current-buffer))))
-    (unless (buffer-live-p buffer)
-      (user-error "Cannot apply fixes: their buffer is gone"))
-    (with-current-buffer buffer
-      (when buffer-read-only
-        (user-error "Cannot apply fixes in a read-only buffer"))
-      (mapc #'flycheck--check-fix-tick fixes)
-      ;; Ignore fixes with no edits: they contribute nothing and would trip
-      ;; up `flycheck--fix-span'.  In practice every live fix has edits.
-      (setq fixes (seq-filter #'flycheck-fix-edits fixes))
-      (save-restriction
-        (widen)
-        ;; Greedily select a non-overlapping subset, bottom-up: process the
-        ;; fixes lowest in the buffer first and keep a fix only if its whole
-        ;; span sits at or above every fix already selected below it.
-        (let ((spanned (mapcar (lambda (fix)
-                                 (cons (flycheck--fix-span fix) fix))
-                               fixes))
-              (boundary most-positive-fixnum)
-              (selected nil))
-          ;; Sort by span start, latest in the buffer first, and keep a fix
-          ;; when its whole span ends at or before every fix already kept
-          ;; below it.  Sorting by start (not end) maximizes the number of
-          ;; fixes applied: it is the classic interval-scheduling greedy, so
-          ;; one wide-span fix can't crowd out several small ones.
-          (setq spanned (sort spanned (lambda (a b) (> (caar a) (caar b)))))
-          (pcase-dolist (`((,beg . ,end) . ,fix) spanned)
-            (when (<= end boundary)
-              (push fix selected)
-              (setq boundary (min boundary beg))))
-          (when selected
-            (flycheck--apply-edits
-             (apply #'append (mapcar #'flycheck-fix-edits selected))))
-          (length selected))))))
+  (flycheck--apply-fixes-in fixes (or buffer (current-buffer))
+                            (lambda (fixes)
+                              (mapc #'flycheck--check-fix-tick fixes))))
 
 (defun flycheck--error-fix-buffer (err)
   "Return the live buffer in which ERR's fix may be applied, or nil.
@@ -5048,6 +5079,105 @@ edited -- cannot be fixed in place."
                   (and buffer-file-name
                        (flycheck-same-files-p filename buffer-file-name))))
         buffer))))
+
+(defun flycheck--error-fix-target (err &optional visit)
+  "Return the live buffer in which ERR's fix is to be applied, or nil.
+
+For an error about the file its own buffer visits that is the buffer
+itself (see `flycheck--error-fix-buffer').  For a cross-file error, one
+a whole-project checker reported about a file no buffer was checked for,
+it is a buffer visiting that file; with VISIT non-nil the file is opened
+when nothing visits it yet, and otherwise such an error resolves to nil."
+  (or (flycheck--error-fix-buffer err)
+      (when-let* ((filename (flycheck-error-filename err))
+                  ((file-regular-p filename)))
+        (or (find-buffer-visiting filename)
+            (and visit (find-file-noselect filename))))))
+
+(defun flycheck--fix-bound (err)
+  "Return what says which state of its file ERR's fix describes.
+
+That is the symbol `now' for a lazy fix provider (see
+`flycheck-error-fix'), which computes the fix against the file as it is
+when asked; the time of the check that produced a fix Flycheck already
+holds; or nil when nothing says, in which case the fix is not applied to
+another file at all."
+  (cond
+   ((functionp (flycheck-error-fix err)) 'now)
+   ;; A buffer check can report a fix for another file it read (rustc names
+   ;; a suggestion in a second crate file this way).  The buffer's tick
+   ;; says nothing about that file, but the time its check started does.
+   ((when-let* ((buffer (flycheck-error-buffer err))
+                ((buffer-live-p buffer)))
+      (buffer-local-value 'flycheck--syntax-check-start-time buffer)))
+   (t (flycheck--project-error-time err))))
+
+(defun flycheck--fix-file-current-p (file checked)
+  "Whether FILE can still hold what a fix bounded by CHECKED describes.
+
+CHECKED is a bound as `flycheck--fix-bound' returns one."
+  (pcase checked
+    ('nil nil)
+    ('now t)
+    (time
+     ;; A file on another host is stamped by that host's clock, which ours
+     ;; has no business comparing against: a machine running a few seconds
+     ;; ahead would refuse every fix.
+     (or (file-remote-p file)
+         (when-let* ((written (file-attribute-modification-time
+                               (file-attributes file))))
+           (not (time-less-p time written)))))))
+
+(defun flycheck--check-fix-file-state (buffer checked)
+  "Signal a `user-error' when BUFFER no longer holds what CHECKED describes.
+
+A fix for a file other than the checked one carries no modification tick
+to compare against (see `flycheck-apply-fix'): its line and column
+numbers describe the file as its checker read it from disk.  So the file
+must still be what was read, which it is not once the buffer has unsaved
+changes, the file changed under it, or it was written after the check
+that produced the fix.  CHECKED is that check, as `flycheck--fix-bound'
+reports it; a fix nothing bounds is refused rather than applied at
+positions that may describe an older file."
+  (let ((name (file-name-nondirectory (or (buffer-file-name buffer)
+                                          (buffer-name buffer)))))
+    (when (buffer-modified-p buffer)
+      (user-error "%s has unsaved changes; save it and check again" name))
+    (unless (verify-visited-file-modtime buffer)
+      (user-error "%s changed on disk; revert it and check again" name))
+    (unless checked
+      (user-error "Nothing says which state of %s this fix is for; \
+check again" name))
+    (unless (flycheck--fix-file-current-p (buffer-file-name buffer) checked)
+      (user-error "%s was written since the check; check again" name))))
+
+(defun flycheck--apply-error-fix (err &optional visit)
+  "Apply ERR's fix in the buffer whose text it edits.
+
+That is ERR's own buffer, or, for an error about another file, a buffer
+visiting that file, opened when VISIT is non-nil and nothing visits it
+yet.  Return a cons of the applied fix and the buffer it was applied in,
+or nil when the checker turns out to have no fix after all (see
+`flycheck-error-resolve-fix').  Signal a `user-error', touching nothing,
+when the fix cannot be applied safely."
+  (let* ((in-place (flycheck--error-fix-buffer err))
+         (bound (unless in-place (flycheck--fix-bound err)))
+         (buffer (or in-place (flycheck--error-fix-target err visit))))
+    (unless buffer
+      (user-error "Cannot apply this fix: %s"
+                  (let ((filename (flycheck-error-filename err)))
+                    (cond
+                     ((null filename) "the buffer of this error is gone")
+                     ((not (file-regular-p filename))
+                      (format "there is no file at %s any more" filename))
+                     (t (format "no buffer visits %s" filename))))))
+    (when-let* ((fix (with-current-buffer buffer
+                       (flycheck-error-resolve-fix err))))
+      (if in-place
+          (flycheck-apply-fix fix buffer)
+        (flycheck--check-fix-file-state buffer bound)
+        (flycheck--apply-fix-in fix buffer))
+      (cons fix buffer))))
 
 (defun flycheck-error-format-snippet (err &optional max-length)
   "Extract the text that ERR refers to from the buffer.
@@ -5543,9 +5673,11 @@ asked to drop a project's results.")
 (defvar flycheck--project-runs (make-hash-table :test 'equal)
   "State of the project-checker runs, keyed by (PROJECT-KEY . CHECKER).
 Each value is a plist of `:process', the run still under way if any,
-and `:errors', what the last completed run reported.  The errors
-reflect the project as of that run; they stay until the next
-`flycheck-check-project' there replaces or clears them.")
+`:errors', what the last completed run reported, and `:time', when that
+run started.  The errors reflect the project as of that run; they stay
+until the next `flycheck-check-project' there replaces or clears them.
+The time is what tells a fix for one of those errors whether the file it
+edits has been written since (see `flycheck--check-fix-file-state').")
 
 (defun flycheck--project-run-extra-errors (project-key _buffers)
   "Return what project-checker runs reported for PROJECT-KEY."
@@ -5558,6 +5690,19 @@ reflect the project as of that run; they stay until the next
 
 (add-hook 'flycheck--project-extra-errors-functions
           #'flycheck--project-run-extra-errors)
+
+(defun flycheck--project-error-time (err)
+  "Return when the project-checker run that reported ERR started, or nil.
+
+Errors from a buffer check are not in these results; what bounds their
+fixes is the check of the buffer that reported them, see
+`flycheck--fix-bound'."
+  (catch 'time
+    (maphash (lambda (_key state)
+               (when (memq err (plist-get state :errors))
+                 (throw 'time (plist-get state :time))))
+             flycheck--project-runs)
+    nil))
 
 (defun flycheck--project-runs-forget (project-key)
   "Drop the run results and kill the running checks of PROJECT-KEY."
@@ -5599,7 +5744,8 @@ reflect the project as of that run; they stay until the next
                                         output checker root))
                            (error (setq failure (error-message-string err))
                                   nil))))
-            (puthash key (list :process nil :errors errors)
+            (puthash key (list :process nil :errors errors
+                               :time (plist-get state :time))
                      flycheck--project-runs)
             (flycheck--project-diagnostics-changed)
             (flycheck-error-list-refresh)
@@ -5671,7 +5817,8 @@ reflect the project as of that run; they stay until the next
         (puthash key (list :process proc
                            :errors (plist-get
                                     (gethash key flycheck--project-runs)
-                                    :errors))
+                                    :errors)
+                           :time (current-time))
                  flycheck--project-runs)))))
 
 (defun flycheck-check-project (&optional clear)
@@ -7562,15 +7709,19 @@ already names it in a grouped list."
          (msg-and-checker
           (concat
            ;; Flag errors that carry an applicable machine fix (apply with
-           ;; `x'/`flycheck-error-list-apply-fix'), for discoverability.  Only
-           ;; badge errors whose fix can actually be applied here, not
-           ;; cross-file ones the apply command would refuse.  A fix that has
-           ;; to be fetched before we know it exists, as an LSP code action
+           ;; `x'/`flycheck-error-list-apply-fix'), for discoverability.  An
+           ;; error about another file is badged too, as long as that file is
+           ;; still there: its fix is applied in the file it names, which the
+           ;; command opens.  A fix that has to
+           ;; be fetched before we know it exists, as an LSP code action
            ;; does, is badged with a question mark rather than left bare: the
            ;; indicators cannot promise it, but there is room to mention it
            ;; here, and otherwise nothing would suggest trying.
            (when (and (flycheck-error-fix error)
-                      (flycheck--error-fix-buffer error))
+                      (or (flycheck--error-fix-buffer error)
+                          (when-let* ((filename (flycheck-error-filename
+                                                 error)))
+                            (file-regular-p filename))))
              (let ((known (flycheck-error-known-fix-p error)))
                (propertize (if known "[fix] " "[fix?] ")
                            'face 'flycheck-error-list-checker-name
@@ -8123,26 +8274,26 @@ related location; see `flycheck-visit-related-location'."
 (defun flycheck-error-list-apply-fix (&optional pos)
   "Apply the suggested fix of the error at POS in the error list.
 
-POS defaults to `point'.  Signal a `user-error' when the error
-has no fix."
+POS defaults to `point'.  The fix is applied in the buffer its line and
+column numbers belong to: the buffer that was checked, or, for an error
+a project checker reported about another file, that file, which is
+opened and left unsaved so the change can be reviewed and undone.
+
+Signal a `user-error' when the error has no fix, or when the file it
+belongs to has changed since the check that produced it."
   (interactive)
-  (let* ((error (tabulated-list-get-id pos))
-         (fixable (and (flycheck-error-p error) (flycheck-error-fix error)))
-         (buffer (and fixable (flycheck--error-fix-buffer error))))
-    (unless fixable
+  (let ((error (tabulated-list-get-id pos)))
+    (unless (and (flycheck-error-p error) (flycheck-error-fix error))
       (user-error "The error at point has no fix"))
-    (unless buffer
-      (user-error "This fix cannot be applied here (the error is in another \
-file, or its buffer is gone)"))
-    ;; Resolve a lazy fix provider in the error's own buffer.
-    (if-let* ((fix (with-current-buffer buffer
-                     (flycheck-error-resolve-fix error))))
-        (progn
-          (flycheck-apply-fix fix buffer)
+    (if-let* ((result (flycheck--apply-error-fix error 'visit)))
+        (pcase-let ((`(,fix . ,buffer) result))
           (flycheck-error-list-refresh)
-          (message "Applied fix%s"
+          (message "Applied fix%s%s"
                    (if-let* ((description (flycheck-fix-description fix)))
-                       (concat ": " description) "")))
+                       (concat ": " description) "")
+                   (if (eq buffer flycheck-error-list-source-buffer)
+                       ""
+                     (format " in %s" (buffer-name buffer)))))
       (user-error "The fix for this error is not available"))))
 
 (defun flycheck-error-list-fix-all ()

--- a/flycheck.el
+++ b/flycheck.el
@@ -5179,6 +5179,109 @@ when the fix cannot be applied safely."
         (flycheck--apply-fix-in fix buffer))
       (cons fix buffer))))
 
+(defun flycheck--fix-file-to-open (err)
+  "Return the file that fixing ERR would have to open, or nil.
+
+That is the file of an error whose fix is still good for it and that no
+live buffer visits.  A file whose state already rules the fix out is not
+one to open: a project's results go stale together, and opening every
+file of one only to refuse them all leaves nothing but buffers behind."
+  (when-let* (((flycheck-error-fix err))
+              ((null (flycheck--error-fix-target err)))
+              (filename (flycheck-error-filename err))
+              ((file-regular-p filename))
+              ((flycheck--fix-file-current-p filename
+                                             (flycheck--fix-bound err))))
+    filename))
+
+(defun flycheck--fix-target-to-open (err)
+  "Return the buffer to apply ERR's fix in, opening its file if worthwhile.
+
+Like `flycheck--error-fix-target' asked to visit, except that it opens
+only the files `flycheck--fix-file-to-open' names."
+  (or (flycheck--error-fix-target err)
+      (when-let* ((filename (flycheck--fix-file-to-open err)))
+        (find-file-noselect filename))))
+
+(defun flycheck--fix-files-to-open (errors)
+  "Return the files fixing ERRORS would have to open, deduplicated.
+
+They come in the order the errors do; see `flycheck--fix-file-to-open'."
+  (seq-uniq (delq nil (mapcar #'flycheck--fix-file-to-open errors))
+            #'flycheck-same-files-p))
+
+(defun flycheck--fix-errors-across-files (errors)
+  "Apply the fixes of ERRORS in the files those errors belong to.
+
+The errors are grouped by the buffer their fix edits (see
+`flycheck--error-fix-target'), which for a cross-file error means
+opening the file it names.  Each file is fixed as a single undoable
+change and left unsaved, so the change can be reviewed and undone.  A
+file whose fixes cannot be applied safely, because it changed since the
+check or its buffer is read-only, is skipped whole rather than aborting
+the rest.
+
+Return a list (APPLIED FILES SKIPPED): how many fixes were applied, in
+how many buffers, and how many were left unapplied."
+  (let ((groups nil) (applied 0) (files 0) (skipped 0))
+    (dolist (err errors)
+      (when (flycheck-error-fix err)
+        ;; Opening a file can fail on its own (unreadable, a file name
+        ;; another handler chokes on); that is this one error's problem,
+        ;; not the whole run's.
+        (if-let* ((target (ignore-errors (flycheck--fix-target-to-open err))))
+            (let ((group (assq target groups)))
+              (unless group
+                (setq group (list target))
+                (push group groups))
+              (setcdr group (cons err (cdr group))))
+          (setq skipped (1+ skipped)))))
+    (pcase-dolist (`(,buffer . ,group) (nreverse groups))
+      (let* ((errs (nreverse group))
+             (count (length errs)))
+        (condition-case nil
+            ;; Ask each lazy provider once, in the buffer the fix belongs
+            ;; to, and keep the error beside the fix it produced: which
+            ;; guard a fix answers to depends on where its error came from.
+            (let* ((pairs (delq nil
+                                (mapcar
+                                 (lambda (err)
+                                   (when-let*
+                                       ((fix (with-current-buffer buffer
+                                               (flycheck-error-resolve-fix
+                                                err))))
+                                     (cons err fix)))
+                                 errs)))
+                   (cross (seq-remove
+                           (lambda (pair)
+                             (eq (flycheck--error-fix-buffer (car pair))
+                                 buffer))
+                           pairs)))
+              (when cross
+                ;; The strictest bound among them decides: nothing bounds
+                ;; the group as soon as one of its fixes is unbounded, and
+                ;; the oldest check otherwise, since a write after that one
+                ;; leaves every fix from it stale.
+                (let* ((bounds (mapcar (lambda (pair)
+                                         (flycheck--fix-bound (car pair)))
+                                       cross))
+                       (times (seq-remove #'symbolp bounds)))
+                  (flycheck--check-fix-file-state
+                   buffer (cond ((memq nil bounds) nil)
+                                (times (car (sort times #'time-less-p)))
+                                (t 'now)))))
+              (with-current-buffer buffer
+                (dolist (pair pairs)
+                  (unless (memq pair cross)
+                    (flycheck--check-fix-tick (cdr pair)))))
+              (let ((n (flycheck--apply-fixes-in
+                        (mapcar #'cdr pairs) buffer)))
+                (setq applied (+ applied n)
+                      skipped (+ skipped (- count n)))
+                (when (> n 0) (setq files (1+ files)))))
+          (user-error (setq skipped (+ skipped count))))))
+    (list applied files skipped)))
+
 (defun flycheck-error-format-snippet (err &optional max-length)
   "Extract the text that ERR refers to from the buffer.
 
@@ -8297,15 +8400,47 @@ belongs to has changed since the check that produced it."
       (user-error "The fix for this error is not available"))))
 
 (defun flycheck-error-list-fix-all ()
-  "Apply every fixable error's fix in the error list's source buffer."
+  "Apply every fix the error list shows.
+
+In the buffer scope that is every fix of the source buffer.  In the
+project scope (see `flycheck-error-list-scope') it is every fix in the
+project, including those for files no buffer visits: such a file is
+opened, fixed as a single undoable change and left unsaved, so the
+change can be reviewed and undone.  A file that changed since the check
+is skipped rather than fixed at stale positions.  Errors a filter hides
+are left alone."
   (interactive)
-  (if-let* ((buffer flycheck-error-list-source-buffer)
-            ((buffer-live-p buffer)))
-      (progn
-        (with-current-buffer buffer
-          (call-interactively #'flycheck-fix-all-errors))
-        (flycheck-error-list-refresh))
-    (user-error "The error list has no live source buffer")))
+  (if (eq flycheck-error-list-scope 'project)
+      (let* ((errors (flycheck-error-list-apply-filter
+                      (flycheck-error-list-current-errors)))
+             (opening (flycheck--fix-files-to-open errors)))
+        (when (and opening
+                   (not (y-or-n-p
+                         (format "Fixing this opens %d file%s; proceed? "
+                                 (length opening)
+                                 (if (= (length opening) 1) "" "s")))))
+          (user-error "Not fixing"))
+        (pcase-let ((`(,applied ,files ,skipped)
+                     (flycheck--fix-errors-across-files errors)))
+          (flycheck-error-list-refresh)
+          (cond
+           ((> applied 0)
+            (message "Applied %d fix%s in %d file%s%s"
+                     applied (if (= applied 1) "" "es")
+                     files (if (= files 1) "" "s")
+                     (if (> skipped 0)
+                         (format " (%d skipped)" skipped)
+                       "")))
+           ((> skipped 0)
+            (user-error "No fix could be applied (%d skipped)" skipped))
+           (t (user-error "No applicable fixes in this project")))))
+    (if-let* ((buffer flycheck-error-list-source-buffer)
+              ((buffer-live-p buffer)))
+        (progn
+          (with-current-buffer buffer
+            (call-interactively #'flycheck-fix-all-errors))
+          (flycheck-error-list-refresh))
+      (user-error "The error list has no live source buffer"))))
 
 (defun flycheck-error-list-next-error-pos (pos &optional n)
   "Starting from POS get the N'th next error in the error list.

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -361,7 +361,42 @@ is when asked, so no earlier check has to vouch for it."
           (cl-letf (((symbol-function 'flycheck-error-list-refresh) #'ignore))
             (flycheck-error-list-apply-fix)))
         (with-current-buffer (find-buffer-visiting file)
-          (expect (buffer-string) :to-equal "hello\n")))))
+          (expect (buffer-string) :to-equal "hello\n"))))
+
+    (it "fixes every file the project scope shows"
+      (let ((a (test-errorlist/file "a.el"))
+            (b (test-errorlist/file "b.el")))
+        (with-temp-buffer
+          (setq-local flycheck-error-list-scope 'project)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () (list (test-errorlist/error a)
+                                      (test-errorlist/error b))))
+                    ((symbol-function 'y-or-n-p) (lambda (_prompt) t))
+                    ((symbol-function 'flycheck-error-list-refresh) #'ignore))
+            (flycheck-error-list-fix-all)))
+        (dolist (file (list a b))
+          (with-current-buffer (find-buffer-visiting file)
+            (expect (buffer-string) :to-equal "hello\n")))))
+
+    (it "opens nothing when the prompt is declined"
+      (let ((a (test-errorlist/file "a.el")))
+        (with-temp-buffer
+          (setq-local flycheck-error-list-scope 'project)
+          (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                     (lambda () (list (test-errorlist/error a))))
+                    ((symbol-function 'y-or-n-p) (lambda (_prompt) nil))
+                    ((symbol-function 'flycheck-error-list-refresh) #'ignore))
+            (expect (flycheck-error-list-fix-all) :to-throw 'user-error)))
+        (expect (find-buffer-visiting a) :to-be nil)))
+
+    (it "signals when the project has nothing to fix"
+      (with-temp-buffer
+        (setq-local flycheck-error-list-scope 'project)
+        (cl-letf (((symbol-function 'flycheck-error-list-current-errors)
+                   (lambda () (list (flycheck-error-new-at
+                                     1 1 'error "x" :checker 'emacs-lisp))))
+                  ((symbol-function 'flycheck-error-list-refresh) #'ignore))
+          (expect (flycheck-error-list-fix-all) :to-throw 'user-error)))))
 
   (describe "Grouping by file"
     (let ((errors (list (flycheck-error-new-at 3 1 'error "in b"

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -235,7 +235,45 @@
 
     (it "marks nothing when the error carries no fix at all"
       (let ((err (flycheck-error-new-at 1 1 'error "x" :checker 'emacs-lisp)))
-        (expect (test-fixbadge/render err) :not :to-match "\\[fix"))))
+        (expect (test-fixbadge/render err) :not :to-match "\\[fix")))
+
+    (it "marks an error about another file, whose fix opens that file"
+      ;; Not rendered through `test-fixbadge/render': the point is what the
+      ;; badge does when the error resolves to no buffer of its own.
+      (let ((file (make-temp-file "flycheck-badge" nil ".el" "x\n")))
+        (unwind-protect
+            (let ((err (flycheck-error-new-at
+                        1 1 'error "x" :checker 'emacs-lisp :buffer nil
+                        :filename file
+                        :fix (flycheck-fix-new :description "d" :edits nil
+                                               :tick 0))))
+              (expect (mapconcat
+                       (lambda (cell) (if (stringp cell) cell (car cell)))
+                       (cadr (flycheck-error-list-make-entry err)) " ")
+                      :to-match "\\[fix\\] "))
+          (delete-file file))))
+
+    (it "marks nothing for an error whose file is gone"
+      ;; The apply command would only refuse it, so promising a fix here
+      ;; would send the user after one that cannot be applied.
+      (let ((err (flycheck-error-new-at
+                  1 1 'error "x" :checker 'emacs-lisp :buffer nil
+                  :filename "/p/gone.el"
+                  :fix (flycheck-fix-new :description "d" :edits nil
+                                         :tick 0))))
+        (expect (mapconcat (lambda (cell) (if (stringp cell) cell (car cell)))
+                           (cadr (flycheck-error-list-make-entry err)) " ")
+                :not :to-match "\\[fix")))
+
+    (it "marks nothing for a fix with neither a buffer nor a file"
+      (let ((err (flycheck-error-new-at
+                  1 1 'error "x" :checker 'emacs-lisp :buffer nil
+                  :filename nil
+                  :fix (flycheck-fix-new :description "d" :edits nil
+                                         :tick 0))))
+        (expect (mapconcat (lambda (cell) (if (stringp cell) cell (car cell)))
+                           (cadr (flycheck-error-list-make-entry err)) " ")
+                :not :to-match "\\[fix"))))
 
   (describe "Applying fixes"
     (it "applies the fix of the error at point"
@@ -278,6 +316,52 @@
       (with-temp-buffer
         (setq-local flycheck-error-list-source-buffer nil)
         (expect (flycheck-error-list-fix-all) :to-throw 'user-error))))
+
+  (describe "Applying fixes across the project"
+    (defvar test-errorlist/dir nil)
+
+    (defun test-errorlist/file (name)
+      "Write a fixable file NAME in the spec's directory and return it."
+      (let ((file (expand-file-name name test-errorlist/dir)))
+        (with-temp-file file (insert "helo\n"))
+        file))
+
+    (defun test-errorlist/error (file)
+      "Return an error about FILE carrying a fix, as a server offers one.
+
+The fix comes from a provider, which computes it against the file as it
+is when asked, so no earlier check has to vouch for it."
+      (flycheck-error-new-at
+       1 1 'error "typo" :checker 'emacs-lisp :filename file :buffer nil
+       :fix (lambda (_err)
+              (flycheck-fix-new
+               :edits (list (flycheck-fix-edit-new
+                             :line 1 :column 1 :end-line 1 :end-column 5
+                             :replacement "hello"))))))
+
+    (before-each
+      (setq test-errorlist/dir
+            (file-name-as-directory
+             (file-truename (make-temp-file "flycheck-el" t)))))
+
+    (after-each
+      (dolist (buffer (buffer-list))
+        (when-let* ((file (buffer-file-name buffer)))
+          (when (string-prefix-p test-errorlist/dir file)
+            (with-current-buffer buffer (set-buffer-modified-p nil))
+            (kill-buffer buffer))))
+      (ignore-errors (delete-directory test-errorlist/dir t)))
+
+    (it "applies the fix of an error about another file, opening it"
+      (let ((file (test-errorlist/file "b.el")))
+        (with-temp-buffer
+          (insert (propertize "row" 'tabulated-list-id
+                              (test-errorlist/error file)))
+          (goto-char (point-min))
+          (cl-letf (((symbol-function 'flycheck-error-list-refresh) #'ignore))
+            (flycheck-error-list-apply-fix)))
+        (with-current-buffer (find-buffer-visiting file)
+          (expect (buffer-string) :to-equal "hello\n")))))
 
   (describe "Grouping by file"
     (let ((errors (list (flycheck-error-new-at 3 1 'error "in b"

--- a/test/specs/test-quick-fixes.el
+++ b/test/specs/test-quick-fixes.el
@@ -500,6 +500,221 @@
                          (current-buffer)))))
           (expect (flycheck-error-fix err) :to-be nil))))))
 
+(defvar flycheck-test--fix-dir nil
+  "The directory of files the cross-file fix specs edit.")
+
+(defun flycheck-test--fix-file (name content)
+  "Write CONTENT to NAME in `flycheck-test--fix-dir' and return the file."
+  (let ((file (expand-file-name name flycheck-test--fix-dir)))
+    (with-temp-file file (insert content))
+    file))
+
+(defun flycheck-test--record-run (err time)
+  "Pretend a project run reported ERR, having started at TIME."
+  (let* ((key (cons flycheck-test--fix-dir 'test-run))
+         (state (gethash key flycheck--project-runs)))
+    (puthash key (list :process nil
+                       :errors (cons err (plist-get state :errors))
+                       :time time)
+             flycheck--project-runs)))
+
+(defun flycheck-test--fix-error (file &optional fix)
+  "Return an error about FILE with FIX, as a project checker reports one.
+
+The error is recorded against a run that started just now, which is what
+bounds the fix of a file the checker read from disk."
+  (let ((err (flycheck-error-new-at
+              1 1 'error "typo" :filename file :buffer nil
+              :fix (or fix (flycheck-test--edit 1 1 1 5 "hello")))))
+    (flycheck-test--record-run err (current-time))
+    err))
+
+(describe "Cross-file fixes"
+
+  (before-each
+    (setq flycheck-test--fix-dir
+          (file-name-as-directory
+           (file-truename (make-temp-file "flycheck-fix" t)))))
+
+  (after-each
+    (dolist (buffer (buffer-list))
+      (when-let* ((file (buffer-file-name buffer)))
+        (when (string-prefix-p flycheck-test--fix-dir file)
+          (with-current-buffer buffer (set-buffer-modified-p nil))
+          (kill-buffer buffer))))
+    (clrhash flycheck--project-runs)
+    (ignore-errors (delete-directory flycheck-test--fix-dir t)))
+
+  (describe "flycheck--error-fix-target"
+
+    (it "resolves an error about its own buffer's file to that buffer"
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name (flycheck-test--fix-file "a.el" "helo\n"))
+        (let ((err (flycheck-error-new-at 1 1 'error "x")))
+          (expect (flycheck--error-fix-target err) :to-be (current-buffer)))))
+
+    (it "resolves a cross-file error to the buffer already visiting its file"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo\n"))
+             (buffer (find-file-noselect file))
+             (err (flycheck-test--fix-error file)))
+        (expect (flycheck--error-fix-target err) :to-be buffer)))
+
+    (it "opens the file only when asked to"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo\n"))
+             (err (flycheck-test--fix-error file)))
+        (expect (flycheck--error-fix-target err) :to-be nil)
+        (expect (buffer-file-name (flycheck--error-fix-target err 'visit))
+                :to-equal file)))
+
+    (it "resolves nothing for a file that is not there"
+      (let ((err (flycheck-test--fix-error
+                  (expand-file-name "gone.el" flycheck-test--fix-dir))))
+        (expect (flycheck--error-fix-target err 'visit) :to-be nil))))
+
+  (describe "flycheck--apply-error-fix"
+
+    (it "applies a fix in the file the error names, opening it"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-test--fix-error file)))
+        (expect (flycheck--apply-error-fix err 'visit) :to-be-truthy)
+        (with-current-buffer (find-buffer-visiting file)
+          (expect (buffer-string) :to-equal "hello world\n")
+          ;; Left for review and undo rather than written out.
+          (expect (buffer-modified-p) :to-be t))))
+
+    (it "refuses to open a file it was not allowed to visit"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-test--fix-error file)))
+        (expect (flycheck--apply-error-fix err) :to-throw 'user-error)
+        (expect (find-buffer-visiting file) :to-be nil)))
+
+    (it "refuses a fix for a buffer with unsaved changes"
+      ;; What the checker read is no longer what the buffer holds, so the
+      ;; fix's line and column numbers may point anywhere.
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (buffer (find-file-noselect file))
+             (err (flycheck-test--fix-error file)))
+        (with-current-buffer buffer (goto-char (point-min)) (insert "\n"))
+        (expect (flycheck--apply-error-fix err 'visit) :to-throw 'user-error)
+        (with-current-buffer buffer
+          (expect (buffer-string) :to-equal "\nhelo world\n"))))
+
+    (it "refuses a fix whose file changed under its buffer"
+      ;; Standing in for the file being rewritten behind the buffer's back,
+      ;; which a file system with a coarse clock would not always show.
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (buffer (find-file-noselect file))
+             (err (flycheck-test--fix-error file)))
+        (with-current-buffer buffer (set-visited-file-modtime '(0 0)))
+        (expect (flycheck--apply-error-fix err 'visit) :to-throw 'user-error)
+        (with-current-buffer buffer
+          (expect (buffer-string) :to-equal "helo world\n"))))
+
+    (it "refuses a fix whose file was written after the check ran"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-test--fix-error file)))
+        (flycheck-test--record-run err (time-add (current-time) -60))
+        (expect (flycheck--apply-error-fix err 'visit) :to-throw 'user-error)))
+
+    (it "refuses a fix nothing says the state of"
+      ;; Neither a run nor a live buffer stands behind this one, so there is
+      ;; no telling whether its positions still describe the file.
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-error-new-at
+                   1 1 'error "typo" :filename file :buffer nil
+                   :fix (flycheck-test--edit 1 1 1 5 "hello"))))
+        (expect (condition-case signalled
+                    (flycheck--apply-error-fix err 'visit)
+                  (user-error (error-message-string signalled)))
+                :to-match "Nothing says which state")))
+
+    (it "refuses a buffer check's fix for a file written since that check"
+      ;; rustc names a suggestion in another crate file this way: the fix
+      ;; carries the checked buffer's tick, which says nothing about the
+      ;; file it edits, so the check's time is what bounds it.
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (checked (generate-new-buffer " checked"))
+             (err (with-current-buffer checked
+                    (setq flycheck--syntax-check-start-time
+                          (time-add (current-time) -60))
+                    (flycheck-error-new-at
+                     1 1 'error "typo" :filename file
+                     :fix (flycheck-test--edit 1 1 1 5 "hello")))))
+        (unwind-protect
+            (expect (flycheck--apply-error-fix err 'visit) :to-throw
+                    'user-error)
+          (kill-buffer checked))))
+
+    (it "applies a buffer check's fix for a file untouched since that check"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (checked (generate-new-buffer " checked"))
+             (err (with-current-buffer checked
+                    (setq flycheck--syntax-check-start-time
+                          (time-add (current-time) 60))
+                    (flycheck-error-new-at
+                     1 1 'error "typo" :filename file
+                     :fix (flycheck-test--edit 1 1 1 5 "hello")))))
+        (unwind-protect
+            (progn
+              (expect (flycheck--apply-error-fix err 'visit) :to-be-truthy)
+              (with-current-buffer (find-buffer-visiting file)
+                (expect (buffer-string) :to-equal "hello world\n")))
+          (kill-buffer checked))))
+
+    (it "applies a fix a provider computed against the file just now"
+      ;; A lazy provider answers for the file as it is when asked, so no
+      ;; earlier check has to vouch for it.
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-error-new-at
+                   1 1 'error "typo" :filename file :buffer nil
+                   :fix (lambda (_err) (flycheck-test--edit 1 1 1 5 "hello")))))
+        (expect (flycheck--apply-error-fix err 'visit) :to-be-truthy)
+        (with-current-buffer (find-buffer-visiting file)
+          (expect (buffer-string) :to-equal "hello world\n"))))
+
+    (it "applies a fix whose file has not been written since the check"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-test--fix-error file)))
+        (flycheck-test--record-run err (time-add (current-time) 60))
+        (expect (flycheck--apply-error-fix err 'visit) :to-be-truthy)
+        (with-current-buffer (find-buffer-visiting file)
+          (expect (buffer-string) :to-equal "hello world\n"))))
+
+    (it "does not weigh a file on another host against the local clock"
+      ;; Its timestamp comes from that host's clock; a machine running a
+      ;; little ahead would otherwise refuse every fix.
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-test--fix-error file)))
+        (find-file-noselect file)
+        (flycheck-test--record-run err (time-add (current-time) -60))
+        (cl-letf (((symbol-function 'file-remote-p)
+                   (lambda (name &rest _) (and (equal name file) "/ssh:h:"))))
+          (expect (flycheck--apply-error-fix err 'visit) :to-be-truthy))
+        (with-current-buffer (find-buffer-visiting file)
+          (expect (buffer-string) :to-equal "hello world\n"))))
+
+    (it "returns nothing when a lazy provider comes up empty"
+      (let* ((file (flycheck-test--fix-file "b.el" "helo world\n"))
+             (err (flycheck-test--fix-error file (lambda (_err) nil))))
+        (expect (flycheck--apply-error-fix err 'visit) :to-be nil))))
+
+  (describe "flycheck--project-error-time"
+
+    (it "returns the time of the run that reported the error"
+      (let ((err (flycheck-error-new-at 1 1 'error "x" :filename "/p/a.el"
+                                        :buffer nil))
+            (time (current-time)))
+        (puthash (cons "/p/" 'test-run)
+                 (list :process nil :errors (list err) :time time)
+                 flycheck--project-runs)
+        (expect (flycheck--project-error-time err) :to-equal time)))
+
+    (it "returns nothing for an error no run reported"
+      (expect (flycheck--project-error-time
+               (flycheck-error-new-at 1 1 'error "x" :filename "/p/a.el"
+                                      :buffer nil))
+              :to-be nil))))
+
 (provide 'test-quick-fixes)
 
 ;;; test-quick-fixes.el ends here

--- a/test/specs/test-quick-fixes.el
+++ b/test/specs/test-quick-fixes.el
@@ -698,6 +698,113 @@ bounds the fix of a file the checker read from disk."
              (err (flycheck-test--fix-error file (lambda (_err) nil))))
         (expect (flycheck--apply-error-fix err 'visit) :to-be nil))))
 
+  (describe "flycheck--fix-files-to-open"
+
+    (it "lists the files fixing would have to open, once each"
+      (let* ((a (flycheck-test--fix-file "a.el" "helo\n"))
+             (b (flycheck-test--fix-file "b.el" "helo\n")))
+        (find-file-noselect b)
+        (expect (flycheck--fix-files-to-open
+                 (list (flycheck-test--fix-error a)
+                       (flycheck-test--fix-error a)
+                       (flycheck-test--fix-error b)))
+                :to-equal (list a))))
+
+    (it "ignores errors that carry no fix"
+      (let ((a (flycheck-test--fix-file "a.el" "helo\n")))
+        (expect (flycheck--fix-files-to-open
+                 (list (flycheck-error-new-at 1 1 'error "x" :filename a
+                                              :buffer nil)))
+                :to-be nil))))
+
+  (describe "flycheck--fix-errors-across-files"
+
+    (it "fixes several files at once and counts them"
+      (let* ((a (flycheck-test--fix-file "a.el" "helo\n"))
+             (b (flycheck-test--fix-file "b.el" "helo\n")))
+        (expect (flycheck--fix-errors-across-files
+                 (list (flycheck-test--fix-error a)
+                       (flycheck-test--fix-error b)))
+                :to-equal '(2 2 0))
+        (dolist (file (list a b))
+          (with-current-buffer (find-buffer-visiting file)
+            (expect (buffer-string) :to-equal "hello\n")))))
+
+    (it "skips a file that changed and fixes the rest"
+      (let* ((a (flycheck-test--fix-file "a.el" "helo\n"))
+             (b (flycheck-test--fix-file "b.el" "helo\n")))
+        (with-current-buffer (find-file-noselect a)
+          (goto-char (point-max))
+          (insert "extra\n"))
+        (expect (flycheck--fix-errors-across-files
+                 (list (flycheck-test--fix-error a)
+                       (flycheck-test--fix-error b)))
+                :to-equal '(1 1 1))
+        (with-current-buffer (find-buffer-visiting a)
+          (expect (buffer-string) :to-equal "helo\nextra\n"))
+        (with-current-buffer (find-buffer-visiting b)
+          (expect (buffer-string) :to-equal "hello\n"))))
+
+    (it "opens nothing when the project's results are stale"
+      (let* ((a (flycheck-test--fix-file "a.el" "helo\n"))
+             (err (flycheck-test--fix-error a)))
+        (flycheck-test--record-run err (time-add (current-time) -60))
+        (expect (flycheck--fix-errors-across-files (list err))
+                :to-equal '(0 0 1))
+        (expect (find-buffer-visiting a) :to-be nil)))
+
+    (it "skips a file whole when one of its fixes is unbounded"
+      ;; The first error opens the file; the second one, which nothing
+      ;; bounds, then keeps the whole file out rather than riding along.
+      (let* ((a (flycheck-test--fix-file "a.el" "helo\n"))
+             (bounded (flycheck-test--fix-error a))
+             (unbounded (flycheck-error-new-at
+                         1 1 'error "typo" :filename a :buffer nil
+                         :fix (flycheck-test--edit 1 1 1 5 "hello"))))
+        (expect (flycheck--fix-errors-across-files (list bounded unbounded))
+                :to-equal '(0 0 2))
+        (with-current-buffer (find-buffer-visiting a)
+          (expect (buffer-string) :to-equal "helo\n"))))
+
+    (it "counts an error whose file is gone as skipped"
+      (expect (flycheck--fix-errors-across-files
+               (list (flycheck-test--fix-error
+                      (expand-file-name "gone.el" flycheck-test--fix-dir))))
+              :to-equal '(0 0 1)))
+
+    (it "leaves errors without a fix alone"
+      (let ((a (flycheck-test--fix-file "a.el" "helo\n")))
+        (expect (flycheck--fix-errors-across-files
+                 (list (flycheck-error-new-at 1 1 'error "x" :filename a
+                                              :buffer nil)))
+                :to-equal '(0 0 0))
+        (expect (find-buffer-visiting a) :to-be nil)))
+
+    (it "counts a fix that conflicts with another in the same file"
+      (let ((a (flycheck-test--fix-file "a.el" "helo\n")))
+        (expect (flycheck--fix-errors-across-files
+                 (list (flycheck-test--fix-error a)
+                       (flycheck-test--fix-error
+                        a (flycheck-test--edit 1 1 1 5 "hey"))))
+                :to-equal '(1 1 1))))
+
+    (it "still answers to the buffer's tick for its own errors"
+      ;; An error the buffer's own check reported carries the tick of that
+      ;; check; editing the buffer since must keep its fix out.
+      (let* ((a (flycheck-test--fix-file "a.el" "helo\n"))
+             (buffer (find-file-noselect a))
+             (err (with-current-buffer buffer
+                    (flycheck-error-new-at
+                     1 1 'error "typo"
+                     :fix (flycheck-fix-new
+                           :edits (flycheck-fix-edits
+                                   (flycheck-test--edit 1 1 1 5 "hello"))
+                           :tick (1- (buffer-chars-modified-tick buffer)))))))
+        (expect (flycheck--fix-errors-across-files (list err))
+                :to-equal '(0 0 1))
+        (with-current-buffer buffer
+          (expect (buffer-string) :to-equal "helo\n")))))
+
   (describe "flycheck--project-error-time"
 
     (it "returns the time of the run that reported the error"


### PR DESCRIPTION
A project checker reports fixable diagnostics for files no buffer visits, and the error list refused every one of them. Now `x` opens the file an error belongs to and applies the fix there, and `X` in project scope fixes every file the list shows, one undoable change per file.

The awkward half is staleness: the tick a fix carries belongs to the buffer that ran the check, not to the file it edits. So a cross-file fix answers to a bound instead, and one that nothing bounds is refused rather than applied at positions that may describe an older file.