### PR TITLE
Stop a remote checker when its check is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Bugs fixed
 
+- [#2395](https://github.com/flycheck/flycheck/pull/2395): A check that is stopped, or superseded by the next one, no longer leaves its checker running on the remote host: Flycheck interrupts the command there, which is what actually stops it, rather than only dropping its own end of the process.
 - [#2394](https://github.com/flycheck/flycheck/pull/2394): A checker that reads the buffer from standard input now works on a remote host, where the check used to run for ever without ever reporting: Flycheck writes the buffer to a file there and has the remote shell redirect it, since standard input cannot be closed over a TRAMP connection.
 - [#2391](https://github.com/flycheck/flycheck/pull/2391): Setting `flycheck-relevant-error-other-file-minimum-level` to nil shows errors of every level from other files, as it says it does, rather than dropping the `info` ones.
 - [#2390](https://github.com/flycheck/flycheck/pull/2390): The error list's group headers are no longer cut off: they share the File column with the file names, which is now made wide enough for them.

--- a/flycheck.el
+++ b/flycheck.el
@@ -5819,8 +5819,10 @@ fixes is the check of the buffer that reported them, see
     (maphash (lambda (key state)
                (when (equal (car key) project-key)
                  (when-let* ((proc (plist-get state :process)))
-                   (when (process-live-p proc)
-                     (delete-process proc)))
+                   ;; Out of the table first; see `flycheck--project-run'.
+                   (puthash key (plist-put (copy-sequence state) :process nil)
+                            flycheck--project-runs)
+                   (flycheck--delete-process proc))
                  (push key stale)))
              flycheck--project-runs)
     (dolist (key stale)
@@ -5882,10 +5884,15 @@ fixes is the check of the buffer that reported them, see
   "Start the project checker CHECKER with PROPS over the project at ROOT."
   (let* ((key (cons root checker))
          (state (gethash key flycheck--project-runs)))
-    ;; A fresher run replaces one still under way
+    ;; A fresher run replaces one still under way.  Take it out of the
+    ;; table before stopping it: stopping can run its sentinel there and
+    ;; then, and a sentinel that still finds its own process in the table
+    ;; treats the abandoned run as the current one and publishes what it
+    ;; had printed so far.
     (when-let* ((proc (plist-get state :process)))
-      (when (process-live-p proc)
-        (delete-process proc)))
+      (puthash key (plist-put (copy-sequence state) :process nil)
+               flycheck--project-runs)
+      (flycheck--delete-process proc))
     (let* ((default-directory root)
            (stdout (generate-new-buffer
                     (format " *flycheck-project-%s*" checker)))
@@ -10816,14 +10823,36 @@ PROCESS, and terminates standard input with EOF."
        (when process
          ;; No need to explicitly delete the temporary files of the process,
          ;; because deleting runs the sentinel, which will delete them anyway.
-         (delete-process process))
+         (flycheck--delete-process process))
        (signal (car err) (cdr err))))))
+
+(defun flycheck--delete-process (process)
+  "Delete PROCESS, stopping the command behind it wherever it runs.
+
+`delete-process' only drops Emacs\='s end of a remote process: the
+command keeps running on the other host, and a check superseded by the
+next one leaves it there.  Tramp records the pid of that command and
+signals it when the process is interrupted, so interrupt first and let
+the deletion clean up after it."
+  (when (process-live-p process)
+    (unwind-protect
+        ;; Only Tramp's own processes carry a remote pid, and such a
+        ;; process is the connection, so a live one means the connection is
+        ;; open.  It can still be hung -- a suspended laptop, a dropped
+        ;; network -- and this runs from `kill-buffer', so bound the wait
+        ;; rather than let a teardown hang on it.
+        (when (process-get process 'remote-pid)
+          (with-timeout (1 nil)
+            (ignore-errors (interrupt-process process))))
+      ;; Whatever happened above, including a `C-g' out of Tramp, Emacs's
+      ;; end of the process still has to go.
+      (delete-process process))))
 
 (defun flycheck-interrupt-command-checker (_checker process)
   "Interrupt a PROCESS."
   ;; Deleting the process always triggers the sentinel, which does the cleanup
   (when process
-    (delete-process process)))
+    (flycheck--delete-process process)))
 
 (defun flycheck-command-checker-print-doc (checker)
   "Print additional documentation for a command CHECKER."

--- a/test/specs/test-project-runs.el
+++ b/test/specs/test-project-runs.el
@@ -114,6 +114,70 @@
           (expect (flycheck-error-line (car errors)) :to-equal 3)
           (expect (flycheck-error-message (car errors)) :to-equal "boom"))))
 
+    (it "stops naming a run before it stops it"
+      ;; Stopping a process can run its sentinel there and then, and a
+      ;; sentinel that still finds its own process in the table takes the
+      ;; abandoned run for the current one and publishes whatever it had
+      ;; printed by the time it was killed.
+      (flycheck-test--define-run-checker
+       :command (flycheck-test--emacs-command
+                 '(progn (princ "gamma.rb:3:boom\n")
+                         (sleep-for 30))))
+      (flycheck-test--with-temp-project dir
+        (let ((key (cons dir 'test-run))
+              (named-when-stopped 'not-called))
+          (flycheck-check-project)
+          ;; Wait for the run to be under way, so there is something to
+          ;; abandon in the first place.
+          (let ((deadline (+ 10 (float-time))))
+            (while (and (not (process-live-p
+                              (plist-get (gethash key flycheck--project-runs)
+                                         :process)))
+                        (< (float-time) deadline))
+              (accept-process-output nil 0.05)))
+          (expect (process-live-p
+                   (plist-get (gethash key flycheck--project-runs) :process))
+                  :to-be-truthy)
+          (spy-on 'flycheck--delete-process :and-call-fake
+                  (lambda (process)
+                    (setq named-when-stopped
+                          (eq process
+                              (plist-get (gethash key flycheck--project-runs)
+                                         :process)))
+                    (delete-process process)))
+          (flycheck--project-runs-forget dir)
+          (expect named-when-stopped :to-be nil))))
+
+    (it "stops naming a run the next one replaces"
+      ;; The same hazard on the other path: a fresher run over the same
+      ;; project stops the one still under way.
+      (flycheck-test--define-run-checker
+       :command (flycheck-test--emacs-command
+                 '(progn (princ "gamma.rb:3:boom\n")
+                         (sleep-for 30))))
+      (flycheck-test--with-temp-project dir
+        (let ((key (cons dir 'test-run))
+              (named-when-stopped 'not-called))
+          (flycheck-check-project)
+          (let ((deadline (+ 10 (float-time))))
+            (while (and (not (process-live-p
+                              (plist-get (gethash key flycheck--project-runs)
+                                         :process)))
+                        (< (float-time) deadline))
+              (accept-process-output nil 0.05)))
+          (expect (process-live-p
+                   (plist-get (gethash key flycheck--project-runs) :process))
+                  :to-be-truthy)
+          (spy-on 'flycheck--delete-process :and-call-fake
+                  (lambda (process)
+                    (setq named-when-stopped
+                          (eq process
+                              (plist-get (gethash key flycheck--project-runs)
+                                         :process)))
+                    (delete-process process)))
+          (flycheck-check-project)
+          (expect named-when-stopped :to-be nil))))
+
     (it "replaces the previous run's results"
       (flycheck-test--define-run-checker)
       (flycheck-test--with-temp-project dir

--- a/test/specs/test-tramp.el
+++ b/test/specs/test-tramp.el
@@ -275,6 +275,98 @@ the checker is given."
             (expect 'flycheck-process-send-buffer :to-have-been-called))
         (ignore-errors (delete-file local))))))
 
+(describe "Interrupting a check on a remote host"
+
+  ;; `delete-process' drops Emacs's end of a remote process and leaves the
+  ;; command running on the other host.  The mock method runs it locally,
+  ;; so the spec can watch for it and say whether it really stopped.
+
+  (before-all
+    (flycheck-test-tramp-setup-method))
+
+  (after-each
+    (setf (symbol-plist 'test-slow) nil)
+    (ignore-errors (tramp-cleanup-all-connections)))
+
+  (defun flycheck-test-checker-process ()
+    "Return the process of the check running in this buffer, if any.
+Flycheck notes the buffer on the process, which is what tells this
+buffer\='s check from one an earlier spec left behind."
+    (let ((buffer (current-buffer)))
+      (seq-find (lambda (process)
+                  (eq buffer (process-get process 'flycheck-buffer)))
+                (process-list))))
+
+  ;; The mock method runs the "remote" command as a local child of Emacs,
+  ;; in Emacs's own process group, so deleting the process stops it there
+  ;; whether or not it was interrupted first.  Only a real other host shows
+  ;; the difference, which is why this pins the mechanism rather than
+  ;; watching for the process: measured over ssh and over docker, a stopped
+  ;; check left its command running until the interrupt was added.
+
+  (it "interrupts the command on the other host, rather than only dropping it"
+    (assume (flycheck-test-tramp-connectable-p) "no mock TRAMP connection")
+    (let* ((local (make-temp-file "flycheck-interrupt-" nil ".txt" "hello\n"))
+           (remote (concat flycheck-test-tramp-remote-prefix local))
+           (buffer nil))
+      (flycheck-define-command-checker 'test-slow
+        "Reads standard input and then waits, long enough to be caught at it."
+        :command '("sh" "-c" "cat > /dev/null; sleep 60")
+        :standard-input t
+        :error-parser (lambda (_output _checker _buffer) nil)
+        :modes '(text-mode))
+      (unwind-protect
+          (progn
+            (setq buffer (find-file-noselect remote))
+            (with-current-buffer buffer
+              (text-mode)
+              (let ((flycheck-checkers '(test-slow))
+                    (flycheck-check-syntax-automatically nil))
+                (flycheck-mode)
+                (flycheck-buffer)
+                ;; Guard the guard: there is nothing to interrupt unless a
+                ;; check is running, and nothing remote to signal unless
+                ;; Tramp noted the pid it started over there.
+                (let ((process (flycheck-test-checker-process)))
+                  (expect process :to-be-truthy)
+                  (expect (process-get process 'remote-pid) :to-be-truthy))
+                (spy-on 'interrupt-process :and-call-through)
+                (flycheck-stop)
+                (expect 'interrupt-process :to-have-been-called))))
+        (when (buffer-live-p buffer) (kill-buffer buffer))
+        (ignore-errors (delete-file local)))))
+
+  (it "leaves a local check to be deleted as before"
+    (let* ((local (make-temp-file "flycheck-interrupt-" nil ".txt" "hello\n"))
+           (buffer nil))
+      (flycheck-define-command-checker 'test-slow
+        "Reads standard input and then waits."
+        :command '("sh" "-c" "cat > /dev/null; sleep 60")
+        :standard-input t
+        :error-parser (lambda (_output _checker _buffer) nil)
+        :modes '(text-mode))
+      (unwind-protect
+          (progn
+            (setq buffer (find-file-noselect local))
+            (with-current-buffer buffer
+              (text-mode)
+              (let ((flycheck-checkers '(test-slow))
+                    (flycheck-check-syntax-automatically nil))
+                (flycheck-mode)
+                (spy-on 'interrupt-process :and-call-through)
+                (flycheck-buffer)
+                ;; Guard the guard: an absence proves nothing if no check
+                ;; ever ran.
+                (let ((process (flycheck-test-checker-process)))
+                  (expect process :to-be-truthy)
+                  (flycheck-stop)
+                  ;; Locally the process is Emacs's own, and deleting it is
+                  ;; what has always stopped the checker.
+                  (expect 'interrupt-process :not :to-have-been-called)
+                  (expect (process-live-p process) :to-be nil)))))
+        (when (buffer-live-p buffer) (kill-buffer buffer))
+        (ignore-errors (delete-file local))))))
+
 (describe "flycheck--redirect-command"
 
   (it "runs the command through a shell that redirects the file"


### PR DESCRIPTION
Stopping a check left its checker running on the remote host. `delete-process` drops Emacs's end of a remote process and nothing more, so the command carries on where it was started, and since `flycheck-interrupt-running-checks` supersedes a check whenever a save arrives while one is still going, they pile up on the build box. Tramp records the pid it started and signals it when the process is interrupted, which is what actually stops the command. Measured over ssh and over docker: a stopped check used to leave its checker running, and now leaves nothing.

Found while stress-testing #2394 rather than from a report, and it is not caused by that change: a checker taking a file argument leaked in exactly the same way. It matters more now, since a checker reading standard input used to hang rather than run at all.

Interrupting is a round trip over a connection that may be hung, and it runs from `kill-buffer` among other places, so the wait is bounded and Emacs's end of the process goes whatever happens, including a `C-g` out of Tramp.

Project runs needed one more thing. Stopping a process can run its sentinel there and then, and a sentinel that still finds its own process in the table of runs takes the abandoned run for the current one and publishes whatever it had printed by the time it was killed. Both ways of abandoning a run now take it out of the table first. As it stands the kill signal makes that sentinel bail out by itself, so this is a latent hazard rather than a live bug, but it was luck rather than design.
