### PR TITLE
Stop a remote language server when Flycheck gives up on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Bugs fixed
 
+- [#2396](https://github.com/flycheck/flycheck/pull/2396): A language server running on a remote host is stopped there when Flycheck gives up on it, so a server that never answers the `initialize` handshake no longer leaves a copy of itself behind on every attempt.
 - [#2395](https://github.com/flycheck/flycheck/pull/2395): A check that is stopped, or superseded by the next one, no longer leaves its checker running on the remote host: Flycheck interrupts the command there, which is what actually stops it, rather than only dropping its own end of the process.
 - [#2394](https://github.com/flycheck/flycheck/pull/2394): A checker that reads the buffer from standard input now works on a remote host, where the check used to run for ever without ever reporting: Flycheck writes the buffer to a file there and has the remote shell redirect it, since standard input cannot be closed over a TRAMP connection.
 - [#2391](https://github.com/flycheck/flycheck/pull/2391): Setting `flycheck-relevant-error-other-file-minimum-level` to nil shows errors of every level from other files, as it says it does, rather than dropping the `info` ones.

--- a/flycheck.el
+++ b/flycheck.el
@@ -12701,7 +12701,7 @@ The `documents' table maps a document's canonical path (see
 `flycheck-lsp--doc-key') to a `flycheck-lsp--doc'.  `capabilities' is the
 server's advertised capability plist from its `initialize' reply, filled
 in once `initialized' turns non-nil (the handshake runs asynchronously)."
-  connection root command stderr capabilities initialized
+  connection process root command stderr capabilities initialized
   ;; Whether the workspace has been pulled here: a refresh request from
   ;; the server is worth honoring only then
   workspace-pulled
@@ -13190,9 +13190,12 @@ A no-op if the connection died in the meantime."
 Remove it from the registry so a later check starts a fresh one."
   (message "Flycheck LSP: %s failed to initialize (%s)"
            (car (flycheck-lsp--server-command server)) reason)
-  (flycheck-lsp--shutdown-server server)
-  (remhash (flycheck-lsp--server-key server) flycheck-lsp--servers))
+  ;; Through `flycheck-lsp--forget-server' for its ordering: shutting down
+  ;; pumps process output, and a push arriving then can register a fresh
+  ;; server under this key for a trailing `remhash' to drop instead.
+  (flycheck-lsp--forget-server (flycheck-lsp--server-key server) server))
 
+(defvar tramp-dont-suspend-timers)
 (defvar tramp-use-ssh-controlmaster-options)
 (declare-function tramp-shell-quote-argument "tramp" (s))
 (defvar tramp-ssh-controlmaster-options)
@@ -13263,6 +13266,7 @@ the server down.  Return nil if the process could not be spawned at all."
           ;; Spawned inside the handler below: a missing program signals
           ;; here, and the stderr buffer would be left behind.
           (setq proc (flycheck-lsp--spawn name command stderr))
+          (setf (flycheck-lsp--server-process server) proc)
           (setf (flycheck-lsp--server-connection server)
                 (make-instance
                  'jsonrpc-process-connection
@@ -13287,6 +13291,10 @@ the server down.  Return nil if the process could not be spawned at all."
       (error
        ;; `delete-process' reads nil as the current buffer's process, so
        ;; a spawn that never happened must not reach it.
+       ;; Stopped before `jsonrpc-shutdown', which otherwise spends its
+       ;; grace dropping a process that being dropped does not stop - the
+       ;; order `flycheck-lsp--shutdown-server' uses.
+       (flycheck-lsp--force-quit server)
        (when-let* ((conn (flycheck-lsp--server-connection server)))
          (ignore-errors (jsonrpc-shutdown conn 'cleanup-buffers)))
        (when proc (ignore-errors (delete-process proc)))
@@ -13300,6 +13308,11 @@ the server down.  Return nil if the process could not be spawned at all."
   (let* ((key (cons root command))
          (server (gethash key flycheck-lsp--servers)))
     (unless (and server (flycheck-lsp--server-live-p server))
+      ;; A server is only replaced once its connection has gone, which is
+      ;; the case where the server itself is likeliest to still be up on
+      ;; the other host.  Overwriting the registry entry would drop the
+      ;; last reference to it, with nothing left to stop it by.
+      (when server (flycheck-lsp--forget-server key server))
       (setq server (flycheck-lsp--start-server root command))
       (if server
           (puthash key server flycheck-lsp--servers)
@@ -13585,16 +13598,128 @@ a command checker by `flycheck-lsp-prefer-server'."
   "Note that a server's cached diagnostics no longer count."
   (flycheck--project-diagnostics-changed))
 
+(defvar flycheck-lsp--exiting nil
+  "Non-nil while servers are being torn down because Emacs is quitting.
+Bound by `flycheck-lsp--shutdown-all\='.  What hangs then cannot be
+interrupted, so a stopped server is worth more than a working
+connection.")
+
+(defvar flycheck-lsp--exit-grace 0.3
+  "Seconds a server gets to act on `exit' before it is signalled.
+A server told to exit may still be flushing state to disk, and every
+server left running at the end of a session spends this once.")
+
+(defun flycheck-lsp--await-exit (server)
+  "Give SERVER\\='s language server its grace to act on `exit'.
+Return once it has gone or the grace is spent."
+  (when-let* ((proc (flycheck-lsp--server-process server)))
+    (let ((deadline (+ (float-time) flycheck-lsp--exit-grace)))
+      (while (and (process-live-p proc) (< (float-time) deadline))
+        (accept-process-output proc 0.05)))))
+
+(defun flycheck-lsp--host-connected-p (directory)
+  "Return non-nil when DIRECTORY is on a host already connected to.
+
+Two things at once, both of which have to hold before a pid is worth
+signalling.  The pid counts on the server\\='s host and nowhere else, so a
+local DIRECTORY must never reach a kill: it would land on whatever holds
+that number HERE.  And the connection has to be one that already exists,
+because opening a fresh one can block for over a minute on a host that
+has gone away, which this cannot afford on `kill-emacs-hook'.  A host
+out of reach has taken its server with it either way."
+  (file-remote-p directory nil 'connected))
+
+(defun flycheck-lsp--force-quit (server)
+  "Stop SERVER\\='s language server on whatever host it runs on.
+
+Reached once the protocol\\='s own `shutdown' and `exit' have gone
+unanswered, and for a connection that died with the server still up.
+For a server on another host, stopping it is not something
+`delete-process' can do: that drops this end of the connection and
+leaves the server itself running.  Because a later check just starts a
+fresh one, a server that cannot complete a handshake would pile up a
+copy per attempt.
+
+A status of `exit' means the command itself ended, so there is nothing
+left to stop.  Any other status leaves it out there: still running, or
+`signal', which describes this end being dropped and says nothing about
+the other one.  The one case that reads too well is a transport failing
+with the server alive, which also ends up `exit'; that misses an orphan
+rather than signalling the wrong thing.
+
+Tramp starts the command as its own process group leader, so signalling
+the group takes with it any workers the server forked, with the bare
+process as the fallback for a kill(1) that will not take a group.  A
+local server needs none of this, being a real child that
+`delete-process' reaps, and neither does one Tramp recorded no
+`remote-pid' for, as its direct-async path does not."
+  (when-let* ((proc (flycheck-lsp--server-process server))
+              ((not (process-get proc 'flycheck-lsp-quit)))
+              ((not (eq (process-status proc) 'exit)))
+              (pid (process-get proc 'remote-pid))
+              (root (flycheck-lsp--server-root server))
+              ((flycheck-lsp--host-connected-p root))
+              ;; The connection's own directory, not the project's: a
+              ;; root that has since gone from the host fails the `cd'
+              ;; Tramp puts in front of the command, and the kill never
+              ;; runs while looking like it did.
+              (default-directory (concat (file-remote-p root) "/")))
+    ;; Tramp suspends timers around a connection transaction, so the
+    ;; timeout below is inert unless it is told not to.  Telling it costs
+    ;; the connection: a transaction cut off part way leaves the next
+    ;; command reading the last one's output, and file operations failing
+    ;; outright.  Worth it only where the connection has no future anyway
+    ;; and blocking cannot be escaped - Emacs on its way out, with no C-g
+    ;; left to press.
+    (when (let ((tramp-dont-suspend-timers flycheck-lsp--exiting))
+            (with-timeout (1 nil)
+              (ignore-errors
+                (process-file "sh" nil nil nil "-c"
+                              (format "kill -9 -%d 2>/dev/null || kill -9 %d 2>/dev/null"
+                                      pid pid))
+                t)))
+      ;; Marked only once the kill has gone out: one abandoned mid-flight
+      ;; is worth another pass, where a delivered one would be aimed at a
+      ;; pid the host may have given to something else by then.
+      (process-put proc 'flycheck-lsp-quit t))))
+
 (defun flycheck-lsp--shutdown-server (server)
-  "Politely shut SERVER's language server down and free its buffers."
-  (let ((conn (flycheck-lsp--server-connection server)))
-    (when (and conn (jsonrpc-running-p conn))
-      (ignore-errors (jsonrpc-request conn 'shutdown nil :timeout 1))
-      (ignore-errors (jsonrpc-notify conn 'exit nil))
-      (ignore-errors (jsonrpc-shutdown conn t))
-      (flycheck--lsp-server-gone)))
-  (when-let* ((stderr (flycheck-lsp--server-stderr server)))
-    (when (buffer-live-p stderr) (kill-buffer stderr))))
+  "Politely shut SERVER's language server down and free its buffers.
+
+The kill and the buffer are cleanup forms.  Waiting for a server pumps
+its output, which runs this again for whichever other server that output
+finishes off, and an exit thrown through the wait would otherwise leave
+this one running with its buffer behind it.  They signal nothing of
+their own: an error raised on the way out would stand in for whatever
+exit was already leaving.
+
+`jsonrpc-shutdown' stays outside them, and last.  It waits for a
+sentinel with no deadline of its own, pumping output as it goes, so
+running it before the servers nested inside that pumping have been
+stopped leaves its wait with nothing left to finish it."
+  (let* ((conn (flycheck-lsp--server-connection server))
+         (running (and conn (jsonrpc-running-p conn))))
+    (unwind-protect
+        (unwind-protect
+            (when running
+              (ignore-errors (jsonrpc-request conn 'shutdown nil :timeout 1))
+              (ignore-errors (jsonrpc-notify conn 'exit nil))
+              (flycheck-lsp--await-exit server))
+          ;; A connection gone is not a server stopped, so this happens
+          ;; whether or not the branch above ran.
+          (with-demoted-errors "Flycheck LSP: %S"
+            (flycheck-lsp--force-quit server)))
+      (with-demoted-errors "Flycheck LSP: %S"
+        (when-let* ((stderr (flycheck-lsp--server-stderr server)))
+          (when (buffer-live-p stderr) (kill-buffer stderr)))))
+    (when running
+      ;; Bounded even so: by now the server is stopped and what is left is
+      ;; buffer housekeeping, which is not worth a wait with no end of its
+      ;; own.  Unlike the kill, this is an ordinary
+      ;; `accept-process-output' wait, so a timer does reach it.
+      (with-timeout (2 nil)
+        (ignore-errors (jsonrpc-shutdown conn t)))
+      (flycheck--lsp-server-gone))))
 
 (defun flycheck-lsp--close-buffer ()
   "Close the current buffer's document on any server holding it.
@@ -13629,7 +13754,12 @@ Dropped first: shutting down pumps process output, and a diagnostics
 push arriving then can re-trigger a check that registers a fresh server
 under the same key.  Removing afterwards would delete that one instead,
 leaving its process running and unreachable."
-  (remhash key flycheck-lsp--servers)
+  ;; Identity-checked, for the same reason the order is what it is: a
+  ;; push arriving mid-teardown can register a fresh server under this
+  ;; key, and dropping that one would leak it exactly as a trailing
+  ;; `remhash\=' would.
+  (when (eq (gethash key flycheck-lsp--servers) server)
+    (remhash key flycheck-lsp--servers))
   (flycheck-lsp--shutdown-server server))
 
 (defun flycheck-lsp--server-buffer-count (server)
@@ -13747,10 +13877,19 @@ live buffer still owns."
 
 (defun flycheck-lsp--shutdown-all ()
   "Shut down every running LSP server.
-Added to `kill-emacs-hook' the first time a server starts."
-  (dolist (key (hash-table-keys flycheck-lsp--servers))
-    (when-let* ((server (gethash key flycheck-lsp--servers)))
-      (flycheck-lsp--forget-server key server))))
+Added to `kill-emacs-hook' the first time a server starts.
+
+Until the table is empty rather than once over its keys: tearing a
+server down pumps output, and a diagnostics push arriving then can start
+another.  One registered behind the sweep would be a server left running
+on another host with Emacs gone."
+  (let ((flycheck-lsp--exiting t)
+        (keys nil))
+    (while (setq keys (hash-table-keys flycheck-lsp--servers))
+      (let ((key (car keys)))
+        (if-let* ((server (gethash key flycheck-lsp--servers)))
+            (flycheck-lsp--forget-server key server)
+          (remhash key flycheck-lsp--servers))))))
 
 (defun flycheck-lsp--enable ()
   "Set up the current buffer to report its LSP server's diagnostics.

--- a/flycheck.el
+++ b/flycheck.el
@@ -10829,7 +10829,7 @@ PROCESS, and terminates standard input with EOF."
 (defun flycheck--delete-process (process)
   "Delete PROCESS, stopping the command behind it wherever it runs.
 
-`delete-process' only drops Emacs\='s end of a remote process: the
+`delete-process' only drops Emacs\\='s end of a remote process: the
 command keeps running on the other host, and a check superseded by the
 next one leaves it there.  Tramp records the pid of that command and
 signals it when the process is interrupted, so interrupt first and let
@@ -12302,7 +12302,7 @@ key into a server's own documents."
   "Return a `file:' URI naming PATH as the server's host sees it.
 
 A remote PATH is reduced with `file-local-name': the server runs on that
-host and knows nothing of Emacs\='s remote file names."
+host and knows nothing of Emacs\\='s remote file names."
   (let ((enc (url-hexify-string (file-local-name (expand-file-name path))
                                 (cons ?/ url-unreserved-chars))))
     (concat "file://" (if (string-prefix-p "/" enc) enc (concat "/" enc)))))
@@ -12823,12 +12823,12 @@ the root does not change over a buffer's life."
 (defun flycheck-lsp--buffer-uri ()
   "Return the `file:' URI of the current buffer's file, or nil.
 
-The URI names the file as the server\='s host sees it; the host itself is
+The URI names the file as the server\\='s host sees it; the host itself is
 carried by the document key, see `flycheck-lsp--doc-key'."
   (and buffer-file-name (flycheck-lsp--path-to-uri buffer-file-name)))
 
 (defun flycheck-lsp--server-remote (server)
-  "Return SERVER\='s remote prefix, or nil when it runs on this machine."
+  "Return SERVER\\='s remote prefix, or nil when it runs on this machine."
   (when-let* ((root (flycheck-lsp--server-root server)))
     (file-remote-p root)))
 
@@ -13206,7 +13206,7 @@ line discipline raw leaves the byte stream alone.  Eglot wraps remote
 servers the same way.
 
 Arguments are quoted the way a POSIX shell reads them rather than the
-way this machine\='s shell does, since that is what runs them."
+way this machine\\='s shell does, since that is what runs them."
   (list "sh" "-c"
         (concat "stty raw > /dev/null 2>&1; exec "
                 (mapconcat #'tramp-shell-quote-argument command " "))))

--- a/test/specs/test-lsp.el
+++ b/test/specs/test-lsp.el
@@ -27,6 +27,38 @@
 (require 'cl-lib)
 (require 'flycheck-buttercup)
 
+;; A stand-in for a server process that exits when its input closes, the
+;; way a real one acts on `exit'.  `remote-pid' is what tells a server on
+;; another host from a child of this Emacs.  Defined at top level rather
+;; than in the `describe' that uses them: a nested `defmacro' is not a
+;; top-level form, so byte-compiling the specs would leave it unexpanded.
+(defun flycheck-test-lsp-process (&optional remote-pid)
+  "Start a stand-in server process, optionally carrying REMOTE-PID."
+  (let ((proc (start-process "flycheck-test-lsp" nil
+                             "sh" "-c" "read _; exit 0")))
+    (set-process-query-on-exit-flag proc nil)
+    (when remote-pid (process-put proc 'remote-pid remote-pid))
+    proc))
+
+(defun flycheck-test-lsp-await (proc status)
+  "Wait for PROC to reach STATUS, so a spec never races its stand-in."
+  (let ((deadline (+ (float-time) 5)))
+    (while (and (not (eq (process-status proc) status))
+                (< (float-time) deadline))
+      (accept-process-output proc 0.02))
+    (process-status proc)))
+
+;; Enough of a connection for the shutdown path: it asks whether the
+;; connection runs, sends `shutdown' and `exit', then cleans up.
+(defmacro flycheck-test-with-stub-jsonrpc (running &rest body)
+  (declare (indent 1))
+  `(cl-letf (((symbol-function 'jsonrpc-running-p) (lambda (_) ,running))
+             ((symbol-function 'jsonrpc-request) (lambda (&rest _) nil))
+             ((symbol-function 'jsonrpc-notify) (lambda (&rest _) nil))
+             ((symbol-function 'jsonrpc-shutdown) (lambda (&rest _) nil))
+             ((symbol-function 'flycheck--lsp-server-gone) #'ignore))
+     ,@body))
+
 (describe "LSP diagnostics"
 
   (describe "flycheck-lsp--severity-level"
@@ -577,6 +609,344 @@
           (cl-letf (((symbol-function 'flycheck-lsp--shutdown-server) #'ignore))
             (flycheck-lsp--init-failed server "timeout"))
           (expect (gethash key flycheck-lsp--servers) :to-be nil))))
+
+    (describe "flycheck-lsp--force-quit"
+      (it "kills the process group on the host the server runs on"
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc))
+               (called nil))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (cl-letf (((symbol-function 'process-file)
+                           (lambda (program &rest args)
+                             (setq called (list default-directory program args))
+                             0)))
+                  (flycheck-lsp--force-quit server))
+                (expect called :not :to-be nil)
+                ;; On the server's own host, and at the connection's own
+                ;; directory: a project root that has gone from the host
+                ;; would fail Tramp's `cd' and swallow the kill.
+                (expect (nth 0 called) :to-equal "/mock:localhost:/")
+                (expect (nth 1 called) :to-equal "sh")
+                ;; The group first, so a server that forked workers goes with
+                ;; it, and the bare process as the fallback.
+                (expect (car (last (nth 2 called)))
+                        :to-equal
+                        (concat "kill -9 -4242 2>/dev/null"
+                                " || kill -9 4242 2>/dev/null")))
+            (delete-process proc))))
+
+      (it "stops a server whose connection died under it"
+        ;; The status a dropped connection leaves is `signal', which says
+        ;; nothing about the other host: that is the orphan case, not a
+        ;; reason to skip the kill.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc)))
+          (delete-process proc)
+          (expect (process-status proc) :to-be 'signal)
+          (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+          (spy-on 'process-file)
+          (flycheck-lsp--force-quit server)
+          (expect 'process-file :to-have-been-called)))
+
+      (it "leaves a server that exited on its own alone"
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc)))
+          (process-send-eof proc)
+          (expect (flycheck-test-lsp-await proc 'exit) :to-be 'exit)
+          ;; Reachable, so only the status can hold the kill back.
+          (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+          (spy-on 'process-file)
+          (flycheck-lsp--force-quit server)
+          (expect 'process-file :not :to-have-been-called)))
+
+      (it "does not open a connection just to signal a server"
+        ;; Opening one can block for over a minute on a host that has gone
+        ;; away, and this runs while Emacs is trying to exit.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc)))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p)  ; not connected
+                (spy-on 'process-file)
+                (flycheck-lsp--force-quit server)
+                (expect 'process-file :not :to-have-been-called))
+            (delete-process proc))))
+
+      (it "leaves a server Tramp gave no pid alone"
+        ;; Its direct-async path records none, and without one there is
+        ;; nothing to aim a kill at.
+        (let* ((proc (flycheck-test-lsp-process))  ; no remote-pid
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc)))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file)
+                (flycheck-lsp--force-quit server)
+                (expect 'process-file :not :to-have-been-called))
+            (delete-process proc))))
+
+      (it "never signals a pid against this machine"
+        ;; A pid counts on one host.  This state should not arise, and if
+        ;; it ever did the kill would land on a local process group.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/p/" :process proc)))  ; local root, remote pid
+          (unwind-protect
+              (progn
+                (expect (flycheck-lsp--host-connected-p "/p/") :to-be nil)
+                (spy-on 'process-file)
+                (flycheck-lsp--force-quit server)
+                (expect 'process-file :not :to-have-been-called))
+            (delete-process proc))))
+
+      (it "makes its timeout real only while Emacs is quitting"
+        ;; Tramp suspends timers around a transaction, so the timeout is
+        ;; inert unless told otherwise - and telling it costs the
+        ;; connection, which is only acceptable on the way out.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc))
+               (seen nil))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (cl-letf (((symbol-function 'process-file)
+                           (lambda (&rest _)
+                             (push (bound-and-true-p tramp-dont-suspend-timers)
+                                   seen)
+                             0)))
+                  (let ((flycheck-lsp--exiting nil))
+                    (flycheck-lsp--force-quit server))
+                  ;; A second pass, as a later teardown would be.
+                  (process-put proc 'flycheck-lsp-quit nil)
+                  (let ((flycheck-lsp--exiting t))
+                    (flycheck-lsp--force-quit server)))
+                (expect (nreverse seen) :to-equal '(nil t)))
+            (delete-process proc))))
+
+      (it "tries again when the kill never went out"
+        ;; The flag says a kill was delivered, not that one was attempted:
+        ;; a host that drops out mid-call has to be worth another pass.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc)))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file :and-throw-error 'error)
+                (flycheck-lsp--force-quit server)
+                (expect (process-get proc 'flycheck-lsp-quit) :to-be nil)
+                (flycheck-lsp--force-quit server)
+                (expect (spy-calls-count 'process-file) :to-equal 2))
+            (delete-process proc))))
+
+      (it "kills a server once and not again"
+        ;; A pid is only ours until the host reuses it, so a second pass
+        ;; must not fire a kill at whatever holds it by then.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :process proc)))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file)
+                (flycheck-lsp--force-quit server)
+                (expect (spy-calls-count 'process-file) :to-equal 1)
+                (flycheck-lsp--force-quit server)
+                (expect (spy-calls-count 'process-file) :to-equal 1))
+            (delete-process proc)))))
+
+    (describe "flycheck-lsp--shutdown-server"
+      (it "signals a server that will not act on `exit'"
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :connection 'conn
+                        :process proc)))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file)
+                (flycheck-test-with-stub-jsonrpc t
+                  (flycheck-lsp--shutdown-server server))
+                (expect 'process-file :to-have-been-called))
+            (delete-process proc))))
+
+      (it "stops the server before jsonrpc gives up and deletes it"
+        ;; Left to jsonrpc, the teardown warns and stalls for its grace
+        ;; before dropping a process it cannot stop anyway.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :connection 'conn
+                        :process proc))
+               (events nil))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (cl-letf (((symbol-function 'process-file)
+                           (lambda (&rest _) (push 'kill events) 0)))
+                  (flycheck-test-with-stub-jsonrpc t
+                    (cl-letf (((symbol-function 'jsonrpc-shutdown)
+                               (lambda (&rest _) (push 'jsonrpc-shutdown events))))
+                      (flycheck-lsp--shutdown-server server))))
+                (expect (nreverse events)
+                        :to-equal '(kill jsonrpc-shutdown)))
+            (delete-process proc))))
+
+      (it "lets a server that acts on `exit' go on its own"
+        ;; The grace is the whole point: a server that exits when told must
+        ;; not be signalled on its way out.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :connection 'conn
+                        :process proc))
+               ;; Long enough that the stand-in's exit cannot lose a race
+               ;; the spec is not about.
+               (flycheck-lsp--exit-grace 5))
+          (unwind-protect
+              (progn
+                ;; Reachable, so only the grace can hold the kill back.
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file)
+                (flycheck-test-with-stub-jsonrpc t
+                  (cl-letf (((symbol-function 'jsonrpc-notify)
+                             ;; Acting on `exit' is the server going away,
+                             ;; which it does in its own time rather than
+                             ;; inside our call.
+                             (lambda (&rest _)
+                               (run-at-time
+                                0.01 nil
+                                (lambda ()
+                                  (when (process-live-p proc)
+                                    (process-send-eof proc)))))))
+                    (flycheck-lsp--shutdown-server server)))
+                (expect (flycheck-test-lsp-await proc 'exit) :to-be 'exit)
+                (expect 'process-file :not :to-have-been-called))
+            (when (process-live-p proc) (delete-process proc)))))
+
+      (it "stops the server even when the grace exits non-locally"
+        ;; Waiting for a server pumps its output, which runs this again
+        ;; for whichever other server that output finishes off.  An exit
+        ;; thrown through here must not leave this one running, nor its
+        ;; buffer behind for the rest of the session.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (stderr (generate-new-buffer " *flycheck-test-lsp stderr*"))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :connection 'conn
+                        :process proc :stderr stderr)))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file)
+                (catch 'flycheck-test-escape
+                  (flycheck-test-with-stub-jsonrpc t
+                    (cl-letf (((symbol-function 'flycheck-lsp--await-exit)
+                               (lambda (&rest _)
+                                 (throw 'flycheck-test-escape nil))))
+                      (flycheck-lsp--shutdown-server server))))
+                (expect 'process-file :to-have-been-called)
+                (expect (buffer-live-p stderr) :to-be nil))
+            (delete-process proc)
+            (when (buffer-live-p stderr) (kill-buffer stderr)))))
+
+      (it "does not wait on jsonrpc for ever"
+        ;; `jsonrpc-shutdown' waits for a sentinel with no deadline of its
+        ;; own, and it runs while Emacs is quitting.  Bounded, it costs a
+        ;; couple of seconds; unbounded it once hung the whole teardown.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :connection 'conn
+                        :process proc))
+               (elapsed nil))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file)
+                (flycheck-test-with-stub-jsonrpc t
+                  (cl-letf (((symbol-function 'jsonrpc-shutdown)
+                             ;; A sentinel that never arrives, capped well
+                             ;; past the timeout so a regression here fails
+                             ;; rather than hangs the run.
+                             (lambda (&rest _)
+                               (let ((end (+ (float-time) 6)))
+                                 (while (< (float-time) end)
+                                   (accept-process-output nil 0.05))))))
+                    (let ((t0 (float-time)))
+                      (flycheck-lsp--shutdown-server server)
+                      (setq elapsed (- (float-time) t0)))))
+                (expect elapsed :to-be-less-than 4))
+            (delete-process proc))))
+
+      (it "stops a server whose connection has already gone"
+        ;; Nothing holds such a server: the polite branch cannot run, and
+        ;; dropping our end of a remote process does not stop it.
+        (let* ((proc (flycheck-test-lsp-process 4242))
+               (server (flycheck-lsp--server-create
+                        :root "/mock:localhost:/p/" :connection 'conn
+                        :process proc)))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--host-connected-p :and-return-value t)
+                (spy-on 'process-file)
+                (flycheck-test-with-stub-jsonrpc nil
+                  (flycheck-lsp--shutdown-server server))
+                (expect 'process-file :to-have-been-called))
+            (delete-process proc)))))
+
+    (describe "the server registry"
+      (it "stops the server it replaces"
+        ;; A server is only replaced once its connection has gone, which
+        ;; is exactly when the server itself is likeliest to still be up.
+        (let* ((key (cons "/mock:localhost:/p/" '("some-server")))
+               (dead (flycheck-lsp--server-create
+                      :root "/mock:localhost:/p/" :command '("some-server")))
+               (flycheck-lsp--servers (make-hash-table :test 'equal))
+               (forgotten nil))
+          (puthash key dead flycheck-lsp--servers)
+          (cl-letf (((symbol-function 'flycheck-lsp--server-live-p) #'ignore)
+                    ((symbol-function 'flycheck-lsp--start-server)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'flycheck-lsp--forget-server)
+                     (lambda (_key server) (setq forgotten server))))
+            (flycheck-lsp--ensure-server "/mock:localhost:/p/" '("some-server")))
+          (expect forgotten :to-be dead)))
+
+      (it "does not drop a server that replaced the one being forgotten"
+        ;; Shutting down pumps output, and a push arriving then can
+        ;; register a fresh server under the same key.  Forgetting the old
+        ;; one must not take the new one with it.
+        (let* ((key (cons "/p/" '("some-server")))
+               (old (flycheck-lsp--server-create :root "/p/"))
+               (new (flycheck-lsp--server-create :root "/p/"))
+               (flycheck-lsp--servers (make-hash-table :test 'equal)))
+          (puthash key new flycheck-lsp--servers)
+          (cl-letf (((symbol-function 'flycheck-lsp--shutdown-server) #'ignore))
+            (flycheck-lsp--forget-server key old))
+          (expect (gethash key flycheck-lsp--servers) :to-be new)))
+
+      (it "keeps sweeping while teardown registers more servers"
+        ;; `flycheck-lsp--shutdown-all' runs from `kill-emacs-hook'; one
+        ;; registered behind the sweep would outlive Emacs.
+        (let* ((flycheck-lsp--servers (make-hash-table :test 'equal))
+               (a (flycheck-lsp--server-create :root "/a/"))
+               (b (flycheck-lsp--server-create :root "/b/"))
+               (torn nil))
+          (puthash 'a a flycheck-lsp--servers)
+          (cl-letf (((symbol-function 'flycheck-lsp--shutdown-server)
+                     (lambda (server)
+                       (push server torn)
+                       ;; A push arriving mid-teardown starts another.
+                       (when (eq server a)
+                         (puthash 'b b flycheck-lsp--servers)))))
+            (flycheck-lsp--shutdown-all))
+          (expect (nreverse torn) :to-equal (list a b))
+          (expect (hash-table-count flycheck-lsp--servers) :to-equal 0))))
 
     (describe "flycheck-lsp--capable"
       (it "walks the capability plist"
@@ -1310,6 +1680,29 @@ holding its document"
                    default-directory '("flycheck-no-such-program-xyz"))
                   :to-be nil)
           (expect (length (buffer-list)) :to-equal before)))
+
+      (it "stops a server it spawned but could not go on to talk to"
+        ;; Unlike a spawn that never happened, this one leaves a server
+        ;; running on the other host with nothing holding it.
+        (let ((spawned nil))
+          (unwind-protect
+              (progn
+                (spy-on 'flycheck-lsp--force-quit)
+                (cl-letf (((symbol-function 'flycheck-lsp--spawn)
+                           (lambda (&rest _)
+                             (setq spawned (flycheck-test-lsp-process 4242))))
+                          ((symbol-function 'jsonrpc-async-request)
+                           (lambda (&rest _) (error "handshake never got out"))))
+                  ;; A local root: the spawn and the handshake are both
+                  ;; stubbed, so nothing here wants a host, and asking
+                  ;; Tramp for one it has no method for would fail this
+                  ;; for a reason that is not the one under test.
+                  (expect (flycheck-lsp--start-server
+                           temporary-file-directory '("some-server"))
+                          :to-be nil))
+                (expect spawned :not :to-be nil)
+                (expect 'flycheck-lsp--force-quit :to-have-been-called))
+            (when spawned (ignore-errors (delete-process spawned))))))
 
       (it "leaves the current buffer's own process alone when that fails"
         ;; The spawn never happened, so `proc' is nil, and


### PR DESCRIPTION
A language server on a remote host kept running after Flycheck dropped it: `delete-process` only closes this end of the connection. Since every check just starts a fresh server, one that can't finish its handshake piled up a copy per attempt.

The kill goes out only over a connection that already exists. Opening one blocks for over a minute on a host that has gone away, and this runs from `kill-emacs-hook`, so that would be Emacs refusing to quit.

Also in here: five docstrings an escaping backslash short, which rendered as `Emacs=’s`.