### PR TITLE
Fix two things wrong with the error list's File column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Bugs fixed
 
+- [#2390](https://github.com/flycheck/flycheck/pull/2390): The error list's group headers are no longer cut off: they share the File column with the file names, which is now made wide enough for them.
+- [#2390](https://github.com/flycheck/flycheck/pull/2390): A file in a project the buffer and the checker spell differently, as they do for a symlinked directory or macOS's `/tmp`, is named relative to the project in the error list rather than by its whole path.
 - [#2388](https://github.com/flycheck/flycheck/pull/2388): A rustc or Clippy suggestion that only deletes code, like "remove this `mut`", keeps its own message instead of having the empty replacement appended to it.
 - [#2383](https://github.com/flycheck/flycheck/pull/2383): A buffer using `flycheck-lsp-prefer-server` contributes its server’s findings to the error list’s project scope and the mode-line project counts, as one using `flycheck-lsp-mode` already did.
 - [#2371](https://github.com/flycheck/flycheck/pull/2371): LSP quick fixes work in a buffer on a remote host, where the server names the file as its own host sees it and Flycheck compared that against the buffer's remote name, silently declining every fix; the native `flycheck-lsp` client now declines a remote buffer outright, since it looked the server up on the remote host but started it on this one, and leaves those buffers to the command checkers.

--- a/flycheck.el
+++ b/flycheck.el
@@ -5486,11 +5486,21 @@ would otherwise never match what the server says about it."
       (list project-key))))
 
 (defvar flycheck--truenames (make-hash-table :test 'equal)
-  "True names of the paths compared against project keys, memoized.
+  "True names of local paths Flycheck compares against each other, memoized.
 Global, unlike the buffer's `flycheck--file-truename': these are the
-paths servers and stores name, not the buffer's own.
+paths stores, servers and the error list compare, whoever named them.
 A path's true name does not change over a session short of retargeting
 a symbolic link, and the same paths come up on every aggregation.")
+
+(defun flycheck--memoized-truename (path)
+  "Return the true name of PATH, or PATH itself when it has none.
+
+Memoized in `flycheck--truenames': the same paths come up on every
+aggregation, and each lookup is a `file-truename' walk."
+  (or (gethash path flycheck--truenames)
+      (puthash path
+               (or (ignore-errors (file-truename path)) path)
+               flycheck--truenames)))
 
 (defun flycheck--path-under-prefixes-p (path prefixes)
   "Whether the absolute PATH extends one of the directory PREFIXES.
@@ -5500,11 +5510,7 @@ PATH may come from a server or a buffer in another spelling of the
 same place - a symlinked directory, macOS's /tmp; its true name is
 tried when the spelling as given does not match."
   (or (seq-some (lambda (prefix) (string-prefix-p prefix path)) prefixes)
-      (let ((truename (or (gethash path flycheck--truenames)
-                          (puthash path
-                                   (or (ignore-errors (file-truename path))
-                                       path)
-                                   flycheck--truenames))))
+      (let ((truename (flycheck--memoized-truename path)))
         (and (not (equal truename path))
              (seq-some (lambda (prefix) (string-prefix-p prefix truename))
                        prefixes)))))
@@ -7907,9 +7913,23 @@ read the project-wide diagnostics of that buffer's project."
             (dir (and (buffer-live-p flycheck-error-list-source-buffer)
                       (buffer-local-value 'default-directory
                                           flycheck-error-list-source-buffer))))
-      (if (string-prefix-p dir filename)
-          (file-relative-name filename dir)
-        (abbreviate-file-name filename))
+      (cond
+       ((string-prefix-p dir filename) (file-relative-name filename dir))
+       ;; The buffer's directory and the name a checker reports can be
+       ;; different spellings of the same place - a symlinked project, macOS
+       ;; mounting /tmp on /private/tmp - and without resolving them every
+       ;; row of such a project shows a whole absolute path.  Only for local
+       ;; absolute names: a remote true name costs a round trip per path and
+       ;; this runs on every refresh, and a relative one would be resolved
+       ;; against whichever buffer happens to be current.
+       ((and (file-name-absolute-p filename)
+             (not (file-remote-p filename))
+             (not (file-remote-p dir))
+             (let ((true-dir (flycheck--memoized-truename dir))
+                   (true-file (flycheck--memoized-truename filename)))
+               (and (string-prefix-p true-dir true-file)
+                    (file-relative-name true-file true-dir)))))
+       (t (abbreviate-file-name filename)))
     (or filename "<no file>")))
 
 (defun flycheck-error-list--group-key-function (dimension)

--- a/flycheck.el
+++ b/flycheck.el
@@ -7440,6 +7440,9 @@ displayed; see `flycheck-error-list--update-format'.")
     (flycheck--error-list-compute-msg-offset flycheck-error-list-format)
   "Amount of space to use in `flycheck-flush-multiline-message'.")
 
+(defconst flycheck-error-list--file-column-max 40
+  "How wide the File column of the error list may get, in columns.")
+
 (defun flycheck-error-list--column-widths (errors)
   "Compute the File and ID column widths for ERRORS.
 
@@ -7451,7 +7454,8 @@ Return a cons cell (FILE-WIDTH . ID-WIDTH)."
                               (length (file-name-nondirectory file)))))
       (when-let* ((id (flycheck-error-id err)))
         (setq id-width (max id-width (length (format "%s" id))))))
