### PR TITLE
Give every CI job a timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build-manual:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -28,6 +28,7 @@ jobs:
   changed:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -61,6 +62,7 @@ jobs:
   everything:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    # A job runs in 6 to 15 minutes.  Without this it inherits
+    # GitHub's 6 hour default, which a wedged runner once spent in
+    # full before anyone could tell it from a slow one.
+    timeout-minutes: 30
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
A macOS runner wedged the other day and burned GitHub's six hour default before being cancelled, which is indistinguishable from a slow job until the clock runs out. Thirty minutes is double the longest the test matrix has ever taken; the other jobs are scaled to their own runs.