### PR TITLE
Leave a deleting rustc suggestion's message alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Bugs fixed
 
+- [#2388](https://github.com/flycheck/flycheck/pull/2388): A rustc or Clippy suggestion that only deletes code, like "remove this `mut`", keeps its own message instead of having the empty replacement appended to it.
 - [#2383](https://github.com/flycheck/flycheck/pull/2383): A buffer using `flycheck-lsp-prefer-server` contributes its server’s findings to the error list’s project scope and the mode-line project counts, as one using `flycheck-lsp-mode` already did.
 - [#2371](https://github.com/flycheck/flycheck/pull/2371): LSP quick fixes work in a buffer on a remote host, where the server names the file as its own host sees it and Flycheck compared that against the buffer's remote name, silently declining every fix; the native `flycheck-lsp` client now declines a remote buffer outright, since it looked the server up on the remote host but started it on this one, and leaves those buffers to the command checkers.
 - [#2370](https://github.com/flycheck/flycheck/pull/2370): Remote checking keeps the two machines straight: a related location a checker reports on the remote host now opens there rather than at the same path on the local machine, and the `c/c++-clang`, `c/c++-gcc`, `fortran-gfortran`, `d-dmd`, `haskell-ghc`, `haskell-stack-ghc`, `rst-sphinx` and `emacs-lisp` checkers pass plain remote paths on their command lines instead of TRAMP file names the remote tool cannot resolve.

--- a/flycheck.el
+++ b/flycheck.el
@@ -11641,8 +11641,12 @@ https://github.com/rust-lang/rust/blob/master/src/librustc_errors/json.rs#L154"
             ;; Messages from `cargo clippy' may suggest replacement code.  In
             ;; these cases, the `message' field itself is an unhelpful `try' or
             ;; `change this to'.  We add the `suggested_replacement' field in
-            ;; these cases.
-            (if .suggested_replacement
+            ;; these cases.  A suggestion that deletes has an empty
+            ;; replacement, and its message already says what goes ("remove
+            ;; this `mut'"), so appending an empty pair of backquotes to it
+            ;; only makes it look broken.
+            (if (and .suggested_replacement
+                     (not (string-empty-p .suggested_replacement)))
                 (format "%s: `%s`" message .suggested_replacement)
               message)
             :id error-code

--- a/test/specs/languages/test-rust.el
+++ b/test/specs/languages/test-rust.el
@@ -373,6 +373,26 @@
       '(2 5 warning "unneeded `return` statement" :id "clippy::needless_return" :end-line 2 :end-column 16)
       '(2 5 info "for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#needless_return" :id "clippy::needless_return" :end-line 2 :end-column 16)
       '(2 5 info "`#[warn(clippy::needless_return)]` on by default" :id "clippy::needless_return" :end-line 2 :end-column 16)
-      '(2 5 info "remove `return`: `true`" :id "clippy::needless_return" :end-line 2 :end-column 16))))
+      '(2 5 info "remove `return`: `true`" :id "clippy::needless_return" :end-line 2 :end-column 16)))
+
+  (describe "reading a suggestion"
+
+    (it "leaves the message of a suggestion that deletes alone"
+      ;; Such a suggestion has an empty replacement, and its own message
+      ;; already says what goes, so appending the replacement would render
+      ;; as "remove this `mut`: ``".
+      (let* ((diag "{\"message\":\"variable does not need to be mutable\",\
+\"code\":{\"code\":\"unused_mut\"},\"level\":\"warning\",\
+\"spans\":[{\"file_name\":\"a.rs\",\"is_primary\":true,\
+\"line_start\":2,\"line_end\":2,\"column_start\":9,\"column_end\":16}],\
+\"children\":[{\"message\":\"remove this `mut`\",\"spans\":[\
+{\"file_name\":\"a.rs\",\"line_start\":2,\"line_end\":2,\
+\"column_start\":9,\"column_end\":13,\"suggested_replacement\":\"\",\
+\"suggestion_applicability\":\"MachineApplicable\"}]}]}")
+             (messages (mapcar #'flycheck-error-message
+                               (flycheck-parse-rustc-diagnostic
+                                (car (flycheck-parse-json diag)) 'rust-cargo
+                                (current-buffer)))))
+        (expect messages :to-contain "remove this `mut`")))))
 
 ;;; test-rust.el ends here


### PR DESCRIPTION
rustc marks a suggestion that removes code with an empty replacement, and the parser appended it anyway, so "remove this `mut`" showed up in the error list with a stray empty pair of backquotes after it. Noticed while shooting a demo of the project checkers, where `cargo check` produces exactly this shape.