-    (cons (min file-width 40) (min id-width 24))))
+    (cons (min file-width flycheck-error-list--file-column-max)
+          (min id-width 24))))
 
 (defun flycheck-error-list--set-column-width (format name width)
   "Set the width of the column NAME in FORMAT to WIDTH.
@@ -7467,10 +7471,15 @@ ignored."
 
 (defun flycheck-error-list--update-format ()
   "Fit the File and ID column widths to the displayed errors."
-  (pcase-let ((`(,file-width . ,id-width)
-               (flycheck-error-list--column-widths
-                (flycheck-error-list-apply-filter
-                 (flycheck-error-list-current-errors)))))
+  (let* ((errors (flycheck-error-list-apply-filter
+                  (flycheck-error-list-current-errors)))
+         (widths (flycheck-error-list--column-widths errors))
+         (file-width
+          (min flycheck-error-list--file-column-max
+               (max (car widths)
+                       (flycheck-error-list--group-header-width
+                        errors (flycheck-error-list--grouping-dimensions)))))
+         (id-width (cdr widths)))
     (let ((format (copy-sequence flycheck-error-list-format)))
       (flycheck-error-list--set-column-width format "File" file-width)
       (flycheck-error-list--set-column-width format "ID" id-width)
@@ -7977,6 +7986,45 @@ headers above a still-present error keep their collapse too."
                    (remhash path flycheck-error-list--collapsed)))
                flycheck-error-list--collapsed))))
 
+(defun flycheck-error-list--group-header-label (dimension key count collapsed
+                                                         depth)
+  "Return the text of the header of a group at DEPTH.
+
+DIMENSION and KEY name the group, COUNT is how many errors it holds and
+COLLAPSED whether it is collapsed."
+  (format "%s%s %s (%d)"
+          (make-string (* 2 depth) ?\s)
+          (if collapsed "▸" "▾")
+          (flycheck-error-list--group-name dimension key)
+          count))
+
+(defun flycheck-error-list--group-header-width (errors dimensions)
+  "Return the width the headers of ERRORS grouped by DIMENSIONS need.
+
+The headers share the first column with the file names, and are usually
+longer than the names under them, so without this the group a reader is
+looking for is the part that gets elided.  The counts are taken over the
+whole list, which is exact for the outermost dimension and an upper
+bound for the ones nested under it, where a group holds only part of
+what its key names."
+  (let ((width 0) (depth 0))
+    (dolist (dimension dimensions)
+      (let ((counts (make-hash-table :test 'equal))
+            (key-fn (flycheck-error-list--group-key-function dimension)))
+        (dolist (err errors)
+          (let ((key (funcall key-fn err)))
+            (puthash key (1+ (gethash key counts 0)) counts)))
+        (maphash
+         (lambda (key count)
+           (setq width
+                 (max width
+                      (string-width
+                       (flycheck-error-list--group-header-label
+                        dimension key count nil depth)))))
+         counts))
+      (setq depth (1+ depth)))
+    width))
+
 (defun flycheck-error-list--group-header (path dimension key count collapsed depth)
   "Return a header entry for the group at PATH.
 
@@ -7987,11 +8035,8 @@ list headed by `flycheck-group', not a `flycheck-error', so
 navigation and the fix/explain commands skip it."
   (list (list 'flycheck-group path)
         (vector (flycheck-error-list-make-cell
-                 (format "%s%s %s (%d)"
-                         (make-string (* 2 depth) ?\s)
-                         (if collapsed "▸" "▾")
-                         (flycheck-error-list--group-name dimension key)
-                         count)
+                 (flycheck-error-list--group-header-label
+                  dimension key count collapsed depth)
                  'flycheck-error-list-group-header nil
                  'flycheck-error-list-group)
                 "" "" "" "" "")))

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -1069,7 +1069,71 @@ is when asked, so no earlier check has to vouch for it."
 
       (it "rejects an invalid message filter regexp"
         (expect (flycheck-error-list-set-message-filter "[")
-                :to-throw 'user-error)))
+                :to-throw 'user-error))
+
+      (it "fits the File column to the group headers it has to show"
+        ;; The headers live in that column, and are longer than the file
+        ;; names under them, so fitting the names alone elides the very
+        ;; thing the reader is looking for.
+        (flycheck-buttercup-with-temp-buffer
+          (setq flycheck-current-errors
+                (list (flycheck-error-new-at 1 1 'error "a" :checker 'foo
+                                             :filename "s.el")))
+          (let ((source (current-buffer)))
+            (flycheck/with-error-list-buffer
+              (setq flycheck-error-list-source-buffer source
+                    flycheck-error-list-group-by 'file)
+              (flycheck-error-list--update-format)
+              (expect (cadr (aref tabulated-list-format 0))
+                      :to-be-greater-than (length "s.el"))
+              (expect (cadr (aref tabulated-list-format 0))
+                      :to-equal (length "▾ s.el (1)"))))))
+
+      (it "fits the File column to a checker header too"
+        (flycheck-buttercup-with-temp-buffer
+          (setq flycheck-current-errors
+                (list (flycheck-error-new-at 1 1 'error "a"
+                                             :checker 'javascript-eslint
+                                             :filename "s.el")))
+          (let ((source (current-buffer)))
+            (flycheck/with-error-list-buffer
+              (setq flycheck-error-list-source-buffer source
+                    flycheck-error-list-group-by 'checker)
+              (flycheck-error-list--update-format)
+              (expect (cadr (aref tabulated-list-format 0))
+                      :to-equal (length "▾ javascript-eslint (1)"))))))
+
+      (it "sizes a header by what its own group holds"
+        ;; Not by the length of the whole list: nine errors in one file and
+        ;; one in another make a two-digit total and a one-digit group.
+        (flycheck-buttercup-with-temp-buffer
+          (setq flycheck-current-errors
+                (append (make-list 9 (flycheck-error-new-at
+                                      1 1 'error "a" :checker 'foo
+                                      :filename "a.el"))
+                        (list (flycheck-error-new-at 1 1 'error "b"
+                                                     :checker 'foo
+                                                     :filename "b.el"))))
+          (let ((source (current-buffer)))
+            (flycheck/with-error-list-buffer
+              (setq flycheck-error-list-source-buffer source
+                    flycheck-error-list-group-by 'file)
+              (flycheck-error-list--update-format)
+              (expect (cadr (aref tabulated-list-format 0))
+                      :to-equal (length "▾ a.el (9)"))))))
+
+      (it "leaves the column alone when nothing is grouped"
+        (flycheck-buttercup-with-temp-buffer
+          (setq flycheck-current-errors
+                (list (flycheck-error-new-at 1 1 'error "a" :checker 'foo
+                                             :filename "s.el")))
+          (let ((source (current-buffer)))
+            (flycheck/with-error-list-buffer
+              (setq flycheck-error-list-source-buffer source
+                    flycheck-error-list-group-by nil)
+              (flycheck-error-list--update-format)
+              (expect (cadr (aref tabulated-list-format 0))
+                      :to-equal (length "s.el")))))))
 
     (describe "Display"
       (it "displays the error list according to the display action"

--- a/test/specs/test-error-list.el
+++ b/test/specs/test-error-list.el
@@ -1135,6 +1135,88 @@ is when asked, so no earlier check has to vouch for it."
               (expect (cadr (aref tabulated-list-format 0))
                       :to-equal (length "s.el")))))))
 
+    (describe "Naming a file in a group header"
+
+      (it "names a file under the source buffer's directory relative to it"
+        (let ((source (generate-new-buffer " naming-source")))
+          (unwind-protect
+              (progn
+                (with-current-buffer source (setq default-directory "/p/"))
+                (flycheck/with-error-list-buffer
+                  (setq flycheck-error-list-source-buffer source)
+                  (expect (flycheck-error-list--abbreviate-filename "/p/a/b.el")
+                          :to-equal "a/b.el")))
+            (kill-buffer source))))
+
+      (it "resolves a project the buffer and the checker spell differently"
+        ;; A symlinked project directory, or macOS mounting /tmp on
+        ;; /private/tmp: the buffer holds one spelling and the checker
+        ;; reports the other, and the row showed a whole absolute path.
+        (let* ((real (file-name-as-directory
+                      (file-truename (make-temp-file "flycheck-real" t))))
+               (link (concat (directory-file-name real) "-link"))
+               (source (generate-new-buffer " naming-source")))
+          (unwind-protect
+              (progn
+                (make-symbolic-link (directory-file-name real) link t)
+                (with-current-buffer source
+                  (setq default-directory (file-name-as-directory link)))
+                (flycheck/with-error-list-buffer
+                  (setq flycheck-error-list-source-buffer source)
+                  (clrhash flycheck--truenames)
+                  (expect (flycheck-error-list--abbreviate-filename
+                           (expand-file-name "src/b.el" real))
+                          :to-equal "src/b.el")))
+            (kill-buffer source)
+            (ignore-errors (delete-file link))
+            (ignore-errors (delete-directory real t)))))
+
+      (it "does not resolve the names of files on another host"
+        ;; A remote true name costs a round trip per path, and this runs on
+        ;; every refresh of the list.
+        (let ((source (generate-new-buffer " naming-source")))
+          (unwind-protect
+              (progn
+                (with-current-buffer source
+                  (setq default-directory "/ssh:host:/p/"))
+                (flycheck/with-error-list-buffer
+                  (setq flycheck-error-list-source-buffer source)
+                  (spy-on 'flycheck--memoized-truename :and-call-through)
+                  (expect (flycheck-error-list--abbreviate-filename
+                           "/ssh:host:/q/b.el")
+                          :to-equal "/ssh:host:/q/b.el")
+                  (expect 'flycheck--memoized-truename
+                          :not :to-have-been-called)))
+            (kill-buffer source))))
+
+      (it "does not resolve a name that is not absolute"
+        ;; `file-truename' would resolve it against whichever buffer is
+        ;; current, and cache the answer under the bare name.
+        (let ((source (generate-new-buffer " naming-source")))
+          (unwind-protect
+              (progn
+                (with-current-buffer source (setq default-directory "/p/"))
+                (flycheck/with-error-list-buffer
+                  (setq flycheck-error-list-source-buffer source)
+                  (spy-on 'flycheck--memoized-truename :and-call-through)
+                  (expect (flycheck-error-list--abbreviate-filename "s.el")
+                          :to-equal "s.el")
+                  (expect 'flycheck--memoized-truename
+                          :not :to-have-been-called)))
+            (kill-buffer source))))
+
+      (it "falls back to the whole name for a file outside the project"
+        (let ((source (generate-new-buffer " naming-source")))
+          (unwind-protect
+              (progn
+                (with-current-buffer source (setq default-directory "/p/"))
+                (flycheck/with-error-list-buffer
+                  (setq flycheck-error-list-source-buffer source)
+                  (expect (flycheck-error-list--abbreviate-filename
+                           "/elsewhere/b.el")
+                          :to-equal "/elsewhere/b.el")))
+            (kill-buffer source)))))
+
     (describe "Display"
       (it "displays the error list according to the display action"
         (let (received-action)


### PR DESCRIPTION
Two things wrong with the error list's File column, both found while shooting the docs demos.

A group header shares that column with the file names, and is longer than any of them, so fitting the column to the names cut every header off: `models.py …` instead of `models.py (3)`. That is visible in the manual's own screenshot of the grouped list. Under file grouping the leaf rows have no file name to show, so the wider column reads as the indent of a tree, which is the tradeoff here.

The second one only shows up when the project is reached through a symlink, macOS's `/tmp` being the case that caught me: the buffer holds one spelling and the checker reports the other, the literal comparison decides the file is outside the project, and the header shows a whole absolute path. It now compares true names, the way the project store already does, for local absolute names only.
