### PR TITLE
Add nixf checker for Nix

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -938,6 +938,12 @@ to view the docstring of the syntax checker.  Likewise, you may use
 
       .. _nix-instantiate: https://nixos.org/nix/manual/#sec-nix-instantiate
 
+   .. syntax-checker:: nix-nixf
+
+      Check Nix with nixf_.
+
+      .. _nixf: https://github.com/nix-community/nixd/blob/main/libnixf/README.md#nixf-tidy
+
    .. syntax-checker:: statix
 
       Check Nix with statix_.

--- a/flycheck.el
+++ b/flycheck.el
@@ -185,6 +185,7 @@
     markdown-mdl
     markdown-pymarkdown
     nix
+    nix-nixf
     ocaml-dune
     ocaml
     opam
@@ -19667,6 +19668,54 @@ See URL `https://nixos.org/nix/manual/#sec-nix-instantiate'."
   (lambda (errors)
     (flycheck-sanitize-errors
      (flycheck-remove-error-file-names "(string)" errors)))
+  :next-checkers ((warning . nix-nixf))
+  :modes (nix-mode nix-ts-mode))
+
+(defun flycheck-parse-nixf--fix (fixes buffer)
+  "Build a `flycheck-fix' for BUFFER from a nixf FIXES, or nil."
+  (when fixes
+    (flycheck--make-fix
+     buffer (mapconcat (lambda (f) (alist-get 'message f)) fixes " & ")
+     (seq-mapcat
+      (lambda (fix)
+        (seq-map
+         (lambda (edit)
+           (let-alist edit
+             (flycheck-fix-edit-new
+              :line (1+ .range.lCur.line) :column (1+ .range.lCur.column)
+              :end-line (1+ .range.rCur.line) :end-column (1+ .range.rCur.column)
+              :replacement .newText)))
+         (alist-get 'edits fix)))
+      fixes))))
+
+(defun flycheck-parse-nixf (output checker buffer)
+  "Parse nixf warnings from JSON OUTPUT.
+
+CHECKER and BUFFER denote the CHECKER that returned OUTPUT and
+the BUFFER that was checked respectively."
+  (mapcar (lambda (err)
+            (let-alist err
+              (flycheck-error-new-at
+               (1+ .range.lCur.line)
+               (1+ .range.lCur.column)
+               (flycheck-lsp--severity-level .severity)
+               (replace-regexp-in-string "{}" (lambda (_) (pop .args)) .message)
+               :id .sname
+               :checker checker
+               :buffer buffer
+               :filename (buffer-file-name buffer)
+               :end-line (1+ .range.rCur.line)
+               :end-column (1+ .range.rCur.column)
+               :fix (flycheck-parse-nixf--fix .fixes buffer))))
+          (car (flycheck-parse-json output))))
+
+(flycheck-define-checker nix-nixf
+  "Nix checker using nixf.
+
+See URL `https://github.com/nix-community/nixd/blob/main/libnixf/README.md#nixf-tidy'."
+  :command ("nixf-tidy" "--variable-lookup")
+  :standard-input t
+  :error-parser flycheck-parse-nixf
   :modes (nix-mode nix-ts-mode))
 
 (defun flycheck-parse-statix (output checker buffer)

--- a/test/resources/language/nix/warnings.nix
+++ b/test/resources/language/nix/warnings.nix
@@ -1,5 +1,6 @@
 let
   x = 5;
+  y = 6;
 in rec {
   inherit x;
 }

--- a/test/specs/languages/test-nix.el
+++ b/test/specs/languages/test-nix.el
@@ -9,6 +9,45 @@
      "language/nix/syntax-error.nix" 'nix-mode
      '(3 1 error "syntax error, unexpected IN, expecting ';'," :checker nix)))
 
+  (flycheck-buttercup-def-checker-test nix-nixf nix nil
+    (let ((flycheck-disabled-checkers '(nix)))
+      (flycheck-buttercup-should-syntax-check
+       "language/nix/syntax-error.nix" 'nix-mode
+       '(2 14 error "expected ;"
+           :checker nix-nixf :id "parse-expected"
+           :end-line 2 :end-column 14))
+
+      (flycheck-buttercup-should-syntax-check
+       "language/nix/warnings.nix" 'nix-mode
+       '(3 3 warning "definition `y` in let-expression is not used"
+           :checker nix-nixf :id "sema-unused-def-let"
+           :end-line 3 :end-column 4)
+       '(4 4 warning "attrset is not necessary to be `rec`ursive"
+           :checker nix-nixf :id "sema-extra-rec"
+           :end-line 4 :end-column 7))))
+
+  (describe "nixf parser"
+    (it "parses a warning and its fixes"
+      (flycheck-buttercup-with-temp-buffer
+        (let* ((errors (flycheck-parse-output
+                        "[{\"args\":[\";\"],\"fixes\":[\
+{\"edits\":[{\"newText\":\";\",\"range\":{\"lCur\":{\"column\":7,\
+\"line\":1,\"offset\":11},\"rCur\":{\"column\":7,\"line\":1,\"offset\":11}}}],\
+\"message\":\"insert ;\"}],\"kind\":3,\"message\":\"expected {}\",\
+\"notes\":[],\"range\":{\"lCur\":{\"column\":7,\"line\":1,\"offset\":11},\
+\"rCur\":{\"column\":7,\"line\":1,\"offset\":11}},\"severity\":1,\
+\"sname\":\"parse-expected\",\"tag\":[]}]"
+                        'nix-nixf (current-buffer)))
+               (err (car errors))
+               (edits (flycheck-fix-edits (flycheck-error-fix err))))
+          (expect (flycheck-error-line err) :to-equal 2)
+          (expect (flycheck-error-column err) :to-equal 8)
+          (expect (flycheck-error-level err) :to-equal 'error)
+          (expect (flycheck-error-message err) :to-equal "expected ;")
+          (expect (flycheck-error-id err) :to-equal "parse-expected")
+          (expect (length edits) :to-equal 1)
+          (expect (flycheck-fix-edit-replacement (car edits)) :to-equal ";")))))
+
   (describe "the statix checker command"
     (it "appends flycheck-statix-args before the source file"
       (flycheck-buttercup-with-temp-buffer


### PR DESCRIPTION
Hi, this PR adds a checker using [`nixf`](https://github.com/nix-community/nixd/blob/main/libnixf/README.md#nixf-tidy)

```console
$ make PATTERN=Nix specs
...
Language Nix
  flycheck-define-checker/nix/default (127.43ms)
  flycheck-define-checker/nix-nixf/default (58.39ms)
  nixf parser
    parses a warning and its fixes (0.55ms)
  the statix checker command
    appends flycheck-statix-args before the source file (0.73ms)

....
Ran 4 out of 1543 specs, 0 failed, in 3.36s.
```
