### PR TITLE
Let no minimum level mean no minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Bugs fixed
 
+- [#2391](https://github.com/flycheck/flycheck/pull/2391): Setting `flycheck-relevant-error-other-file-minimum-level` to nil shows errors of every level from other files, as it says it does, rather than dropping the `info` ones.
 - [#2390](https://github.com/flycheck/flycheck/pull/2390): The error list's group headers are no longer cut off: they share the File column with the file names, which is now made wide enough for them.
 - [#2390](https://github.com/flycheck/flycheck/pull/2390): A file in a project the buffer and the checker spell differently, as they do for a symlinked directory or macOS's `/tmp`, is named relative to the project in the error list rather than by its whole path.
 - [#2388](https://github.com/flycheck/flycheck/pull/2388): A rustc or Clippy suggestion that only deletes code, like "remove this `mut`", keeps its own message instead of having the empty replacement appended to it.

--- a/flycheck.el
+++ b/flycheck.el
@@ -6068,9 +6068,12 @@ Return ERRORS, modified in-place."
          flycheck-relevant-error-other-file-show
          (or (null buffer-file-name)
              (not (flycheck-same-files-p buffer-file-name file-name)))
-         (<= (flycheck-error-level-severity
-              flycheck-relevant-error-other-file-minimum-level)
-             (flycheck-error-level-severity (flycheck-error-level err))))))
+         ;; nil means every level, which is not the same as the severity
+         ;; of nil: that is 0, and `info' sits below it.
+         (or (null flycheck-relevant-error-other-file-minimum-level)
+             (<= (flycheck-error-level-severity
+                  flycheck-relevant-error-other-file-minimum-level)
+                 (flycheck-error-level-severity (flycheck-error-level err)))))))
 
 (defun flycheck-relevant-error-p (err)
   "Determine whether ERR is relevant for the current buffer.

--- a/test/specs/test-error-api.el
+++ b/test/specs/test-error-api.el
@@ -381,6 +381,34 @@
       (let ((err (flycheck-error-new-at 5 7 'error))
             (rel (flycheck-related-location-new :line 1 :message "here")))
         (setf (flycheck-error-relations err) (list rel))
-        (expect (flycheck-error-relations err) :to-equal (list rel))))))
+        (expect (flycheck-error-relations err) :to-equal (list rel)))))
+
+  (describe "Errors about another file"
+
+    (defun test-error-api/relevant-p (level minimum)
+      "Whether an error of LEVEL about another file shows under MINIMUM."
+      (flycheck-buttercup-with-temp-buffer
+        (setq buffer-file-name "/p/this.el")
+        (let ((flycheck-relevant-error-other-file-minimum-level minimum))
+          (and (flycheck-relevant-error-p
+                (flycheck-error-new-at 1 1 level "m" :filename "/p/other.el"
+                                       :buffer (current-buffer)))
+               t))))
+
+    (it "keeps one at the minimum level"
+      (expect (test-error-api/relevant-p 'error 'error) :to-be t))
+
+    (it "drops one below the minimum level"
+      (expect (test-error-api/relevant-p 'warning 'error) :to-be nil))
+
+    (it "keeps every level when there is no minimum"
+      ;; nil means every level, and `info' sits below the severity nil
+      ;; itself has, so the comparison has to be skipped rather than made.
+      (expect (test-error-api/relevant-p 'info nil) :to-be t)
+      (expect (test-error-api/relevant-p 'warning nil) :to-be t))
+
+    (it "drops them all when they are turned off"
+      (let ((flycheck-relevant-error-other-file-show nil))
+        (expect (test-error-api/relevant-p 'error nil) :to-be nil)))))
 
 ;;; test-error-api.el ends here


### PR DESCRIPTION
Setting `flycheck-relevant-error-other-file-minimum-level` to nil is documented as showing every error from another file. It compared against the severity of nil instead of skipping the comparison, and since that severity is 0 while `info` is -10, info-level errors stayed hidden. Found while shooting a demo of the error list, where an info row from another file never turned up.